### PR TITLE
Recover from denied Accessibility access

### DIFF
--- a/SayIt.xcodeproj/project.pbxproj
+++ b/SayIt.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		94E614AD286A5262C7EAFD39 /* BackendPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9041E9369BA31A0007824D /* BackendPersistenceTests.swift */; };
 		95C03B8BF70FFF18F99B80F8 /* SpeechItemState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD51CABBD6A4B66774A1984 /* SpeechItemState.swift */; };
 		969D61B2F282C219FF951296 /* DiagnosticSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8F4DCDC453E07A4518905B /* DiagnosticSnapshot.swift */; };
+		975420AF9C82FB50C0F04794 /* AppErrorRecoveryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6AEFFFEB026A11B8235D5 /* AppErrorRecoveryAction.swift */; };
 		97FFD241C34F9894CF4E8B9E /* SynthesisOperationLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40828984E8B5F3F75C795F92 /* SynthesisOperationLifecycleTests.swift */; };
 		980814CF3D25517505F78C03 /* SayItHTTP.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E0D0C006406346A39E5C37E /* SayItHTTP.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		98E075B62EF1F0140D7056EF /* SayItStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB95F4768AD968BE1C4CBCD1 /* SayItStyles.swift */; };
@@ -1051,6 +1052,7 @@
 		A42DE1A1821373642D9C83EC /* VoiceDiscoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDiscoveryView.swift; sourceTree = "<group>"; };
 		A5D4DF6C5D91C97996C6017A /* ModelDownloadProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadProgress.swift; sourceTree = "<group>"; };
 		A5E69C5B004A8649EF5386AF /* ExportKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportKind.swift; sourceTree = "<group>"; };
+		A7F6AEFFFEB026A11B8235D5 /* AppErrorRecoveryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorRecoveryAction.swift; sourceTree = "<group>"; };
 		A7FD50F093D897C5794716C1 /* ModelManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManaging.swift; sourceTree = "<group>"; };
 		A89BAB57F71A7F5E2FBB982E /* SayIt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SayIt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A8C3FAB8E768F21BF7E8DFA3 /* SayItAgent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SayItAgent.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1363,6 +1365,7 @@
 			isa = PBXGroup;
 			children = (
 				9D05793EC7DD8A6AD63C5EB8 /* AppDelegate.swift */,
+				A7F6AEFFFEB026A11B8235D5 /* AppErrorRecoveryAction.swift */,
 				6A47804F46DFB604995541E6 /* AppSettings.swift */,
 				D47CAB42068B3B8CA73B1C23 /* AppState.swift */,
 				233AA2BFB1498E7AE7F086BC /* AppWindowCoordinator.swift */,
@@ -3009,6 +3012,7 @@
 				1B7DE382603E96F6DCFE8250 /* AboutSettingsView.swift in Sources */,
 				1499573C719AFE565957C8DE /* AnywhereOnboardingView.swift in Sources */,
 				45E5E96E262A16E29BC0B1C3 /* AppDelegate.swift in Sources */,
+				975420AF9C82FB50C0F04794 /* AppErrorRecoveryAction.swift in Sources */,
 				50F000C6F5AC706BD4EBD9E1 /* AppSettings.swift in Sources */,
 				FFDA6AAAF51DAC39E8D32853 /* AppState.swift in Sources */,
 				B5677AD3CAE8F0FB0A6430A0 /* AppWindowCoordinator.swift in Sources */,

--- a/Sources/SayIt/AppShell/AppErrorRecoveryAction.swift
+++ b/Sources/SayIt/AppShell/AppErrorRecoveryAction.swift
@@ -1,0 +1,10 @@
+enum AppErrorRecoveryAction: Equatable {
+    case openAccessibilitySettings
+
+    var buttonTitle: String {
+        switch self {
+        case .openAccessibilitySettings:
+            "Open Accessibility Settings…"
+        }
+    }
+}

--- a/Sources/SayIt/AppShell/AppState.swift
+++ b/Sources/SayIt/AppShell/AppState.swift
@@ -44,6 +44,7 @@ final class AppState {
     private(set) var requestedModelInstallID: ModelID?
     private(set) var statusText = "Connecting to service"
     private(set) var errorMessage: String?
+    private(set) var errorRecoveryAction: AppErrorRecoveryAction?
     private(set) var needsLongTextConfirmation = false
     private(set) var diagnosticEvents: [DiagnosticEvent] = []
     private(set) var serviceSnapshot: ServiceSnapshot?
@@ -135,18 +136,42 @@ final class AppState {
                 )
                 receive(payload)
             } catch {
-                presentError(error.localizedDescription)
+                presentError(
+                    error.localizedDescription,
+                    recoveryAction: (error as? SelectionServiceError)?
+                        .recoveryAction
+                )
             }
         }
     }
 
     func refreshSelectionAccessibilityAccess() async {
         await selectionService.refreshAuthorization()
+        clearAccessibilityErrorIfAuthorized()
     }
 
     func requestSelectionAccessibilityAccess() {
         Task {
             await selectionService.requestAuthorization()
+            clearAccessibilityErrorIfAuthorized()
+        }
+    }
+
+    func performErrorRecovery() {
+        guard let errorRecoveryAction else { return }
+        switch errorRecoveryAction {
+        case .openAccessibilitySettings:
+            openSelectionAccessibilitySettings()
+        }
+    }
+
+    func openSelectionAccessibilitySettings() {
+        guard selectionService.openAccessibilitySettings() else {
+            presentError(
+                "Accessibility Settings couldn’t be opened. Open System Settings, choose Privacy & Security, then Accessibility.",
+                recoveryAction: .openAccessibilitySettings
+            )
+            return
         }
     }
 
@@ -570,14 +595,27 @@ final class AppState {
         }
     }
 
-    func presentError(_ message: String) {
+    func presentError(
+        _ message: String,
+        recoveryAction: AppErrorRecoveryAction? = nil
+    ) {
         errorMessage = message
+        errorRecoveryAction = recoveryAction
         statusText = "Needs attention"
     }
 
     func clearError() {
         errorMessage = nil
+        errorRecoveryAction = nil
         perform(.clearError)
+    }
+
+    private func clearAccessibilityErrorIfAuthorized() {
+        guard selectionService.accessibilityIsTrusted == true,
+              errorRecoveryAction == .openAccessibilitySettings else {
+            return
+        }
+        clearError()
     }
 
     func finishOnboarding() {
@@ -946,8 +984,14 @@ final class AppState {
         lastServiceRevision = snapshot.revision
         serviceSnapshot = snapshot
         serviceConnection = .online(version: snapshot.serviceVersion)
-        statusText = snapshot.statusText
-        errorMessage = snapshot.lastError
+        if let serviceError = snapshot.lastError {
+            statusText = snapshot.statusText
+            errorMessage = serviceError
+            errorRecoveryAction = nil
+        } else if errorRecoveryAction == nil {
+            statusText = snapshot.statusText
+            errorMessage = nil
+        }
         httpAPIErrorMessage = snapshot.httpServiceError
         needsLongTextConfirmation =
             snapshot.activeJob?.state == .awaitingConfirmation

--- a/Sources/SayIt/AppShell/ErrorStatusView.swift
+++ b/Sources/SayIt/AppShell/ErrorStatusView.swift
@@ -18,7 +18,13 @@ struct ErrorStatusView: View {
             HStack {
                 Button("Dismiss", action: state.clearError)
                 Spacer()
-                if state.installedModelIDs.isEmpty {
+                if let recoveryAction = state.errorRecoveryAction {
+                    Button(
+                        recoveryAction.buttonTitle,
+                        action: state.performErrorRecovery
+                    )
+                    .buttonStyle(.borderedProminent)
+                } else if state.installedModelIDs.isEmpty {
                     Button("Choose a model", action: openOnboarding)
                         .buttonStyle(.borderedProminent)
                 }

--- a/Sources/SayIt/Selection/SelectionServiceController.swift
+++ b/Sources/SayIt/Selection/SelectionServiceController.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Observation
 import SayItCore
 import SayItProtocol
@@ -103,6 +104,15 @@ final class SelectionServiceController {
 
     func openLoginItemsSettings() {
         SMAppService.openSystemSettingsLoginItems()
+    }
+
+    func openAccessibilitySettings() -> Bool {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        ) else {
+            return false
+        }
+        return NSWorkspace.shared.open(url)
     }
 
     private func perform(_ work: () async throws -> Void) async {

--- a/Sources/SayIt/Selection/SelectionServiceError.swift
+++ b/Sources/SayIt/Selection/SelectionServiceError.swift
@@ -11,7 +11,7 @@ enum SelectionServiceError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .accessibilityRequired:
-            "Allow Accessibility access for the selected-text helper, then press the shortcut again."
+            "Accessibility access is off. Allow the Say It selected-text helper in Accessibility Settings, then press the shortcut again."
         case .noSelection:
             "No readable text is selected in the frontmost app."
         case .selectionTooLong(let maximumCharacters):
@@ -22,6 +22,15 @@ enum SelectionServiceError: LocalizedError {
             "Allow the Say It selected-text helper in Login Items."
         case .helperUnavailable:
             "The selected-text helper is unavailable."
+        }
+    }
+
+    var recoveryAction: AppErrorRecoveryAction? {
+        switch self {
+        case .accessibilityRequired:
+            .openAccessibilitySettings
+        default:
+            nil
         }
     }
 }

--- a/Sources/SayIt/Settings/SelectionAccessSettingsView.swift
+++ b/Sources/SayIt/Settings/SelectionAccessSettingsView.swift
@@ -18,11 +18,20 @@ struct SelectionAccessSettingsView: View {
                     .foregroundStyle(.secondary)
 
                     if state.selectionService.accessibilityIsTrusted != true {
-                        Button(
-                            "Allow…",
-                            action: state.requestSelectionAccessibilityAccess
-                        )
-                        .disabled(state.selectionService.isWorking)
+                        if state.selectionService.accessibilityIsTrusted == false {
+                            Button(
+                                "Open Settings…",
+                                action: state
+                                    .openSelectionAccessibilitySettings
+                            )
+                        } else {
+                            Button(
+                                "Allow…",
+                                action: state
+                                    .requestSelectionAccessibilityAccess
+                            )
+                            .disabled(state.selectionService.isWorking)
+                        }
                     }
                     if state.selectionService.requiresLoginItemApproval {
                         Button(

--- a/Tests/SayItPlaybackTests/AppErrorRecoveryActionTests.swift
+++ b/Tests/SayItPlaybackTests/AppErrorRecoveryActionTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import SayIt
+
+@Suite("App error recovery")
+struct AppErrorRecoveryActionTests {
+    @Test("Accessibility denial offers a settings recovery action")
+    func accessibilityDenialRecovery() {
+        let error = SelectionServiceError.accessibilityRequired
+
+        #expect(error.recoveryAction == .openAccessibilitySettings)
+        #expect(
+            error.recoveryAction?.buttonTitle
+                == "Open Accessibility Settings…"
+        )
+    }
+
+    @Test("Other selection failures do not offer accessibility recovery")
+    func unrelatedSelectionFailureRecovery() {
+        #expect(SelectionServiceError.noSelection.recoveryAction == nil)
+        #expect(
+            SelectionServiceError.helperUnavailable.recoveryAction == nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- attach a contextual recovery action to selected-text Accessibility failures
- open Privacy & Security > Accessibility directly from the menu-bar error and from Settings after denial
- keep the recovery error visible across service polling and clear it automatically once access is granted
- cover accessibility-specific and unrelated selection error mappings with unit tests

## Testing

- ./Scripts/build-app.sh
- swift test --disable-sandbox --filter SayItPlaybackTests (25 tests passed)
- swift test --disable-sandbox --filter AppErrorRecoveryActionTests (2 tests passed)
- swift test --disable-sandbox was also attempted; model-heavy tests depend on an MLX default metallib that is unavailable in the SwiftPM test environment, and the selection-agent pasteboard test cannot write to the pasteboard in the headless test context

## Risk

Low. The new behavior is limited to Accessibility denial recovery. Subsequent hotkey presses still invoke the macOS prompt API, while the direct System Settings action provides the reliable fallback when macOS does not show the consent dialog again.