### PR TITLE
Replace background polling with revision-driven updates

### DIFF
--- a/SayIt.xcodeproj/project.pbxproj
+++ b/SayIt.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		0F8D81FFA4D5DA431F4127F1 /* PlaybackBufferPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07BCC4B6990BB603ECCEF34 /* PlaybackBufferPolicyTests.swift */; };
 		1066672AD8F1CD5C55522FFE /* ReadClipboardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D607DFF8375415948AC3F253 /* ReadClipboardButton.swift */; };
 		10735CBA536A20F40662860E /* VoiceRecordingSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060772E7D86FC0C811C36B0D /* VoiceRecordingSink.swift */; };
+		116DBCF73EB42D0A37C9C725 /* ServiceEventSSEWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D012050844E68503016F40D5 /* ServiceEventSSEWriter.swift */; };
 		11F40A811AF89ADAF6D28E44 /* AccessibilityAncestorSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456A6147E5C1F299C5F70B42 /* AccessibilityAncestorSearch.swift */; };
 		1222CE5AD3F752C87A20D209 /* VoiceFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815F4468AEC35FC11968AE16 /* VoiceFingerprint.swift */; };
 		1277983D5FFBC76A6CD5274E /* ModelFileDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D4CBC539AFA34387DA49C6 /* ModelFileDescriptor.swift */; };
@@ -54,6 +55,7 @@
 		1499573C719AFE565957C8DE /* AnywhereOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9139DB6590D67057C09ABBF /* AnywhereOnboardingView.swift */; };
 		14C2C345DED4A876DEB5AABB /* APITokenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C260D3D114063A57EE6106 /* APITokenRecord.swift */; };
 		15BC1D2ACF0F95AC493733D5 /* ModelManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69AC3686B8CAE0506DD0984 /* ModelManagerTests.swift */; };
+		168A63FEEDC7C157E117CB1C /* ServiceEventHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24BB3FA53E080276A116642 /* ServiceEventHubTests.swift */; };
 		16A5F34E0F821CFCC1C608D0 /* APITokenMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEF4E9A880944ACA9E6A4AA /* APITokenMetadata.swift */; };
 		19488C0CF76ABE8972AE4980 /* QueuePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E857E910DF547DDF281E5A /* QueuePolicy.swift */; };
 		1AB6750260BF70B395B0F9E5 /* HistorySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFDA6836016ADDCDC5ACF3AF /* HistorySettingsView.swift */; };
@@ -94,6 +96,7 @@
 		2F98443BCC6A9CE666AFF7D2 /* SayItCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E5B162BA286FB4707D990A4 /* SayItCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		30F806119784A3EA06D08732 /* APITokenCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AADDFBAF6765A7A9E46F6F /* APITokenCreation.swift */; };
 		313D65581012CCDBC2CAB6C1 /* UpdateCheckerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA5A7C6B8C75A3FB3E9D0F4 /* UpdateCheckerError.swift */; };
+		32FC4CC7ADAA06A627E07AD0 /* HTTPEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEAC3BEEF3A43EBD6DCF107 /* HTTPEventStreamTests.swift */; };
 		35C5858DED5258F9813091A5 /* SynthesisError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF73CF550608FF1F4C96C1B /* SynthesisError.swift */; };
 		360339154AB4814D00BBCB3B /* TokenCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62B45AACA98296E67663E5A /* TokenCreationSheet.swift */; };
 		364005AD51699126DC66000A /* IdempotencyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC719FAC8BB29024BACE25E2 /* IdempotencyStore.swift */; };
@@ -278,6 +281,7 @@
 		949825DCFA63B68D7D413914 /* VoiceCandidateSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A3C6644EA34D12746690E4 /* VoiceCandidateSnapshot.swift */; };
 		94E614AD286A5262C7EAFD39 /* BackendPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9041E9369BA31A0007824D /* BackendPersistenceTests.swift */; };
 		95C03B8BF70FFF18F99B80F8 /* SpeechItemState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD51CABBD6A4B66774A1984 /* SpeechItemState.swift */; };
+		9684E098325999D8FABA0137 /* MenuPresentationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC4D0942783275CF546AA4F /* MenuPresentationObserver.swift */; };
 		969D61B2F282C219FF951296 /* DiagnosticSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8F4DCDC453E07A4518905B /* DiagnosticSnapshot.swift */; };
 		975420AF9C82FB50C0F04794 /* AppErrorRecoveryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6AEFFFEB026A11B8235D5 /* AppErrorRecoveryAction.swift */; };
 		97FFD241C34F9894CF4E8B9E /* SynthesisOperationLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40828984E8B5F3F75C795F92 /* SynthesisOperationLifecycleTests.swift */; };
@@ -326,6 +330,7 @@
 		ABB053936127AD65EFDBF1F5 /* SayItProtocol.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A8BAAEAFC62A33241DF5822 /* SayItProtocol.framework */; };
 		AC7A99C556D950AA7912D34D /* KittenVoiceArchiveConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C462F1A523FD96FFB614980 /* KittenVoiceArchiveConverter.swift */; };
 		AC7F2812FD464707EE4D6006 /* SynthesisActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C900418213D0916ED7E5673 /* SynthesisActor.swift */; };
+		ADB314E2EFB15D2EA9A64854 /* HTTPServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9814F42CCE178A8FD9F81F55 /* HTTPServiceConfiguration.swift */; };
 		ADFE18B1B816866D75DD9484 /* SpeakingPace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A78B1E50C30F43CAE87675A /* SpeakingPace.swift */; };
 		AF3ACD2ECD2F6114D39FB113 /* VoiceLevelMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DF48C57E3282A40DF16672 /* VoiceLevelMeter.swift */; };
 		B04D737763D887612F91CA02 /* SayItXPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00445B56A690FA19B85A8F34 /* SayItXPC.framework */; };
@@ -456,6 +461,7 @@
 		F9882AEA31FACA3D95BD96A5 /* SayItProtocol.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A8BAAEAFC62A33241DF5822 /* SayItProtocol.framework */; };
 		FA550C1E268502477F0576F5 /* VoiceSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710003C5064943E2D9FBD734 /* VoiceSelection.swift */; };
 		FA5D14317857B5754D28667E /* SpeechJobState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D707F2139917BDA968CD00 /* SpeechJobState.swift */; };
+		FCCC10F5D9C4F8CFED7E15FD /* ServiceEventHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42453BD4A1521C07FC437B41 /* ServiceEventHub.swift */; };
 		FD155F2A5AD59CA9DE66BFEE /* AudioRouteRecoveryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72085624DA9E991F7D421A9B /* AudioRouteRecoveryPolicyTests.swift */; };
 		FDDB9383D9EDE9D3692A36B3 /* CLICommandSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9828AEDF7F2EE0C7277DB4 /* CLICommandSupport.swift */; };
 		FED9870DF8EA343A6AFD71F5 /* PCMStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336FF814DDD5418256DAC78D /* PCMStore.swift */; };
@@ -896,7 +902,9 @@
 		3F0988A39F0FE54069C0F6CC /* HistoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDetailView.swift; sourceTree = "<group>"; };
 		3F82CDFD943568E864550065 /* CommunityModelResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityModelResolver.swift; sourceTree = "<group>"; };
 		3F9041E9369BA31A0007824D /* BackendPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPersistenceTests.swift; sourceTree = "<group>"; };
+		3FEAC3BEEF3A43EBD6DCF107 /* HTTPEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPEventStreamTests.swift; sourceTree = "<group>"; };
 		40828984E8B5F3F75C795F92 /* SynthesisOperationLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynthesisOperationLifecycleTests.swift; sourceTree = "<group>"; };
+		42453BD4A1521C07FC437B41 /* ServiceEventHub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceEventHub.swift; sourceTree = "<group>"; };
 		42906742AE99316BD670BB7E /* VoiceTuningPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTuningPreset.swift; sourceTree = "<group>"; };
 		42BFC2964BF2ABF447564986 /* VoiceRecordingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingError.swift; sourceTree = "<group>"; };
 		431BE087EDC0779B11802FCC /* SayItXPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItXPCClient.swift; sourceTree = "<group>"; };
@@ -1029,6 +1037,7 @@
 		94F16A987463D89C3208C8D6 /* PlaybackContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackContext.swift; sourceTree = "<group>"; };
 		96AADDFBAF6765A7A9E46F6F /* APITokenCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenCreation.swift; sourceTree = "<group>"; };
 		97C260D3D114063A57EE6106 /* APITokenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenRecord.swift; sourceTree = "<group>"; };
+		9814F42CCE178A8FD9F81F55 /* HTTPServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPServiceConfiguration.swift; sourceTree = "<group>"; };
 		98358E5044F1911C15A82B63 /* DiagnosticSnapshot+Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiagnosticSnapshot+Event.swift"; sourceTree = "<group>"; };
 		9842DB392263544D975DAA5F /* VoiceTuningPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTuningPolicyTests.swift; sourceTree = "<group>"; };
 		9921FBAE1C609BFD9AB4942F /* BackendSettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendSettingsStoreTests.swift; sourceTree = "<group>"; };
@@ -1090,6 +1099,7 @@
 		C159E47E305909312F3675A5 /* ResumeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeCommand.swift; sourceTree = "<group>"; };
 		C18D316474D0C21D880BE963 /* VoiceCloneWizard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCloneWizard.swift; sourceTree = "<group>"; };
 		C1F03C694936914BB34739D7 /* DiagnosticExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticExport.swift; sourceTree = "<group>"; };
+		C24BB3FA53E080276A116642 /* ServiceEventHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceEventHubTests.swift; sourceTree = "<group>"; };
 		C48D19F3EA41DDA50FB5AEFF /* APITokenRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenRow.swift; sourceTree = "<group>"; };
 		C509233A0D24A11DE540B5D0 /* SynthesisPerformanceEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynthesisPerformanceEstimator.swift; sourceTree = "<group>"; };
 		C5CCCB7A23542E9559F8DB1C /* ResolvedVoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedVoice.swift; sourceTree = "<group>"; };
@@ -1102,6 +1112,7 @@
 		C98C1A12E2DC7F92DBA7E752 /* SelectionXPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionXPCClient.swift; sourceTree = "<group>"; };
 		C9C3EEF657685D177B47895A /* SpeechItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechItem.swift; sourceTree = "<group>"; };
 		CB9828AEDF7F2EE0C7277DB4 /* CLICommandSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICommandSupport.swift; sourceTree = "<group>"; };
+		CBC4D0942783275CF546AA4F /* MenuPresentationObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuPresentationObserver.swift; sourceTree = "<group>"; };
 		CC719FAC8BB29024BACE25E2 /* IdempotencyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdempotencyStore.swift; sourceTree = "<group>"; };
 		CDEF4E9A880944ACA9E6A4AA /* APITokenMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenMetadata.swift; sourceTree = "<group>"; };
 		CEB589732A789AF6BE59CA74 /* ModelSnapshot+Descriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelSnapshot+Descriptor.swift"; sourceTree = "<group>"; };
@@ -1110,6 +1121,7 @@
 		CF3BE6ACF9AE86C8F17B156D /* VoiceRecordingProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingProcessor.swift; sourceTree = "<group>"; };
 		CF768A2E826D211CF143AC18 /* SayItSelectionXPCExportedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItSelectionXPCExportedService.swift; sourceTree = "<group>"; };
 		CFA5A7C6B8C75A3FB3E9D0F4 /* UpdateCheckerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCheckerError.swift; sourceTree = "<group>"; };
+		D012050844E68503016F40D5 /* ServiceEventSSEWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceEventSSEWriter.swift; sourceTree = "<group>"; };
 		D07BCC4B6990BB603ECCEF34 /* PlaybackBufferPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBufferPolicyTests.swift; sourceTree = "<group>"; };
 		D10A73BA42E64EDE0FFA4E02 /* RetentionCandidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetentionCandidate.swift; sourceTree = "<group>"; };
 		D110E067E893E21EA4B05686 /* SayItWireCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItWireCodec.swift; sourceTree = "<group>"; };
@@ -1385,6 +1397,7 @@
 				4CC9632EA8823DD86F4CA8B4 /* MenuBarLabel.swift */,
 				8077FB8567737F537A02DE3B /* MenuBarRootView.swift */,
 				504A1CDB257EFB01D742FAE6 /* MenuFooterView.swift */,
+				CBC4D0942783275CF546AA4F /* MenuPresentationObserver.swift */,
 				D607DFF8375415948AC3F253 /* ReadClipboardButton.swift */,
 				F13CEBAFD3BF5D864C5BD06D /* SayItApplication.swift */,
 				9B3FF8D568898C9A58A33EB6 /* ServiceRepairView.swift */,
@@ -1486,6 +1499,7 @@
 		1958149C99F0D41BCEFA8505 /* SayItHTTPTests */ = {
 			isa = PBXGroup;
 			children = (
+				3FEAC3BEEF3A43EBD6DCF107 /* HTTPEventStreamTests.swift */,
 				8166F2DBCD9F7161F09835CC /* HTTPInfrastructureTests.swift */,
 				6262901F90523430DD888CF9 /* HTTPVoiceRouteIntegrationTests.swift */,
 				EE0B498E2479F4BBFF960B12 /* HTTPVoiceSubmissionTests.swift */,
@@ -1639,6 +1653,7 @@
 			children = (
 				BD2C197A18B385CC45949276 /* DiagnosticEvent+Snapshot.swift */,
 				FE13E5BA1B40745372B9772E /* HistoryItemSnapshot+ServiceSnapshot.swift */,
+				9814F42CCE178A8FD9F81F55 /* HTTPServiceConfiguration.swift */,
 				14DAC08EDC3B2C762800ACFE /* JobJournalStore.swift */,
 				4B643C036FE29C1A2C8547AC /* ModelDescriptor+Snapshot.swift */,
 				B374AB05A892A4A82438E9DE /* ModelDownloadProgress+Snapshot.swift */,
@@ -1646,6 +1661,7 @@
 				2C8B25B86087F7FC6D9EBD10 /* PlaybackContentState.swift */,
 				94F16A987463D89C3208C8D6 /* PlaybackContext.swift */,
 				2E46EB83C78D6FE379603B90 /* SayItBackendService.swift */,
+				42453BD4A1521C07FC437B41 /* ServiceEventHub.swift */,
 				0BE5C34234C6C62438D71E5A /* SpeechJobSource+TriggerSource.swift */,
 			);
 			path = Service;
@@ -2103,6 +2119,7 @@
 				6C5C8FD44D6CA11CEA0B6212 /* SayItHTTPServer+Upload.swift */,
 				6E46C278E2A69A51F79DE353 /* SayItHTTPServer+VoiceRoutes.swift */,
 				B59C1431DC3F3B4E084DCB7C /* SecondsRequest.swift */,
+				D012050844E68503016F40D5 /* ServiceEventSSEWriter.swift */,
 			);
 			name = SayItHTTP;
 			path = Sources/SayItHTTP;
@@ -2156,6 +2173,7 @@
 				B2C2FE18267ED3F1A992644F /* PCMStreamConditionerTests.swift */,
 				D07BCC4B6990BB603ECCEF34 /* PlaybackBufferPolicyTests.swift */,
 				E34A1926523800EBB0B6959D /* PlaybackControllerBoundaryTests.swift */,
+				C24BB3FA53E080276A116642 /* ServiceEventHubTests.swift */,
 				C66497ED594E15E3EF2CF5FD /* SpeechQueuePolicyTests.swift */,
 				DC8FE48DDB4640E0887AC670 /* SynthesisActorTests.swift */,
 				40828984E8B5F3F75C795F92 /* SynthesisOperationLifecycleTests.swift */,
@@ -2722,6 +2740,7 @@
 				862EDDD16F402EC12212F7BE /* BackendSpeechSynthesizing.swift in Sources */,
 				9A468EF5A94031E08CFEE119 /* CommunityModelResolver.swift in Sources */,
 				945A39481BECA04AEDA50C1F /* DiagnosticEvent+Snapshot.swift in Sources */,
+				ADB314E2EFB15D2EA9A64854 /* HTTPServiceConfiguration.swift in Sources */,
 				0933C3DB1F15CB642A263B79 /* HistoryItemSnapshot+ServiceSnapshot.swift in Sources */,
 				F1C9759FFD7F42B474603F0F /* HistoryItemSnapshot.swift in Sources */,
 				87E78A91A66292F711C87D5D /* HistoryStore.swift in Sources */,
@@ -2751,6 +2770,7 @@
 				8C37C42D200745BF0203A5AD /* PlaybackError.swift in Sources */,
 				A39B77F55EC1AAE939D53C10 /* ResolvedVoice.swift in Sources */,
 				7AE751EA7DE12B38E00969F8 /* SayItBackendService.swift in Sources */,
+				FCCC10F5D9C4F8CFED7E15FD /* ServiceEventHub.swift in Sources */,
 				05F4361DDBD00ADEC9FA4D25 /* SpeechItem.swift in Sources */,
 				BF93DE1D2B25E06EC0FA2815 /* SpeechJobSource+TriggerSource.swift in Sources */,
 				4F4C80F9B704A34D4DE00AEB /* String+Padding.swift in Sources */,
@@ -2989,6 +3009,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32FC4CC7ADAA06A627E07AD0 /* HTTPEventStreamTests.swift in Sources */,
 				90368787F03E175110973EA5 /* HTTPInfrastructureTests.swift in Sources */,
 				4BC00C950E7DD2A85A22890D /* HTTPVoiceRouteIntegrationTests.swift in Sources */,
 				D7D5E8A66E0E403C7ACDAC9E /* HTTPVoiceSubmissionTests.swift in Sources */,
@@ -3055,6 +3076,7 @@
 				58F83E662C322E4BC40E6F4B /* MenuBarLabel.swift in Sources */,
 				51C0584024264406E5670233 /* MenuBarRootView.swift in Sources */,
 				560D74E1A13F3E50F535D55F /* MenuFooterView.swift in Sources */,
+				9684E098325999D8FABA0137 /* MenuPresentationObserver.swift in Sources */,
 				B55961DBE87C92B7140B4286 /* ModelDisclosureRow.swift in Sources */,
 				EFB987AC996D3190C88081AF /* ModelRowView.swift in Sources */,
 				7E512A306F97FFFAC8E597BE /* ModelSnapshot+Descriptor.swift in Sources */,
@@ -3150,6 +3172,7 @@
 				47B3E985C906D5B4EEF241C5 /* PCMStreamConditionerTests.swift in Sources */,
 				0F8D81FFA4D5DA431F4127F1 /* PlaybackBufferPolicyTests.swift in Sources */,
 				2AA1EDF6AE8183DA3C9C6B6F /* PlaybackControllerBoundaryTests.swift in Sources */,
+				168A63FEEDC7C157E117CB1C /* ServiceEventHubTests.swift in Sources */,
 				F88A3CF15CA4053F7D587898 /* SpeechQueuePolicyTests.swift in Sources */,
 				BD7E756DBD67FF169CDD68C2 /* SynthesisActorTests.swift in Sources */,
 				97FFD241C34F9894CF4E8B9E /* SynthesisOperationLifecycleTests.swift in Sources */,
@@ -3186,6 +3209,7 @@
 				0A2D669D9D8BCA189C6ECF28 /* SayItHTTPServer+VoiceRoutes.swift in Sources */,
 				F639B38795383E43347A9A95 /* SayItHTTPServer.swift in Sources */,
 				9BE94003FF79DC47D54D4E5A /* SecondsRequest.swift in Sources */,
+				116DBCF73EB42D0A37C9C725 /* ServiceEventSSEWriter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/SayIt/AppShell/AppDelegate.swift
+++ b/Sources/SayIt/AppShell/AppDelegate.swift
@@ -22,7 +22,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSWindow.didExposeNotification,
             NSWindow.willCloseNotification,
             NSWindow.didMiniaturizeNotification,
-            NSWindow.didDeminiaturizeNotification
+            NSWindow.didDeminiaturizeNotification,
+            NSWindow.didChangeOcclusionStateNotification
         ] {
             center.addObserver(
                 forName: name,
@@ -93,8 +94,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.async {
             MainActor.assumeIsolated {
                 let hasVisibleWindow = NSApp.windows.contains { window in
-                    window.isVisible && window.canBecomeMain
+                    window.isVisible
+                        && !window.isMiniaturized
+                        && window.canBecomeMain
                 }
+                AppState.shared.setAppWindowPresented(hasVisibleWindow)
                 let target: NSApplication.ActivationPolicy =
                     hasVisibleWindow ? .regular : .accessory
                 if NSApp.activationPolicy() != target {

--- a/Sources/SayIt/AppShell/AppState.swift
+++ b/Sources/SayIt/AppShell/AppState.swift
@@ -32,11 +32,17 @@ final class AppState {
     private var modelInstallRequestGeneration: UInt64 = 0
     private var serviceRepairTask: Task<Void, Never>?
     private var selectionRequestTask: Task<Void, Never>?
+    @ObservationIgnored
+    private var menuActivityTask: Task<Void, Never>?
     private var lastModelsRevision: UInt64?
     private var lastHistoryRevision: UInt64?
     private var lastDiagnosticsRevision: UInt64?
     private var lastVoicesRevision: UInt64?
     private var lastServiceRevision: UInt64?
+    @ObservationIgnored
+    private var serviceConnectionGeneration: UInt64 = 0
+    @ObservationIgnored
+    private var activeJobID: UUID?
     private var downloadByteCounts: [ModelID: Int64] = [:]
     private var modelIDToSelectAfterInstallation: ModelID?
 
@@ -51,7 +57,6 @@ final class AppState {
     private(set) var errorRecoveryAction: AppErrorRecoveryAction?
     private(set) var needsLongTextConfirmation = false
     private(set) var diagnosticEvents: [DiagnosticEvent] = []
-    private(set) var serviceSnapshot: ServiceSnapshot?
     private(set) var serviceConnection: ServiceConnectionState = .connecting
     private(set) var backendSettings = BackendSettingsSnapshot()
     private(set) var apiTokens: [APITokenMetadata] = []
@@ -64,9 +69,15 @@ final class AppState {
     private(set) var availableUpdateURL: URL?
     private(set) var isCheckingForUpdates = false
     private(set) var clipboardHasNewText = false
+    private(set) var isMenuPresented = false
+    private(set) var isAppWindowPresented = false
     @ObservationIgnored
     private var lastReadChangeCount = NSPasteboard.general.changeCount
     var isShowingOnboarding: Bool
+
+    var isPlaybackSurfacePresented: Bool {
+        isMenuPresented || isAppWindowPresented
+    }
 
     private init() {
         settings = AppSettings()
@@ -201,12 +212,16 @@ final class AppState {
     }
 
     func refreshClipboardState() {
+        guard isMenuPresented else { return }
         let pasteboard = NSPasteboard.general
         let hasText = !(pasteboard.string(forType: .string)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true)
-        clipboardHasNewText = hasText
+        let hasNewText = hasText
             && pasteboard.changeCount != lastReadChangeCount
+        if clipboardHasNewText != hasNewText {
+            clipboardHasNewText = hasNewText
+        }
     }
 
     func speakSample() {
@@ -305,13 +320,41 @@ final class AppState {
     }
 
     func confirmLongText() {
-        guard let id = serviceSnapshot?.activeJob?.id else { return }
+        guard let id = activeJobID else { return }
         perform(.confirmJob(id))
     }
 
     func cancelLongText() {
-        guard let id = serviceSnapshot?.activeJob?.id else { return }
+        guard let id = activeJobID else { return }
         perform(.cancelJob(id))
+    }
+
+    func setMenuPresented(_ isPresented: Bool) {
+        guard isMenuPresented != isPresented else { return }
+        isMenuPresented = isPresented
+        menuActivityTask?.cancel()
+        menuActivityTask = nil
+        guard isPresented else { return }
+
+        refreshClipboardState()
+        menuActivityTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch is CancellationError {
+                    return
+                } catch {
+                    return
+                }
+                guard let self, self.isMenuPresented else { return }
+                self.refreshClipboardState()
+            }
+        }
+    }
+
+    func setAppWindowPresented(_ isPresented: Bool) {
+        guard isAppWindowPresented != isPresented else { return }
+        isAppWindowPresented = isPresented
     }
 
     func cancelCurrentRequest(preserveHistory: Bool = true) {
@@ -922,6 +965,7 @@ final class AppState {
 
     func restartBackgroundService() {
         Task {
+            resetServiceRevisionTracking()
             await backgroundService.restart()
             await client.invalidate()
             serviceConnection = .connecting
@@ -930,6 +974,7 @@ final class AppState {
 
     func enableBackgroundService() {
         Task {
+            resetServiceRevisionTracking()
             await backgroundService.enable()
             await client.invalidate()
             serviceConnection = .connecting
@@ -937,6 +982,15 @@ final class AppState {
     }
 
     func terminateBackgroundServiceForQuit() async {
+        menuActivityTask?.cancel()
+        menuActivityTask = nil
+        isMenuPresented = false
+        isAppWindowPresented = false
+        pollingTask?.cancel()
+        resetServiceRevisionTracking()
+        await client.invalidate()
+        await pollingTask?.value
+        pollingTask = nil
         selectionRequestTask?.cancel()
         await selectionRequestTask?.value
         selectionRequestTask = nil
@@ -1039,22 +1093,36 @@ final class AppState {
                 guard let self else { return }
                 self.backgroundService.refresh()
                 guard !self.backgroundService.isUserDisabled else {
-                    self.serviceConnection = .disabled
+                    if self.serviceConnection != .disabled {
+                        self.resetServiceRevisionTracking()
+                        self.serviceConnection = .disabled
+                    }
                     try? await Task.sleep(for: .seconds(1))
                     continue
                 }
                 do {
                     try await self.synchronizeServiceState()
                     retryDelay = .milliseconds(250)
-                    try await Task.sleep(for: .milliseconds(100))
+                } catch is CancellationError {
+                    return
                 } catch let failure as ServiceFailure
                     where failure.code == "protocol.version_mismatch" {
-                    self.serviceConnection = .updateRequired
-                    self.statusText = "Service update required"
+                    if self.serviceConnection != .updateRequired {
+                        self.serviceConnection = .updateRequired
+                    }
+                    if self.statusText != "Service update required" {
+                        self.statusText = "Service update required"
+                    }
                     try? await Task.sleep(for: .seconds(2))
                 } catch {
-                    self.serviceConnection = .offline
-                    self.statusText = "Background service unavailable"
+                    guard !Task.isCancelled else { return }
+                    self.resetServiceRevisionTracking()
+                    if self.serviceConnection != .offline {
+                        self.serviceConnection = .offline
+                    }
+                    if self.statusText != "Background service unavailable" {
+                        self.statusText = "Background service unavailable"
+                    }
                     await self.client.invalidate()
                     self.scheduleServiceRepair()
                     try? await Task.sleep(for: retryDelay)
@@ -1073,6 +1141,7 @@ final class AppState {
         serviceRepairTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(1))
             guard let self, !Task.isCancelled else { return }
+            self.resetServiceRevisionTracking()
             await self.backgroundService.ensureRunning()
             await self.client.invalidate()
             self.serviceRepairTask = nil
@@ -1080,11 +1149,28 @@ final class AppState {
     }
 
     private func synchronizeServiceState() async throws {
-        guard let lastServiceRevision else {
+        let requestedRevision = lastServiceRevision
+        let requestedGeneration = serviceConnectionGeneration
+        guard let requestedRevision else {
             try await reloadServiceSnapshot()
             return
         }
-        let response = try await send(.events(after: lastServiceRevision))
+        let response = try await send(
+            .waitForEvents(
+                after: requestedRevision,
+                playbackInterval: Self.playbackRefreshInterval(
+                    isPlaybackSurfacePresented: isPlaybackSurfacePresented
+                )
+            )
+        )
+        guard Self.isServiceStateRequestCurrent(
+            requestedRevision: requestedRevision,
+            currentRevision: lastServiceRevision,
+            requestedGeneration: requestedGeneration,
+            currentGeneration: serviceConnectionGeneration
+        ) else {
+            return
+        }
         guard case .events(let events) = response else {
             try requireSuccess(response)
             throw ServiceFailure(
@@ -1095,7 +1181,7 @@ final class AppState {
         guard let event = events.last else { return }
         guard Self.shouldApplyEvent(
             id: event.id,
-            after: lastServiceRevision
+            after: requestedRevision
         ) else {
             return
         }
@@ -1104,9 +1190,26 @@ final class AppState {
 
     nonisolated static func shouldApplyEvent(
         id: UInt64,
-        after revision: UInt64
+        after revision: UInt64?
     ) -> Bool {
-        id > revision
+        guard let revision else { return true }
+        return id > revision
+    }
+
+    nonisolated static func isServiceStateRequestCurrent(
+        requestedRevision: UInt64?,
+        currentRevision: UInt64?,
+        requestedGeneration: UInt64,
+        currentGeneration: UInt64
+    ) -> Bool {
+        requestedGeneration == currentGeneration
+            && requestedRevision == currentRevision
+    }
+
+    nonisolated static func playbackRefreshInterval(
+        isPlaybackSurfacePresented: Bool
+    ) -> TimeInterval {
+        isPlaybackSurfacePresented ? 0.25 : 1
     }
 
     nonisolated static func shouldPresentOnboarding(
@@ -1124,7 +1227,17 @@ final class AppState {
     }
 
     private func reloadServiceSnapshot() async throws {
+        let requestedRevision = lastServiceRevision
+        let requestedGeneration = serviceConnectionGeneration
         let response = try await send(.snapshot)
+        guard Self.isServiceStateRequestCurrent(
+            requestedRevision: requestedRevision,
+            currentRevision: lastServiceRevision,
+            requestedGeneration: requestedGeneration,
+            currentGeneration: serviceConnectionGeneration
+        ) else {
+            return
+        }
         guard case .snapshot(let snapshot) = response else {
             try requireSuccess(response)
             throw ServiceFailure(
@@ -1136,30 +1249,65 @@ final class AppState {
     }
 
     private func apply(_ snapshot: ServiceSnapshot) {
+        guard Self.shouldApplyEvent(
+            id: snapshot.revision,
+            after: lastServiceRevision
+        ) else {
+            return
+        }
         lastServiceRevision = snapshot.revision
-        serviceSnapshot = snapshot
-        serviceConnection = .online(version: snapshot.serviceVersion)
+        activeJobID = snapshot.activeJob?.id
+        let onlineConnection = ServiceConnectionState.online(
+            version: snapshot.serviceVersion
+        )
+        if serviceConnection != onlineConnection {
+            serviceConnection = onlineConnection
+        }
         if let serviceError = snapshot.lastError {
-            statusText = snapshot.statusText
-            errorMessage = serviceError
-            errorRecoveryAction = nil
+            if statusText != snapshot.statusText {
+                statusText = snapshot.statusText
+            }
+            if errorMessage != serviceError {
+                errorMessage = serviceError
+            }
+            if errorRecoveryAction != nil {
+                errorRecoveryAction = nil
+            }
         } else if Self.shouldDismissPresentedError(
             serviceError: snapshot.lastError,
             playbackState: snapshot.playback.state
         ) {
-            statusText = snapshot.statusText
-            errorMessage = nil
-            errorRecoveryAction = nil
+            if statusText != snapshot.statusText {
+                statusText = snapshot.statusText
+            }
+            if errorMessage != nil {
+                errorMessage = nil
+            }
+            if errorRecoveryAction != nil {
+                errorRecoveryAction = nil
+            }
         } else if errorRecoveryAction == nil {
-            statusText = snapshot.statusText
-            errorMessage = nil
+            if statusText != snapshot.statusText {
+                statusText = snapshot.statusText
+            }
+            if errorMessage != nil {
+                errorMessage = nil
+            }
         }
-        httpAPIErrorMessage = snapshot.httpServiceError
-        needsLongTextConfirmation =
+        if httpAPIErrorMessage != snapshot.httpServiceError {
+            httpAPIErrorMessage = snapshot.httpServiceError
+        }
+        let awaitsConfirmation =
             snapshot.activeJob?.state == .awaitingConfirmation
-        installedModelIDs = Set(
+        if needsLongTextConfirmation != awaitsConfirmation {
+            needsLongTextConfirmation = awaitsConfirmation
+        }
+        let newInstalledModelIDs = Set(
             snapshot.installedModelIDs.map { ModelID($0) }
         )
+        if installedModelIDs != newInstalledModelIDs {
+            installedModelIDs = newInstalledModelIDs
+        }
         if let requestedModelInstallID,
            installedModelIDs.contains(requestedModelInstallID) {
             self.requestedModelInstallID = nil
@@ -1171,8 +1319,12 @@ final class AppState {
         }
         playback.apply(snapshot.playback)
         applyDownload(snapshot.download)
-        modelInstallError = snapshot.modelInstallError.map {
+        let nextModelInstallError = snapshot.modelInstallError.map {
             (modelID: ModelID($0.modelID), message: $0.message)
+        }
+        if modelInstallError?.modelID != nextModelInstallError?.modelID
+            || modelInstallError?.message != nextModelInstallError?.message {
+            modelInstallError = nextModelInstallError
         }
         if let modelInstallError,
            modelIDToSelectAfterInstallation == modelInstallError.modelID {
@@ -1188,9 +1340,12 @@ final class AppState {
                 snapshot.settings.showNowPlayingTitles
         }
 
-        isShowingOnboarding = Self.shouldPresentOnboarding(
+        let shouldShowOnboarding = Self.shouldPresentOnboarding(
             onboardingComplete: settings.onboardingComplete
         )
+        if isShowingOnboarding != shouldShowOnboarding {
+            isShowingOnboarding = shouldShowOnboarding
+        }
 
         if lastModelsRevision != snapshot.modelsRevision {
             lastModelsRevision = snapshot.modelsRevision
@@ -1204,7 +1359,9 @@ final class AppState {
             lastDiagnosticsRevision = snapshot.diagnosticsRevision
             Task { await loadDiagnostics() }
         }
-        voiceStudio = snapshot.voiceStudio
+        if voiceStudio != snapshot.voiceStudio {
+            voiceStudio = snapshot.voiceStudio
+        }
         if lastVoicesRevision != snapshot.voicesRevision {
             lastVoicesRevision = snapshot.voicesRevision
             Task { await refreshVoices() }
@@ -1216,16 +1373,21 @@ final class AppState {
               let state = ModelInstallationState(
                 rawValue: snapshot.state
               ) else {
-            downloadProgress = nil
+            if downloadProgress != nil {
+                downloadProgress = nil
+            }
             return
         }
-        downloadProgress = ModelDownloadProgress(
+        let nextProgress = ModelDownloadProgress(
             modelID: ModelID(snapshot.modelID),
             state: state,
             completedBytes: snapshot.completedBytes,
             totalBytes: snapshot.totalBytes,
             bytesPerSecond: Int64(snapshot.bytesPerSecond)
         )
+        if downloadProgress != nextProgress {
+            downloadProgress = nextProgress
+        }
         if requestedModelInstallID == downloadProgress?.modelID {
             requestedModelInstallID = nil
         }
@@ -1400,12 +1562,22 @@ final class AppState {
             if error is SayItXPCClientError {
                 modelIDToSelectAfterInstallation = nil
                 requestedModelInstallID = nil
+                resetServiceRevisionTracking()
                 serviceConnection = .offline
                 statusText = "Background service unavailable"
                 await client.invalidate()
             }
             throw error
         }
+    }
+
+    private func resetServiceRevisionTracking() {
+        serviceConnectionGeneration &+= 1
+        lastServiceRevision = nil
+        lastModelsRevision = nil
+        lastHistoryRevision = nil
+        lastDiagnosticsRevision = nil
+        lastVoicesRevision = nil
     }
 
     private func requireSuccess(_ response: ServiceResponse) throws {

--- a/Sources/SayIt/AppShell/MenuBarLabel.swift
+++ b/Sources/SayIt/AppShell/MenuBarLabel.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct MenuBarLabel: View {
     @Environment(AppState.self) private var state
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var isActive: Bool {
         state.playback.state == .playing
@@ -11,31 +10,29 @@ struct MenuBarLabel: View {
     }
 
     var body: some View {
-        Group {
-            if isActive, !reduceMotion {
-                icon
-                    .phaseAnimator([1.0, 0.4]) { view, phase in
-                        view.opacity(phase)
-                    } animation: { _ in
-                        .easeInOut(duration: 0.8)
-                    }
-            } else {
-                icon
+        icon
+            .opacity(isActive ? 0.72 : 1)
+            .overlay(alignment: .bottomTrailing) {
+                if isActive {
+                    Circle()
+                        .fill(Color.accentColor)
+                        .frame(width: 5, height: 5)
+                        .accessibilityHidden(true)
+                }
             }
-        }
-        .overlay(alignment: .topTrailing) {
-            if state.errorMessage != nil {
-                Circle()
-                    .fill(.red)
-                    .frame(width: 6, height: 6)
-                    .accessibilityHidden(true)
+            .overlay(alignment: .topTrailing) {
+                if state.errorMessage != nil {
+                    Circle()
+                        .fill(.red)
+                        .frame(width: 6, height: 6)
+                        .accessibilityHidden(true)
+                }
             }
-        }
-        .accessibilityLabel("Say It")
-        .accessibilityValue(state.statusText)
-        .background {
-            AppWindowCoordinator()
-        }
+            .accessibilityLabel("Say It")
+            .accessibilityValue(state.statusText)
+            .background {
+                AppWindowCoordinator()
+            }
     }
 
     private var icon: some View {

--- a/Sources/SayIt/AppShell/MenuBarRootView.swift
+++ b/Sources/SayIt/AppShell/MenuBarRootView.swift
@@ -2,11 +2,6 @@ import SwiftUI
 
 struct MenuBarRootView: View {
     @Environment(AppState.self) private var state
-    private let clipboardTimer = Timer.publish(
-        every: 1,
-        on: .main,
-        in: .common
-    ).autoconnect()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -30,7 +25,7 @@ struct MenuBarRootView: View {
                     .transition(.opacity)
             } else if state.playback.state != .idle {
                 Divider()
-                PlaybackSectionView()
+                PlaybackSectionView(isPresented: state.isMenuPresented)
                     .padding(.horizontal, DesignTokens.generousSpacing)
                     .padding(.bottom, DesignTokens.compactSpacing)
                 SpeechLyricsView(
@@ -68,9 +63,11 @@ struct MenuBarRootView: View {
         }
         .frame(width: DesignTokens.popoverWidth)
         .animation(.smooth(duration: 0.3), value: section)
-        .onAppear(perform: state.refreshClipboardState)
-        .onReceive(clipboardTimer) { _ in
-            state.refreshClipboardState()
+        .background {
+            MenuPresentationObserver(
+                onChange: state.setMenuPresented
+            )
+            .frame(width: 0, height: 0)
         }
     }
 

--- a/Sources/SayIt/AppShell/MenuPresentationObserver.swift
+++ b/Sources/SayIt/AppShell/MenuPresentationObserver.swift
@@ -1,0 +1,95 @@
+import AppKit
+import SwiftUI
+
+struct MenuPresentationObserver: NSViewRepresentable {
+    let onChange: @MainActor (Bool) -> Void
+
+    func makeNSView(context: Context) -> PresentationTrackingView {
+        PresentationTrackingView(onChange: onChange)
+    }
+
+    func updateNSView(
+        _ nsView: PresentationTrackingView,
+        context: Context
+    ) {
+        nsView.onChange = onChange
+        nsView.reportPresentation()
+    }
+
+    static func dismantleNSView(
+        _ nsView: PresentationTrackingView,
+        coordinator: Void
+    ) {
+        nsView.stopObserving()
+        nsView.onChange(false)
+    }
+}
+
+@MainActor
+final class PresentationTrackingView: NSView {
+    var onChange: @MainActor (Bool) -> Void
+    private var observations: [NSObjectProtocol] = []
+
+    init(onChange: @escaping @MainActor (Bool) -> Void) {
+        self.onChange = onChange
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        startObservingWindow()
+    }
+
+    func reportPresentation() {
+        let isPresented = window?.isVisible == true
+            && window?.occlusionState.contains(.visible) == true
+        onChange(isPresented)
+    }
+
+    func stopObserving() {
+        for observation in observations {
+            NotificationCenter.default.removeObserver(observation)
+        }
+        observations.removeAll(keepingCapacity: true)
+    }
+
+    private func startObservingWindow() {
+        stopObserving()
+        guard let window else {
+            onChange(false)
+            return
+        }
+        let center = NotificationCenter.default
+        for name in [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didResignKeyNotification,
+            NSWindow.didMiniaturizeNotification,
+            NSWindow.didDeminiaturizeNotification,
+            NSWindow.didChangeOcclusionStateNotification,
+            NSWindow.willCloseNotification
+        ] {
+            observations.append(
+                center.addObserver(
+                    forName: name,
+                    object: window,
+                    queue: .main
+                ) { [weak self] notification in
+                    let isClosing = notification.name == NSWindow.willCloseNotification
+                    MainActor.assumeIsolated {
+                        if isClosing {
+                            self?.onChange(false)
+                        } else {
+                            self?.reportPresentation()
+                        }
+                    }
+                }
+            )
+        }
+        reportPresentation()
+    }
+}

--- a/Sources/SayIt/Playback/PlaybackController.swift
+++ b/Sources/SayIt/Playback/PlaybackController.swift
@@ -35,16 +35,36 @@ final class PlaybackController {
     var commandHandler: ((ServiceCommand) -> Void)?
 
     func apply(_ snapshot: PlaybackSnapshot) {
-        state = PlaybackState(rawValue: snapshot.state) ?? .idle
-        elapsed = snapshot.elapsed
-        generatedDuration = snapshot.generatedDuration
-        estimatedDuration = snapshot.estimatedDuration
+        let nextState = PlaybackState(rawValue: snapshot.state) ?? .idle
+        if state != nextState {
+            state = nextState
+        }
+        if elapsed != snapshot.elapsed {
+            elapsed = snapshot.elapsed
+        }
+        if generatedDuration != snapshot.generatedDuration {
+            generatedDuration = snapshot.generatedDuration
+        }
+        if estimatedDuration != snapshot.estimatedDuration {
+            estimatedDuration = snapshot.estimatedDuration
+        }
         if snapshot.includesContent {
-            amplitudes = snapshot.amplitudes
-            currentTitle = snapshot.currentTitle
-            modelID = snapshot.modelID.map { ModelID($0) }
-            spokenText = snapshot.spokenText
-            spokenChunks = snapshot.spokenChunks
+            if amplitudes != snapshot.amplitudes {
+                amplitudes = snapshot.amplitudes
+            }
+            if currentTitle != snapshot.currentTitle {
+                currentTitle = snapshot.currentTitle
+            }
+            let nextModelID = snapshot.modelID.map { ModelID($0) }
+            if modelID != nextModelID {
+                modelID = nextModelID
+            }
+            if spokenText != snapshot.spokenText {
+                spokenText = snapshot.spokenText
+            }
+            if spokenChunks != snapshot.spokenChunks {
+                spokenChunks = snapshot.spokenChunks
+            }
         }
         if rate != snapshot.rate {
             let handler = commandHandler

--- a/Sources/SayIt/Playback/PlaybackSectionView.swift
+++ b/Sources/SayIt/Playback/PlaybackSectionView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PlaybackSectionView: View {
     @Environment(AppState.self) private var state
+    let isPresented: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignTokens.standardSpacing) {
@@ -25,6 +26,7 @@ struct PlaybackSectionView: View {
                     estimatedDuration: state.playback.estimatedDuration,
                     isPlaying: state.playback.state == .playing,
                     isBuffering: state.playback.state == .buffering,
+                    isPresented: isPresented,
                     onSeek: state.playback.seek
                 )
                 .transition(.opacity)

--- a/Sources/SayIt/Playback/VoiceRibbonView.swift
+++ b/Sources/SayIt/Playback/VoiceRibbonView.swift
@@ -10,6 +10,7 @@ struct VoiceRibbonView: View {
     let estimatedDuration: TimeInterval
     let isPlaying: Bool
     let isBuffering: Bool
+    let isPresented: Bool
     let onSeek: (TimeInterval) -> Void
 
     private var totalDuration: TimeInterval {
@@ -30,9 +31,22 @@ struct VoiceRibbonView: View {
         generation < 0.999
     }
 
+    nonisolated static func shouldPauseTimeline(
+        isPresented: Bool,
+        isProcessing: Bool
+    ) -> Bool {
+        !isPresented || !isProcessing
+    }
+
     var body: some View {
         TimelineView(
-            .animation(minimumInterval: 1.0 / 30.0, paused: !isProcessing)
+            .animation(
+                minimumInterval: 1.0 / 15.0,
+                paused: Self.shouldPauseTimeline(
+                    isPresented: isPresented,
+                    isProcessing: isProcessing
+                )
+            )
         ) { timeline in
             RibbonCanvas(
                 amplitudes: amplitudes,
@@ -78,6 +92,7 @@ struct VoiceRibbonView: View {
         }
         .padding(.bottom, 13)
         .onChange(of: progress, initial: true) { oldValue, newValue in
+            guard isPresented else { return }
             let isJump = newValue < oldValue || abs(newValue - oldValue) > 0.03
             if isPlaying, !isJump {
                 let target = min(newValue + (newValue - oldValue), 1)
@@ -91,14 +106,24 @@ struct VoiceRibbonView: View {
             }
         }
         .onChange(of: isPlaying) { _, playing in
-            guard !playing else { return }
+            guard isPresented, !playing else { return }
             withAnimation(.smooth(duration: 0.2)) {
                 smoothedProgress = progress
             }
         }
         .onChange(of: generation, initial: true) { _, newValue in
+            guard isPresented else { return }
             withAnimation(.smooth(duration: 0.6)) {
                 smoothedGeneration = newValue
+            }
+        }
+        .onChange(of: isPresented, initial: true) { _, presented in
+            guard presented else { return }
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                smoothedProgress = progress
+                smoothedGeneration = generation
             }
         }
         .accessibilityElement(children: .ignore)

--- a/Sources/SayIt/Service/BackgroundServiceController.swift
+++ b/Sources/SayIt/Service/BackgroundServiceController.swift
@@ -63,7 +63,10 @@ final class BackgroundServiceController {
     }
 
     func refresh() {
-        status = service.status
+        let currentStatus = service.status
+        if status != currentStatus {
+            status = currentStatus
+        }
     }
 
     func ensureRunning() async {

--- a/Sources/SayIt/Settings/SpeechPreviewView.swift
+++ b/Sources/SayIt/Settings/SpeechPreviewView.swift
@@ -35,7 +35,9 @@ struct SpeechPreviewView: View {
 
             if state.playback.state != .idle {
                 Divider()
-                PlaybackSectionView()
+                PlaybackSectionView(
+                    isPresented: state.isAppWindowPresented
+                )
                     .transition(
                         .opacity.combined(with: .move(edge: .top))
                     )

--- a/Sources/SayItAgent/HTTPServerSupervisor.swift
+++ b/Sources/SayItAgent/HTTPServerSupervisor.swift
@@ -1,59 +1,52 @@
 import Foundation
 import SayItBackend
 import SayItHTTP
-import SayItProtocol
 
 @MainActor
 final class HTTPServerSupervisor {
     private let backend: SayItBackendService
-    private var monitorTask: Task<Void, Never>?
     private var serverTask: Task<Void, Never>?
     private var activePort: Int?
+    private var isStarted = false
 
     init(backend: SayItBackendService) {
         self.backend = backend
     }
 
     func start() {
-        guard monitorTask == nil else { return }
-        monitorTask = Task { [weak self] in
-            while !Task.isCancelled {
-                await self?.synchronize()
-                try? await Task.sleep(for: .seconds(1))
-            }
+        guard !isStarted else { return }
+        isStarted = true
+        backend.setHTTPServiceConfigurationHandler { [weak self] configuration in
+            self?.synchronize(configuration)
         }
     }
 
     func stop() {
-        monitorTask?.cancel()
-        monitorTask = nil
+        guard isStarted else { return }
+        isStarted = false
+        backend.setHTTPServiceConfigurationHandler(nil)
         serverTask?.cancel()
         serverTask = nil
         activePort = nil
     }
 
-    private func synchronize() async {
-        let response = await backend.handle(
-            ServiceRequest(command: .snapshot)
-        )
-        guard case .snapshot(let snapshot) = response else { return }
-
-        guard snapshot.settings.httpEnabled else {
+    private func synchronize(_ configuration: HTTPServiceConfiguration) {
+        guard configuration.isEnabled else {
             serverTask?.cancel()
             serverTask = nil
             activePort = nil
             return
         }
-        guard activePort != snapshot.settings.httpPort || serverTask == nil else {
+        guard activePort != configuration.port || serverTask == nil else {
             return
         }
 
         serverTask?.cancel()
-        activePort = snapshot.settings.httpPort
+        activePort = configuration.port
         do {
             let server = try SayItHTTPServer(
                 backend: backend,
-                port: snapshot.settings.httpPort
+                port: configuration.port
             )
             serverTask = Task {
                 do {
@@ -68,9 +61,10 @@ final class HTTPServerSupervisor {
             }
         } catch {
             activePort = nil
-            await backend.reportHTTPServiceError(
-                "HTTP API could not start: \(error.localizedDescription)"
-            )
+            let message = "HTTP API could not start: \(error.localizedDescription)"
+            Task {
+                await backend.reportHTTPServiceError(message)
+            }
         }
     }
 }

--- a/Sources/SayItBackend/Playback/BackendPlaybackControlling.swift
+++ b/Sources/SayItBackend/Playback/BackendPlaybackControlling.swift
@@ -5,6 +5,7 @@ import SayItProtocol
 @MainActor
 protocol BackendPlaybackControlling: PlaybackControlling {
     var onFailure: (@MainActor (String) -> Void)? { get set }
+    var onExternalControl: (@MainActor () -> Void)? { get set }
     var state: PlaybackState { get }
     var elapsed: TimeInterval { get }
     var generatedDuration: TimeInterval { get }

--- a/Sources/SayItBackend/Playback/PlaybackController.swift
+++ b/Sources/SayItBackend/Playback/PlaybackController.swift
@@ -55,6 +55,9 @@ final class PlaybackController: BackendPlaybackControlling {
     @ObservationIgnored
     var onFailure: (@MainActor (String) -> Void)?
 
+    @ObservationIgnored
+    var onExternalControl: (@MainActor () -> Void)?
+
     private(set) var state: PlaybackState = .idle
     private(set) var elapsed: TimeInterval = 0
     private(set) var generatedDuration: TimeInterval = 0
@@ -1050,11 +1053,19 @@ final class PlaybackController: BackendPlaybackControlling {
     private func configureRemoteCommands() {
         let commands = MPRemoteCommandCenter.shared()
         commands.playCommand.addTarget { [weak self] _ in
-            Task { @MainActor in self?.play() }
+            Task { @MainActor in
+                guard let self else { return }
+                self.play()
+                self.onExternalControl?()
+            }
             return .success
         }
         commands.pauseCommand.addTarget { [weak self] _ in
-            Task { @MainActor in self?.pause() }
+            Task { @MainActor in
+                guard let self else { return }
+                self.pause()
+                self.onExternalControl?()
+            }
             return .success
         }
         commands.togglePlayPauseCommand.addTarget { [weak self] _ in
@@ -1065,17 +1076,23 @@ final class PlaybackController: BackendPlaybackControlling {
                 } else {
                     self.play()
                 }
+                self.onExternalControl?()
             }
             return .success
         }
         commands.stopCommand.addTarget { [weak self] _ in
-            Task { @MainActor in self?.stop() }
+            Task { @MainActor in
+                guard let self else { return }
+                self.stop()
+                self.onExternalControl?()
+            }
             return .success
         }
         commands.nextTrackCommand.addTarget { [weak self] _ in
             Task { @MainActor in
                 guard let self else { return }
                 self.skip(by: self.forwardSkipInterval)
+                self.onExternalControl?()
             }
             return .success
         }
@@ -1083,6 +1100,7 @@ final class PlaybackController: BackendPlaybackControlling {
             Task { @MainActor in
                 guard let self else { return }
                 self.skip(by: -self.backwardSkipInterval)
+                self.onExternalControl?()
             }
             return .success
         }
@@ -1093,6 +1111,7 @@ final class PlaybackController: BackendPlaybackControlling {
             Task { @MainActor in
                 guard let self else { return }
                 self.skip(by: -self.backwardSkipInterval)
+                self.onExternalControl?()
             }
             return .success
         }
@@ -1103,6 +1122,7 @@ final class PlaybackController: BackendPlaybackControlling {
             Task { @MainActor in
                 guard let self else { return }
                 self.skip(by: self.forwardSkipInterval)
+                self.onExternalControl?()
             }
             return .success
         }
@@ -1110,7 +1130,11 @@ final class PlaybackController: BackendPlaybackControlling {
             guard let position = event as? MPChangePlaybackPositionCommandEvent else {
                 return .commandFailed
             }
-            Task { @MainActor in self?.seek(to: position.positionTime) }
+            Task { @MainActor in
+                guard let self else { return }
+                self.seek(to: position.positionTime)
+                self.onExternalControl?()
+            }
             return .success
         }
         commands.changePlaybackRateCommand.supportedPlaybackRates = [
@@ -1124,7 +1148,9 @@ final class PlaybackController: BackendPlaybackControlling {
                 return .commandFailed
             }
             Task { @MainActor in
-                self?.rate = Double(rateEvent.playbackRate)
+                guard let self else { return }
+                self.rate = Double(rateEvent.playbackRate)
+                self.onExternalControl?()
             }
             return .success
         }

--- a/Sources/SayItBackend/Playback/PlaybackController.swift
+++ b/Sources/SayItBackend/Playback/PlaybackController.swift
@@ -24,7 +24,7 @@ final class PlaybackController: BackendPlaybackControlling {
     private let engine = AVAudioEngine()
     private let player = AVAudioPlayerNode()
     private let timePitch = AVAudioUnitTimePitch()
-    private var timelineTask: Task<Void, Never>?
+    private let timeline = TimelineDriver()
     private var audioConfigurationTask: Task<Void, Never>?
     private var audioConfigurationRecoveryTask: Task<Void, Never>?
     private var completionWatchdogTask: Task<Void, Never>?
@@ -120,7 +120,6 @@ final class PlaybackController: BackendPlaybackControlling {
         timePitch.pitch = 0
         timePitch.overlap = Self.highQualityTimePitchOverlap
         configureRemoteCommands()
-        startTimeline()
         monitorAudioConfiguration()
     }
 
@@ -209,6 +208,7 @@ final class PlaybackController: BackendPlaybackControlling {
         lastStablePlaybackTime = elapsed
         cancelAudioConfigurationRecovery()
         player.pause()
+        stopTimeline()
         state = .paused
         updateNowPlaying()
     }
@@ -242,6 +242,7 @@ final class PlaybackController: BackendPlaybackControlling {
                 from: currentPlaybackTime(),
                 requestedDuration: duration
             )
+            stopTimeline()
             state = .paused
             try await Task.sleep(for: actualDuration)
         } catch {
@@ -448,6 +449,7 @@ final class PlaybackController: BackendPlaybackControlling {
         failureMessage = nil
         state = .playing
         lastStablePlaybackTime = elapsed
+        startTimeline()
         scheduleCompletionWatchdog()
         updateNowPlaying()
     }
@@ -614,6 +616,7 @@ final class PlaybackController: BackendPlaybackControlling {
     }
 
     private func invalidateScheduledAudio() {
+        stopTimeline()
         completionWatchdogTask?.cancel()
         completionWatchdogTask = nil
         scheduleGeneration &+= 1
@@ -780,17 +783,16 @@ final class PlaybackController: BackendPlaybackControlling {
     }
 
     private func startTimeline() {
-        timelineTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(100))
-                guard let self else { return }
-                if self.state == .playing {
-                    self.elapsed = self.currentPlaybackTime()
-                    self.lastStablePlaybackTime = self.elapsed
-                    self.updateNowPlaying(throttleTimeline: true)
-                }
-            }
+        timeline.start { [weak self] in
+            guard let self, self.state == .playing else { return }
+            self.elapsed = self.currentPlaybackTime()
+            self.lastStablePlaybackTime = self.elapsed
+            self.updateNowPlaying(throttleTimeline: true)
         }
+    }
+
+    private func stopTimeline() {
+        timeline.stop()
     }
 
     private func monitorAudioConfiguration() {
@@ -958,6 +960,7 @@ final class PlaybackController: BackendPlaybackControlling {
 
     private func reportFailure(_ error: Error, shouldResume: Bool = false) {
         cancelAudioConfigurationRecovery()
+        stopTimeline()
         if shouldResume {
             elapsed = currentPlaybackTime()
         }
@@ -1142,5 +1145,69 @@ final class PlaybackController: BackendPlaybackControlling {
             MPNowPlayingInfoPropertyElapsedPlaybackTime: elapsed,
             MPNowPlayingInfoPropertyPlaybackRate: state == .playing ? rate : 0
         ]
+    }
+}
+
+extension PlaybackController {
+    @MainActor
+    final class TimelineDriver {
+        typealias Sleep = @Sendable (Duration) async throws -> Void
+
+        static let interval = Duration.milliseconds(250)
+
+        private let sleep: Sleep
+        private var task: Task<Void, Never>?
+        private var generation: UInt64 = 0
+
+        var isActive: Bool {
+            task != nil
+        }
+
+        init(
+            sleep: @escaping Sleep = { duration in
+                try await Task.sleep(for: duration)
+            }
+        ) {
+            self.sleep = sleep
+        }
+
+        deinit {
+            task?.cancel()
+        }
+
+        func start(
+            onTick: @escaping @MainActor @Sendable () -> Void
+        ) {
+            guard task == nil else { return }
+            generation &+= 1
+            let activeGeneration = generation
+            let sleep = self.sleep
+            task = Task { @MainActor [weak self] in
+                do {
+                    while !Task.isCancelled {
+                        try await sleep(Self.interval)
+                        try Task.checkCancellation()
+                        guard self?.generation == activeGeneration else {
+                            return
+                        }
+                        onTick()
+                    }
+                } catch {
+                    // Cancellation and clock failures both end this cadence.
+                }
+                self?.clearIfCurrent(activeGeneration)
+            }
+        }
+
+        func stop() {
+            generation &+= 1
+            task?.cancel()
+            task = nil
+        }
+
+        private func clearIfCurrent(_ completedGeneration: UInt64) {
+            guard generation == completedGeneration else { return }
+            task = nil
+        }
     }
 }

--- a/Sources/SayItBackend/Service/HTTPServiceConfiguration.swift
+++ b/Sources/SayItBackend/Service/HTTPServiceConfiguration.swift
@@ -1,0 +1,9 @@
+public struct HTTPServiceConfiguration: Equatable, Sendable {
+    public let isEnabled: Bool
+    public let port: Int
+
+    public init(isEnabled: Bool, port: Int) {
+        self.isEnabled = isEnabled
+        self.port = port
+    }
+}

--- a/Sources/SayItBackend/Service/SayItBackendService.swift
+++ b/Sources/SayItBackend/Service/SayItBackendService.swift
@@ -172,6 +172,10 @@ public final class SayItBackendService: SayItService {
         playback.onFailure = { [weak self] message in
             self?.recordFailure(message)
         }
+        playback.onExternalControl = { [weak self] in
+            guard let self else { return }
+            self.revision &+= 1
+        }
     }
 
     public func start() async {

--- a/Sources/SayItBackend/Service/SayItBackendService.swift
+++ b/Sources/SayItBackend/Service/SayItBackendService.swift
@@ -45,7 +45,23 @@ public final class SayItBackendService: SayItService {
     private var statusText = "Starting service"
     private var errorMessage: String?
     private var httpServiceError: String?
-    private var revision: UInt64 = 0
+    private var httpServiceConfigurationHandler: (
+        @MainActor (HTTPServiceConfiguration) -> Void
+    )?
+    private let eventHub: ServiceEventHub
+    private var revision = UInt64.random(in: 1...UInt64(Int64.max)) {
+        didSet {
+            guard revision != oldValue else { return }
+            cachedServiceEvent = nil
+            lastPublishedPlaybackState = playback.state
+            let playbackContent = currentPlaybackContent
+            if lastPlaybackContent != playbackContent {
+                lastPlaybackContent = playbackContent
+                playbackContentRevision = revision
+            }
+            eventHub.publish(revision)
+        }
+    }
     private var modelsRevision: UInt64 = 0
     private var historyRevision: UInt64 = 0
     private var diagnosticsRevision: UInt64 = 0
@@ -54,10 +70,11 @@ public final class SayItBackendService: SayItService {
     private var voiceStudioSnapshot: VoiceStudioSnapshot?
     private var voiceDraftsByID: [UUID: VoiceDraftCandidate] = [:]
     private var voiceCloneDraft: VoiceCloneDraft?
-    private var lastProgressRevisionDate = Date.distantPast
-    private var lastReplayProgressTick: Int?
     private var lastPlaybackContent: PlaybackContentState?
+    private var lastPublishedPlaybackState: PlaybackState?
     private var playbackContentRevision: UInt64 = 0
+    private var cachedServiceEvent: ServiceEvent?
+    private(set) var eventSnapshotBuildCount = 0
     private var isModelTransitionInProgress = false
     private var isShuttingDown = false
     private let serviceVersion: String
@@ -79,11 +96,17 @@ public final class SayItBackendService: SayItService {
         playback: any BackendPlaybackControlling,
         synthesizer: (any BackendSpeechSynthesizing)? = nil,
         catalogOverride: ModelCatalog? = nil,
-        modelManagerOverride: ModelManager? = nil
+        modelManagerOverride: ModelManager? = nil,
+        eventSleep: ServiceEventHub.Sleep? = nil
     ) throws {
         self.directories = directories
         self.serviceVersion = serviceVersion
         self.playback = playback
+        if let eventSleep {
+            eventHub = ServiceEventHub(sleep: eventSleep)
+        } else {
+            eventHub = ServiceEventHub()
+        }
         setenv("HF_HUB_CACHE", directories.hubCache.path, 1)
 
         let catalog = if let catalogOverride {
@@ -258,11 +281,46 @@ public final class SayItBackendService: SayItService {
     }
 
     public func events(after sequence: UInt64) async -> [ServiceEvent] {
-        let snapshot = makeSnapshot(playbackContentAfter: sequence)
-        guard snapshot.revision > sequence else { return [] }
-        return [
-            ServiceEvent(id: snapshot.revision, snapshot: snapshot)
-        ]
+        synchronizePlaybackStateRevision()
+        guard revision != sequence else { return [] }
+        return [currentServiceEvent()]
+    }
+
+    private func waitForEvents(
+        after sequence: UInt64,
+        playbackInterval: TimeInterval
+    ) async throws -> [ServiceEvent] {
+        let matchedBeforePlaybackSynchronization = revision == sequence
+        synchronizePlaybackStateRevision()
+        if revision != sequence {
+            let event = currentServiceEvent()
+            return [
+                matchedBeforePlaybackSynchronization
+                    ? project(event, after: sequence)
+                    : event
+            ]
+        }
+
+        let requestedInterval = playbackInterval.isFinite
+            ? playbackInterval
+            : 1
+        let interval = min(max(requestedInterval, 0.1), 5)
+        let wasPlaying = playback.state == .playing
+        let timeout: Duration = wasPlaying
+            ? .milliseconds(Int64((interval * 1_000).rounded()))
+            : .seconds(30)
+        try await eventHub.wait(
+            after: sequence,
+            currentRevision: revision,
+            timeout: timeout
+        )
+        try Task.checkCancellation()
+
+        if revision == sequence, wasPlaying {
+            revision &+= 1
+        }
+        guard revision != sequence else { return [] }
+        return [project(currentServiceEvent(), after: sequence)]
     }
 
     public func authorize(
@@ -286,11 +344,19 @@ public final class SayItBackendService: SayItService {
         diagnosticsRevision &+= 1
     }
 
+    public func setHTTPServiceConfigurationHandler(
+        _ handler: (@MainActor (HTTPServiceConfiguration) -> Void)?
+    ) {
+        httpServiceConfigurationHandler = handler
+        handler?(httpServiceConfiguration)
+    }
+
     public func reportHTTPServiceError(_ message: String) async {
         await waitForPendingModelTransitions()
         var settings = settingsStore.value
         settings.httpEnabled = false
         try? settingsStore.update(settings)
+        httpServiceConfigurationHandler?(httpServiceConfiguration)
         httpServiceError = message
         revision &+= 1
         await diagnostics.record(
@@ -310,9 +376,17 @@ public final class SayItBackendService: SayItService {
     private func handle(_ command: ServiceCommand) async throws -> ServiceResponse {
         switch command {
         case .snapshot:
+            synchronizePlaybackStateRevision()
             return .snapshot(makeSnapshot())
         case .events(let sequence):
             return .events(await events(after: sequence))
+        case .waitForEvents(let sequence, let playbackInterval):
+            return .events(
+                try await waitForEvents(
+                    after: sequence,
+                    playbackInterval: playbackInterval
+                )
+            )
         case .submit(let submission):
             return .job(try await submit(submission))
         case .jobs:
@@ -456,14 +530,17 @@ public final class SayItBackendService: SayItService {
         case .toggleHistoryPinned(let id):
             try history.togglePinned(id: id)
             historyRevision &+= 1
+            revision &+= 1
             return .accepted
         case .deleteHistory(let id):
             try history.remove(id: id)
             historyRevision &+= 1
+            revision &+= 1
             return .accepted
         case .clearHistory:
             try history.removeAll()
             historyRevision &+= 1
+            revision &+= 1
             return .accepted
         case .diagnostics:
             let events = await diagnostics.events()
@@ -473,6 +550,7 @@ public final class SayItBackendService: SayItService {
         case .clearDiagnostics:
             try await diagnostics.clear()
             diagnosticsRevision &+= 1
+            revision &+= 1
             return .accepted
         case .updateSettings(let settings):
             try await updateSettings(settings)
@@ -1660,12 +1738,7 @@ public final class SayItBackendService: SayItService {
             || playback.state == .buffering
             || playback.state == .preparing {
             try Task.checkCancellation()
-            if playback.state == .paused {
-                updateJob(id, state: .paused, progress: playbackProgress)
-            } else {
-                updateJob(id, state: .playing, progress: playbackProgress)
-            }
-            try await Task.sleep(for: .milliseconds(100))
+            try await Task.sleep(for: .milliseconds(250))
         }
         finishJob(id, state: .completed)
     }
@@ -1687,6 +1760,7 @@ public final class SayItBackendService: SayItService {
         case .chunkStarted(_, let chunk):
             registerSpokenChunk(chunk)
         case .audio(let chunk):
+            let revisionBeforeAudio = revision
             flushPendingSpokenChunk()
             try playback.enqueue(chunk)
             spokenAudioCursor = playback.generatedDuration
@@ -1697,6 +1771,9 @@ public final class SayItBackendService: SayItService {
             } else {
                 statusText = "Buffering"
                 updateJob(request.id, state: .buffering, progress: 0.2)
+            }
+            if revision == revisionBeforeAudio {
+                revision &+= 1
             }
         case .metrics(let metrics):
             playback.observeSynthesisMetrics(metrics)
@@ -1876,18 +1953,17 @@ public final class SayItBackendService: SayItService {
     ) {
         guard var job = jobsByID[id], !job.state.isTerminal else { return }
         let previousState = job.state
+        let boundedProgress = min(max(progress, 0), 1)
+        guard state != previousState || boundedProgress != job.progress else {
+            return
+        }
         if job.startedAt == nil, state != .queued {
             job.startedAt = .now
         }
         job.state = state
-        job.progress = min(max(progress, 0), 1)
+        job.progress = boundedProgress
         jobsByID[id] = job
-        let now = Date.now
-        if state != previousState
-            || now.timeIntervalSince(lastProgressRevisionDate) >= 0.1 {
-            revision &+= 1
-            lastProgressRevisionDate = now
-        }
+        revision &+= 1
         if state != previousState {
             persistJobJournal()
         }
@@ -1960,39 +2036,59 @@ public final class SayItBackendService: SayItService {
         lastRecordedTextEnd = range.upperBound
     }
 
-    private func makeSnapshot(
-        playbackContentAfter sequence: UInt64? = nil
-    ) -> ServiceSnapshot {
-        if activeJobID == nil, playback.state == .playing {
-            let tick = Int(playback.elapsed * 10)
-            if tick != lastReplayProgressTick {
-                lastReplayProgressTick = tick
-                revision &+= 1
-            }
-        } else {
-            lastReplayProgressTick = nil
-        }
-        var activeJob = activeJobID.flatMap { jobsByID[$0] }
-        if var job = activeJob, playback.state == .playing {
-            job.state = .playing
-            job.progress = playbackProgress
-            activeJob = job
-        }
-        let playbackContent = PlaybackContentState(
+    private var currentPlaybackContent: PlaybackContentState {
+        PlaybackContentState(
             currentTitle: playback.currentTitle,
             modelID: playback.currentModelID,
             amplitudes: playback.amplitudes,
             spokenText: playback.spokenText,
             spokenChunks: playback.spokenChunks
         )
-        if lastPlaybackContent != playbackContent {
-            lastPlaybackContent = playbackContent
-            revision &+= 1
-            playbackContentRevision = revision
+    }
+
+    private func synchronizePlaybackStateRevision() {
+        let currentState = playback.state
+        guard let lastPublishedPlaybackState else {
+            self.lastPublishedPlaybackState = currentState
+            return
         }
-        let includesPlaybackContent = sequence.map {
-            playbackContentRevision > $0
-        } ?? true
+        guard lastPublishedPlaybackState != currentState else { return }
+        revision &+= 1
+    }
+
+    private func currentServiceEvent() -> ServiceEvent {
+        if let cachedServiceEvent,
+           cachedServiceEvent.id == revision {
+            return cachedServiceEvent
+        }
+        eventSnapshotBuildCount &+= 1
+        let event = ServiceEvent(id: revision, snapshot: makeSnapshot())
+        cachedServiceEvent = event
+        return event
+    }
+
+    private func project(
+        _ event: ServiceEvent,
+        after sequence: UInt64
+    ) -> ServiceEvent {
+        guard sequence < event.id,
+              playbackContentRevision <= sequence else {
+            return event
+        }
+        return ServiceEvent(
+            id: event.id,
+            snapshot: event.snapshot.omittingPlaybackContent
+        )
+    }
+
+    private func makeSnapshot() -> ServiceSnapshot {
+        var activeJob = activeJobID.flatMap { jobsByID[$0] }
+        if var job = activeJob, playback.state == .playing {
+            job.state = .playing
+            job.progress = playbackProgress
+            activeJob = job
+        }
+        let playbackContent = currentPlaybackContent
         return ServiceSnapshot(
             serviceVersion: serviceVersion,
             revision: revision,
@@ -2008,22 +2104,12 @@ public final class SayItBackendService: SayItService {
                 estimatedDuration: playback.estimatedDuration,
                 rate: playback.rate,
                 volume: playback.volume,
-                currentTitle: includesPlaybackContent
-                    ? playbackContent.currentTitle
-                    : "",
-                modelID: includesPlaybackContent
-                    ? playbackContent.modelID
-                    : nil,
-                amplitudes: includesPlaybackContent
-                    ? playbackContent.amplitudes
-                    : [],
-                spokenText: includesPlaybackContent
-                    ? playbackContent.spokenText
-                    : "",
-                spokenChunks: includesPlaybackContent
-                    ? playbackContent.spokenChunks
-                    : [],
-                includesContent: includesPlaybackContent
+                currentTitle: playbackContent.currentTitle,
+                modelID: playbackContent.modelID,
+                amplitudes: playbackContent.amplitudes,
+                spokenText: playbackContent.spokenText,
+                spokenChunks: playbackContent.spokenChunks,
+                includesContent: true
             ),
             download: downloadProgress?.serviceSnapshot,
             modelInstallError: modelInstallError,
@@ -2814,6 +2900,7 @@ public final class SayItBackendService: SayItService {
         if settings.httpEnabled != previousSettings.httpEnabled
             || settings.httpPort != previousSettings.httpPort {
             httpServiceError = nil
+            httpServiceConfigurationHandler?(httpServiceConfiguration)
         }
         applyPlaybackSettings(settings)
         await synthesizer.updateConfiguration(
@@ -2843,6 +2930,14 @@ public final class SayItBackendService: SayItService {
         playback.backwardSkipInterval = settings.rewindInterval
         playback.forwardSkipInterval = settings.forwardInterval
         playback.showTitleInNowPlaying = settings.showNowPlayingTitles
+    }
+
+    private var httpServiceConfiguration: HTTPServiceConfiguration {
+        let settings = settingsStore.value
+        return HTTPServiceConfiguration(
+            isEnabled: settings.httpEnabled,
+            port: settings.httpPort
+        )
     }
 
     private static func textCleaningOptions(
@@ -2966,5 +3061,38 @@ public final class SayItBackendService: SayItService {
     private var playbackProgress: Double {
         guard playback.generatedDuration > 0 else { return 0.2 }
         return min(max(playback.elapsed / playback.generatedDuration, 0.2), 0.99)
+    }
+}
+
+private extension ServiceSnapshot {
+    var omittingPlaybackContent: ServiceSnapshot {
+        ServiceSnapshot(
+            protocolVersion: protocolVersion,
+            serviceVersion: serviceVersion,
+            revision: revision,
+            statusText: statusText,
+            lastError: lastError,
+            httpServiceError: httpServiceError,
+            activeJob: activeJob,
+            queuedJobs: queuedJobs,
+            playback: PlaybackSnapshot(
+                state: playback.state,
+                elapsed: playback.elapsed,
+                generatedDuration: playback.generatedDuration,
+                estimatedDuration: playback.estimatedDuration,
+                rate: playback.rate,
+                volume: playback.volume,
+                includesContent: false
+            ),
+            download: download,
+            modelInstallError: modelInstallError,
+            installedModelIDs: installedModelIDs,
+            settings: settings,
+            modelsRevision: modelsRevision,
+            historyRevision: historyRevision,
+            diagnosticsRevision: diagnosticsRevision,
+            voicesRevision: voicesRevision,
+            voiceStudio: voiceStudio
+        )
     }
 }

--- a/Sources/SayItBackend/Service/ServiceEventHub.swift
+++ b/Sources/SayItBackend/Service/ServiceEventHub.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+@MainActor
+final class ServiceEventHub {
+    typealias Sleep = @Sendable (Duration) async throws -> Void
+
+    private let sleep: Sleep
+    private var latestRevision: UInt64 = 0
+    private var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private var timeoutTasks: [UUID: Task<Void, Never>] = [:]
+
+    var waiterCount: Int {
+        waiters.count
+    }
+
+    init(
+        sleep: @escaping Sleep = { duration in
+            try await Task.sleep(for: duration)
+        }
+    ) {
+        self.sleep = sleep
+    }
+
+    func publish(_ revision: UInt64) {
+        guard revision > latestRevision else { return }
+        latestRevision = revision
+        resumeAllWaiters()
+    }
+
+    func wait(
+        after sequence: UInt64,
+        currentRevision: UInt64,
+        timeout: Duration
+    ) async throws {
+        guard currentRevision == sequence,
+              latestRevision <= sequence else { return }
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                guard currentRevision == sequence,
+                      latestRevision <= sequence else {
+                    continuation.resume()
+                    return
+                }
+
+                waiters[waiterID] = continuation
+                let sleep = self.sleep
+                timeoutTasks[waiterID] = Task { [weak self] in
+                    do {
+                        try await sleep(timeout)
+                    } catch is CancellationError {
+                        return
+                    } catch {
+                        self?.failWaiter(waiterID, error: error)
+                        return
+                    }
+                    self?.resumeWaiter(waiterID)
+                }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelWaiter(waiterID)
+            }
+        }
+    }
+
+    private func resumeWaiter(_ id: UUID) {
+        timeoutTasks.removeValue(forKey: id)?.cancel()
+        waiters.removeValue(forKey: id)?.resume()
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        timeoutTasks.removeValue(forKey: id)?.cancel()
+        waiters.removeValue(forKey: id)?.resume(
+            throwing: CancellationError()
+        )
+    }
+
+    private func failWaiter(_ id: UUID, error: any Error) {
+        timeoutTasks.removeValue(forKey: id)?.cancel()
+        waiters.removeValue(forKey: id)?.resume(throwing: error)
+    }
+
+    private func resumeAllWaiters() {
+        let continuations = Array(waiters.values)
+        waiters.removeAll(keepingCapacity: true)
+        for task in timeoutTasks.values {
+            task.cancel()
+        }
+        timeoutTasks.removeAll(keepingCapacity: true)
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}

--- a/Sources/SayItHTTP/SayItHTTPServer+SystemRoutes.swift
+++ b/Sources/SayItHTTP/SayItHTTPServer+SystemRoutes.swift
@@ -75,25 +75,20 @@ extension SayItHTTPServer {
                     body: .init { writer in
                         var lastRevision = requestedRevision
                         while !Task.isCancelled {
-                            let events = await backend.events(
-                                after: lastRevision
-                            )
-                            for event in events {
-                                let data = try SayItWireCodec.encode(event)
-                                let json = String(decoding: data, as: UTF8.self)
-                                let payload = """
-                                id: \(event.id)
-                                event: snapshot
-                                data: \(json)
-
-
-                                """
-                                try await writer.write(
-                                    ByteBuffer(string: payload)
+                            let response = await backend.handle(
+                                ServiceRequest(
+                                    command: .waitForEvents(
+                                        after: lastRevision,
+                                        playbackInterval: 1
+                                    )
                                 )
-                                lastRevision = event.id
-                            }
-                            try await Task.sleep(for: .milliseconds(100))
+                            )
+                            guard !Task.isCancelled else { break }
+                            try await ServiceEventSSEWriter.write(
+                                response,
+                                lastRevision: &lastRevision,
+                                to: &writer
+                            )
                         }
                         try await writer.finish(nil)
                     }

--- a/Sources/SayItHTTP/ServiceEventSSEWriter.swift
+++ b/Sources/SayItHTTP/ServiceEventSSEWriter.swift
@@ -1,0 +1,39 @@
+import Hummingbird
+import SayItProtocol
+
+enum ServiceEventSSEWriter {
+    static func write(
+        _ response: ServiceResponse,
+        lastRevision: inout UInt64,
+        to writer: inout any ResponseBodyWriter
+    ) async throws {
+        switch response {
+        case .events(let events):
+            guard !events.isEmpty else {
+                try await writer.write(ByteBuffer(string: ": heartbeat\n\n"))
+                return
+            }
+
+            for event in events {
+                let data = try SayItWireCodec.encode(event)
+                let json = String(decoding: data, as: UTF8.self)
+                let payload = """
+                id: \(event.id)
+                event: snapshot
+                data: \(json)
+
+
+                """
+                try await writer.write(ByteBuffer(string: payload))
+                lastRevision = event.id
+            }
+        case .failure(let failure):
+            throw failure
+        default:
+            throw ServiceFailure(
+                code: "events.invalid_response",
+                message: "The service returned an invalid event response."
+            )
+        }
+    }
+}

--- a/Sources/SayItProtocol/SayItProtocolVersion.swift
+++ b/Sources/SayItProtocol/SayItProtocolVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public enum SayItProtocolVersion {
-    public static let current = 6
+    public static let current = 7
 }

--- a/Sources/SayItProtocol/ServiceCommand.swift
+++ b/Sources/SayItProtocol/ServiceCommand.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum ServiceCommand: Codable, Sendable {
     case snapshot
     case events(after: UInt64)
+    case waitForEvents(after: UInt64, playbackInterval: TimeInterval)
     case submit(SpeechSubmission)
     case jobs
     case confirmJob(UUID)

--- a/Tests/SayItBackendTests/BackendServiceCommandTests.swift
+++ b/Tests/SayItBackendTests/BackendServiceCommandTests.swift
@@ -344,6 +344,48 @@ struct BackendServiceCommandTests {
         #expect(await sleepRecorder.recordedDurations().isEmpty)
     }
 
+    @Test("External playback controls wake paused event requests")
+    func externalPlaybackControlsWakePausedEventRequests() async throws {
+        let sleepGate = BackendEventSleepGate()
+        let fixture = try ServiceFixture { duration in
+            try await sleepGate.sleep(duration)
+        }
+        defer { fixture.remove() }
+        await fixture.service.start()
+        #expect(
+            isAccepted(
+                await fixture.service.handle(.init(command: .play))
+            )
+        )
+        #expect(
+            isAccepted(
+                await fixture.service.handle(.init(command: .pause))
+            )
+        )
+        let paused = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        let response = Task { @MainActor in
+            await fixture.service.handle(
+                .init(
+                    command: .waitForEvents(
+                        after: paused.revision,
+                        playbackInterval: 0.25
+                    )
+                )
+            )
+        }
+        await sleepGate.waitUntilSleeping()
+        fixture.playback.play()
+        fixture.playback.notifyExternalControl()
+
+        let event = try #require(try events(await response.value).first)
+        await sleepGate.resume()
+        #expect(event.id > paused.revision)
+        #expect(event.snapshot.playback.state == "playing")
+    }
+
     @Test("History mutations publish a service event")
     func historyMutationsPublishRevision() async throws {
         let fixture = try ServiceFixture(seedVoiceAndHistory: true)
@@ -2386,6 +2428,7 @@ private actor DeterministicSynthesizer: BackendSpeechSynthesizing {
 @MainActor
 private final class RecordingBackendPlayback: BackendPlaybackControlling {
     var onFailure: (@MainActor (String) -> Void)?
+    var onExternalControl: (@MainActor () -> Void)?
     private(set) var state: PlaybackState = .idle
     private(set) var elapsed: TimeInterval = 0
     private(set) var generatedDuration: TimeInterval = 0
@@ -2470,6 +2513,10 @@ private final class RecordingBackendPlayback: BackendPlaybackControlling {
 
     func finishForTesting() {
         state = .finished
+    }
+
+    func notifyExternalControl() {
+        onExternalControl?()
     }
 
     func archive(

--- a/Tests/SayItBackendTests/BackendServiceCommandTests.swift
+++ b/Tests/SayItBackendTests/BackendServiceCommandTests.swift
@@ -15,6 +15,7 @@ struct BackendServiceCommandTests {
         let beforeStart = try snapshot(
             await fixture.service.handle(.init(command: .snapshot))
         )
+        #expect(beforeStart.revision != 0)
         #expect(beforeStart.statusText == "Starting service")
 
         await fixture.service.start()
@@ -51,7 +52,7 @@ struct BackendServiceCommandTests {
                 .init(command: .events(after: started.revision))
             )
         )
-        #expect(failureEvents.last?.snapshot.playback.includesContent == false)
+        #expect(failureEvents.last?.snapshot.playback.includesContent == true)
         let failed = try snapshot(
             await fixture.service.handle(.init(command: .snapshot))
         )
@@ -68,6 +69,374 @@ struct BackendServiceCommandTests {
         )
         #expect(cleared.lastError == nil)
         #expect(cleared.statusText == "Ready to speak")
+    }
+
+    @Test("Waiting event requests resume when service state changes")
+    func waitingEventsResumeOnRevision() async throws {
+        let fixture = try ServiceFixture()
+        defer { fixture.remove() }
+        await fixture.service.start()
+        let started = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        let waitingResponse = Task { @MainActor in
+            await fixture.service.handle(
+                .init(
+                    command: .waitForEvents(
+                        after: started.revision,
+                        playbackInterval: 1
+                    )
+                )
+            )
+        }
+        await Task.yield()
+        await fixture.service.reportServiceError("Transport failed")
+
+        let received = try events(await waitingResponse.value)
+        #expect(received.last?.id ?? 0 > started.revision)
+        #expect(received.last?.snapshot.lastError == "Transport failed")
+        #expect(received.last?.snapshot.playback.includesContent == false)
+    }
+
+    @Test("Canceling a waiting event request returns promptly")
+    func waitingEventsHonorCancellation() async throws {
+        let fixture = try ServiceFixture()
+        defer { fixture.remove() }
+        await fixture.service.start()
+        let started = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        let waitingResponse = Task { @MainActor in
+            await fixture.service.handle(
+                .init(
+                    command: .waitForEvents(
+                        after: started.revision,
+                        playbackInterval: 1
+                    )
+                )
+            )
+        }
+        await Task.yield()
+        waitingResponse.cancel()
+
+        let response = await waitingResponse.value
+        #expect(try failure(response).code == "service.request_canceled")
+    }
+
+    @Test("A revision from an earlier service process resynchronizes immediately")
+    func waitingEventsResynchronizeFutureRevision() async throws {
+        let fixture = try ServiceFixture()
+        defer { fixture.remove() }
+        await fixture.service.start()
+        let started = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+        let earlierProcessRevision = started.revision &+ 1_000
+
+        let waitingResponse = Task { @MainActor in
+            await fixture.service.handle(
+                .init(
+                    command: .waitForEvents(
+                        after: earlierProcessRevision,
+                        playbackInterval: 1
+                    )
+                )
+            )
+        }
+        await Task.yield()
+        await fixture.service.reportServiceError("Transport failed")
+
+        let received = try events(await waitingResponse.value)
+        guard let event = received.first else {
+            Issue.record("Expected a resynchronization event")
+            return
+        }
+        #expect(received.count == 1)
+        #expect(event.id == started.revision)
+        #expect(event.id < earlierProcessRevision)
+        #expect(event.snapshot.statusText == "Ready to speak")
+        #expect(event.snapshot.playback.includesContent)
+    }
+
+    @Test("Immediate waiting-event resynchronization includes playback content")
+    func waitingEventsImmediateResynchronizationIncludesContent() async throws {
+        let fixture = try ServiceFixture()
+        defer { fixture.remove() }
+        await fixture.service.start()
+        let started = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+        await fixture.service.reportServiceError("Transport failed")
+
+        let response = await fixture.service.handle(
+            .init(
+                command: .waitForEvents(
+                    after: started.revision,
+                    playbackInterval: 1
+                )
+            )
+        )
+        let event = try #require(try events(response).first)
+
+        #expect(event.snapshot.lastError == "Transport failed")
+        #expect(event.snapshot.playback.includesContent)
+    }
+
+    @Test("One service revision builds one event snapshot for all readers")
+    func eventSnapshotsAreCachedPerRevision() async throws {
+        let fixture = try ServiceFixture()
+        defer { fixture.remove() }
+        await fixture.service.start()
+        let started = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+        let buildsBefore = fixture.service.eventSnapshotBuildCount
+        await fixture.service.reportServiceError("Transport failed")
+
+        let first = try events(
+            await fixture.service.handle(
+                .init(command: .events(after: started.revision))
+            )
+        )
+        let second = try events(
+            await fixture.service.handle(
+                .init(command: .events(after: started.revision))
+            )
+        )
+
+        #expect(first.first?.id == second.first?.id)
+        #expect(fixture.service.eventSnapshotBuildCount == buildsBefore + 1)
+    }
+
+    @Test("Active playback emits a bounded cadence heartbeat")
+    func activePlaybackCadenceHeartbeat() async throws {
+        let sleepRecorder = BackendEventSleepRecorder()
+        let fixture = try ServiceFixture { duration in
+            await sleepRecorder.record(duration)
+        }
+        defer { fixture.remove() }
+        await fixture.service.start()
+        #expect(
+            isAccepted(
+                await fixture.service.handle(.init(command: .play))
+            )
+        )
+        let playing = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        let response = await fixture.service.handle(
+            .init(
+                command: .waitForEvents(
+                    after: playing.revision,
+                    playbackInterval: 0.01
+                )
+            )
+        )
+        let heartbeat = try #require(try events(response).first)
+
+        #expect(heartbeat.id > playing.revision)
+        #expect(heartbeat.snapshot.playback.state == "playing")
+        #expect(
+            await sleepRecorder.recordedDurations() == [.milliseconds(100)]
+        )
+    }
+
+    @Test("Idle event heartbeat does not synthesize a revision")
+    func idleEventHeartbeatIsSilent() async throws {
+        let sleepRecorder = BackendEventSleepRecorder()
+        let fixture = try ServiceFixture { duration in
+            await sleepRecorder.record(duration)
+        }
+        defer { fixture.remove() }
+        await fixture.service.start()
+        let idle = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        let response = await fixture.service.handle(
+            .init(
+                command: .waitForEvents(
+                    after: idle.revision,
+                    playbackInterval: 0.25
+                )
+            )
+        )
+
+        #expect(try events(response).isEmpty)
+        #expect(
+            await sleepRecorder.recordedDurations() == [.seconds(30)]
+        )
+        let afterHeartbeat = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+        #expect(afterHeartbeat.revision == idle.revision)
+    }
+
+    @Test("A playback transition during the cadence publishes its final state")
+    func playbackTransitionDuringCadencePublishes() async throws {
+        let sleepGate = BackendEventSleepGate()
+        let fixture = try ServiceFixture { duration in
+            try await sleepGate.sleep(duration)
+        }
+        defer { fixture.remove() }
+        await fixture.service.start()
+        #expect(
+            isAccepted(
+                await fixture.service.handle(.init(command: .play))
+            )
+        )
+        let playing = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        let response = Task { @MainActor in
+            await fixture.service.handle(
+                .init(
+                    command: .waitForEvents(
+                        after: playing.revision,
+                        playbackInterval: 0.25
+                    )
+                )
+            )
+        }
+        await sleepGate.waitUntilSleeping()
+        fixture.playback.finishForTesting()
+        await sleepGate.resume()
+
+        let event = try #require(try events(await response.value).first)
+        #expect(event.id > playing.revision)
+        #expect(event.snapshot.playback.state == "finished")
+    }
+
+    @Test("A playback transition between requests publishes immediately")
+    func playbackTransitionBetweenRequestsPublishes() async throws {
+        let sleepRecorder = BackendEventSleepRecorder()
+        let fixture = try ServiceFixture { duration in
+            await sleepRecorder.record(duration)
+        }
+        defer { fixture.remove() }
+        await fixture.service.start()
+        #expect(
+            isAccepted(
+                await fixture.service.handle(.init(command: .play))
+            )
+        )
+        let playing = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+        fixture.playback.finishForTesting()
+
+        let response = await fixture.service.handle(
+            .init(
+                command: .waitForEvents(
+                    after: playing.revision,
+                    playbackInterval: 0.25
+                )
+            )
+        )
+        let event = try #require(try events(response).first)
+
+        #expect(event.id > playing.revision)
+        #expect(event.snapshot.playback.state == "finished")
+        #expect(await sleepRecorder.recordedDurations().isEmpty)
+    }
+
+    @Test("History mutations publish a service event")
+    func historyMutationsPublishRevision() async throws {
+        let fixture = try ServiceFixture(seedVoiceAndHistory: true)
+        defer { fixture.remove() }
+        await fixture.service.start()
+        let historyID = try #require(fixture.historyID)
+        let before = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        #expect(
+            isAccepted(
+                await fixture.service.handle(
+                    .init(command: .toggleHistoryPinned(historyID))
+                )
+            )
+        )
+        let published = try events(
+            await fixture.service.handle(
+                .init(command: .events(after: before.revision))
+            )
+        )
+
+        let event = try #require(published.first)
+        #expect(event.id > before.revision)
+        #expect(event.snapshot.historyRevision > before.historyRevision)
+
+        #expect(
+            isAccepted(
+                await fixture.service.handle(
+                    .init(command: .deleteHistory(historyID))
+                )
+            )
+        )
+        let deletion = try #require(
+            try events(
+                await fixture.service.handle(
+                    .init(command: .events(after: event.id))
+                )
+            ).first
+        )
+        #expect(deletion.id > event.id)
+        #expect(
+            deletion.snapshot.historyRevision
+                > event.snapshot.historyRevision
+        )
+
+        #expect(
+            isAccepted(
+                await fixture.service.handle(.init(command: .clearHistory))
+            )
+        )
+        let cleared = try #require(
+            try events(
+                await fixture.service.handle(
+                    .init(command: .events(after: deletion.id))
+                )
+            ).first
+        )
+        #expect(cleared.id > deletion.id)
+        #expect(
+            cleared.snapshot.historyRevision
+                > deletion.snapshot.historyRevision
+        )
+    }
+
+    @Test("Clearing diagnostics publishes a service event")
+    func clearingDiagnosticsPublishesRevision() async throws {
+        let fixture = try ServiceFixture()
+        defer { fixture.remove() }
+        await fixture.service.start()
+        let before = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        #expect(
+            isAccepted(
+                await fixture.service.handle(.init(command: .clearDiagnostics))
+            )
+        )
+        let event = try #require(
+            try events(
+                await fixture.service.handle(
+                    .init(command: .events(after: before.revision))
+                )
+            ).first
+        )
+
+        #expect(event.id > before.revision)
+        #expect(
+            event.snapshot.diagnosticsRevision
+                > before.diagnosticsRevision
+        )
     }
 
     @Test("Playback commands forward state and validate rates")
@@ -142,6 +511,18 @@ struct BackendServiceCommandTests {
         let original = try snapshot(
             await fixture.service.handle(.init(command: .snapshot))
         ).settings
+        var httpConfigurations: [HTTPServiceConfiguration] = []
+        fixture.service.setHTTPServiceConfigurationHandler {
+            httpConfigurations.append($0)
+        }
+        #expect(
+            httpConfigurations == [
+                HTTPServiceConfiguration(
+                    isEnabled: original.httpEnabled,
+                    port: original.httpPort
+                )
+            ]
+        )
 
         var invalidCases: [(BackendSettingsSnapshot, String)] = []
         var value = original
@@ -203,6 +584,13 @@ struct BackendServiceCommandTests {
         #expect(fixture.playback.forwardSkipInterval == 42)
         #expect(fixture.playback.showTitleInNowPlaying)
         #expect(
+            httpConfigurations.last
+                == HTTPServiceConfiguration(
+                    isEnabled: true,
+                    port: 49_999
+                )
+        )
+        #expect(
             try snapshot(
                 await fixture.service.handle(.init(command: .snapshot))
             ).settings == updated
@@ -214,6 +602,13 @@ struct BackendServiceCommandTests {
         )
         #expect(httpFailure.httpServiceError == "Port occupied")
         #expect(!httpFailure.settings.httpEnabled)
+        #expect(
+            httpConfigurations.last
+                == HTTPServiceConfiguration(
+                    isEnabled: false,
+                    port: 49_999
+                )
+        )
     }
 
     @Test("Submission validation and queue commands are deterministic")
@@ -382,6 +777,61 @@ struct BackendServiceCommandTests {
                 == [0]
         )
 
+        _ = await fixture.service.handle(.init(command: .clear))
+    }
+
+    @Test("Repeated buffering audio publishes changed playback content")
+    func repeatedBufferingAudioPublishesContent() async throws {
+        let eventGate = BackendSynthesisEventGate()
+        let fixture = try ServiceFixture(
+            synthesizesAudio: true,
+            synthesisEventGate: eventGate
+        )
+        defer { fixture.remove() }
+        try fixture.seedInstallation(modelID: fixture.seedModelID)
+        await fixture.service.start()
+        let text = String(repeating: "A complete sentence. ", count: 180)
+
+        _ = try submittedJob(
+            await fixture.service.handle(
+                .init(
+                    command: .submit(
+                        SpeechSubmission(
+                            text: text,
+                            source: .preview,
+                            modelID: fixture.seedModelID,
+                            permitsLongText: true
+                        )
+                    )
+                )
+            )
+        )
+        for _ in 0..<300 {
+            guard fixture.playback.generatedDuration < 1 else { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(fixture.playback.generatedDuration == 1)
+        let afterFirstChunk = try snapshot(
+            await fixture.service.handle(.init(command: .snapshot))
+        )
+
+        await eventGate.releaseNext()
+        for _ in 0..<300 {
+            guard fixture.playback.generatedDuration < 2 else { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(fixture.playback.generatedDuration == 2)
+        let event = try #require(
+            try events(
+                await fixture.service.handle(
+                    .init(command: .events(after: afterFirstChunk.revision))
+                )
+            ).first
+        )
+
+        #expect(event.snapshot.playback.generatedDuration == 2)
+        #expect(event.snapshot.playback.includesContent)
+        await eventGate.releaseNext()
         _ = await fixture.service.handle(.init(command: .clear))
     }
 
@@ -1557,9 +2007,11 @@ private final class ServiceFixture {
     init(
         seedVoiceAndHistory: Bool = false,
         synthesizesAudio: Bool = false,
+        synthesisEventGate: BackendSynthesisEventGate? = nil,
         downloadCatalog: ModelCatalog? = nil,
         downloadSession: URLSession? = nil,
-        dependencyPreparationGate: DependencyPreparationGate? = nil
+        dependencyPreparationGate: DependencyPreparationGate? = nil,
+        eventSleep: ServiceEventHub.Sleep? = nil
     ) throws {
         root = FileManager.default.temporaryDirectory.appending(
             path: "SayItServiceTests-\(UUID().uuidString)",
@@ -1578,6 +2030,7 @@ private final class ServiceFixture {
         playback = RecordingBackendPlayback()
         synthesizer = DeterministicSynthesizer(
             synthesizesAudio: synthesizesAudio,
+            eventGate: synthesisEventGate,
             dependencyPreparationGate: dependencyPreparationGate
         )
         let modelManager: ModelManager?
@@ -1597,7 +2050,8 @@ private final class ServiceFixture {
             playback: playback,
             synthesizer: synthesizer,
             catalogOverride: downloadCatalog,
-            modelManagerOverride: modelManager
+            modelManagerOverride: modelManager,
+            eventSleep: eventSleep
         )
     }
 
@@ -1734,6 +2188,72 @@ private final class ServiceFixture {
     }
 }
 
+private actor BackendEventSleepRecorder {
+    private var durations: [Duration] = []
+
+    func record(_ duration: Duration) {
+        durations.append(duration)
+    }
+
+    func recordedDurations() -> [Duration] {
+        durations
+    }
+}
+
+private actor BackendEventSleepGate {
+    private var isSleeping = false
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func sleep(_ duration: Duration) async throws {
+        _ = duration
+        isSleeping = true
+        let waiters = startedWaiters
+        startedWaiters.removeAll(keepingCapacity: false)
+        for waiter in waiters {
+            waiter.resume()
+        }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    func waitUntilSleeping() async {
+        guard !isSleeping else { return }
+        await withCheckedContinuation { continuation in
+            startedWaiters.append(continuation)
+        }
+    }
+
+    func resume() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
+private actor BackendSynthesisEventGate {
+    private var permits = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if permits > 0 {
+            permits -= 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func releaseNext() {
+        guard !waiters.isEmpty else {
+            permits += 1
+            return
+        }
+        waiters.removeFirst().resume()
+    }
+}
+
 private actor DeterministicSynthesizer: BackendSpeechSynthesizing {
     private(set) var requestedModelIDs: [String] = []
     private(set) var requestedLanguages: [String?] = []
@@ -1741,13 +2261,16 @@ private actor DeterministicSynthesizer: BackendSpeechSynthesizing {
     private(set) var referenceTranscripts: [String?] = []
     private(set) var unloadCount = 0
     private let synthesizesAudio: Bool
+    private let eventGate: BackendSynthesisEventGate?
     private let dependencyPreparationGate: DependencyPreparationGate?
 
     init(
         synthesizesAudio: Bool = false,
+        eventGate: BackendSynthesisEventGate? = nil,
         dependencyPreparationGate: DependencyPreparationGate? = nil
     ) {
         self.synthesizesAudio = synthesizesAudio
+        self.eventGate = eventGate
         self.dependencyPreparationGate = dependencyPreparationGate
     }
 
@@ -1769,6 +2292,35 @@ private actor DeterministicSynthesizer: BackendSpeechSynthesizing {
             targetCharacterCount: 2_000,
             hardCharacterLimit: 2_500
         ).chunks(for: request.cleanedText.text)
+        if let eventGate, chunks.count >= 2 {
+            return AsyncThrowingStream { continuation in
+                Task {
+                    continuation.yield(.modelLoaded(request.model.id))
+                    for (index, chunk) in chunks.prefix(2).enumerated() {
+                        if index > 0 {
+                            await eventGate.wait()
+                        }
+                        continuation.yield(
+                            .chunkStarted(index: index, chunk: chunk)
+                        )
+                        continuation.yield(
+                            .audio(
+                                AudioChunk(
+                                    requestID: request.id,
+                                    index: index,
+                                    samples: [0.1],
+                                    sampleRate: 1,
+                                    startsParagraph: chunk.startsParagraph
+                                )
+                            )
+                        )
+                    }
+                    await eventGate.wait()
+                    continuation.yield(.completed)
+                    continuation.finish()
+                }
+            }
+        }
         return AsyncThrowingStream { continuation in
             continuation.yield(.modelLoaded(request.model.id))
             for (index, chunk) in chunks.enumerated() {
@@ -1914,6 +2466,10 @@ private final class RecordingBackendPlayback: BackendPlaybackControlling {
 
     func finishBuffering() {
         state = .playing
+    }
+
+    func finishForTesting() {
+        state = .finished
     }
 
     func archive(

--- a/Tests/SayItBackendTests/PlaybackControllerBoundaryTests.swift
+++ b/Tests/SayItBackendTests/PlaybackControllerBoundaryTests.swift
@@ -96,7 +96,7 @@ struct PlaybackControllerBoundaryTests {
             PlaybackController.TimelineDriver { duration in
                 try await sleeper.sleep(for: duration)
             }
-        weak var weakTimeline = timeline
+        weak let weakTimeline = timeline
 
         timeline?.start {}
         await waitForRequests(1, from: sleeper)

--- a/Tests/SayItBackendTests/PlaybackControllerBoundaryTests.swift
+++ b/Tests/SayItBackendTests/PlaybackControllerBoundaryTests.swift
@@ -16,4 +16,185 @@ struct PlaybackControllerBoundaryTests {
             ) < 0.000_001
         )
     }
+
+    @Test("Playback timeline is single-instance and restartable")
+    @MainActor
+    func playbackTimelineLifecycle() async {
+        let sleeper = TimelineSleepGate()
+        let ticks = TimelineTickCounter()
+        let timeline = PlaybackController.TimelineDriver { duration in
+            try await sleeper.sleep(for: duration)
+        }
+
+        #expect(
+            PlaybackController.TimelineDriver.interval
+                == .milliseconds(250)
+        )
+        #expect(!timeline.isActive)
+
+        timeline.start(onTick: ticks.record)
+        timeline.start(onTick: ticks.record)
+        #expect(timeline.isActive)
+        await waitForRequests(1, from: sleeper)
+        #expect(await sleeper.durations() == [.milliseconds(250)])
+        #expect(await sleeper.pendingCount() == 1)
+
+        await sleeper.resumeNext()
+        await waitForRequests(2, from: sleeper)
+        #expect(ticks.count == 1)
+        #expect(timeline.isActive)
+
+        timeline.stop()
+        #expect(!timeline.isActive)
+        timeline.start(onTick: ticks.record)
+        #expect(timeline.isActive)
+        await waitForRequests(3, from: sleeper)
+        await waitForPendingCount(1, from: sleeper)
+
+        await sleeper.resumeNext()
+        await waitForRequests(4, from: sleeper)
+        #expect(ticks.count == 2)
+        #expect(timeline.isActive)
+
+        timeline.stop()
+        await waitForPendingCount(0, from: sleeper)
+        #expect(!timeline.isActive)
+        #expect(
+            await sleeper.durations()
+                == Array(repeating: .milliseconds(250), count: 4)
+        )
+    }
+
+    @Test("Playback timeline clears failed cadence and can restart")
+    @MainActor
+    func playbackTimelineRecoversFromClockFailure() async {
+        let sleeper = TimelineSleepGate()
+        let timeline = PlaybackController.TimelineDriver { duration in
+            try await sleeper.sleep(for: duration)
+        }
+
+        timeline.start {}
+        await waitForRequests(1, from: sleeper)
+        await sleeper.failNext()
+        while timeline.isActive {
+            await Task.yield()
+        }
+
+        timeline.start {}
+        await waitForRequests(2, from: sleeper)
+        #expect(timeline.isActive)
+
+        timeline.stop()
+        await waitForPendingCount(0, from: sleeper)
+    }
+
+    @Test("Playback timeline cancels its cadence on deinitialization")
+    @MainActor
+    func playbackTimelineDeinitialization() async {
+        let sleeper = TimelineSleepGate()
+        var timeline: PlaybackController.TimelineDriver? =
+            PlaybackController.TimelineDriver { duration in
+                try await sleeper.sleep(for: duration)
+            }
+        weak var weakTimeline = timeline
+
+        timeline?.start {}
+        await waitForRequests(1, from: sleeper)
+        timeline = nil
+
+        #expect(weakTimeline == nil)
+        await waitForPendingCount(0, from: sleeper)
+    }
+
+    @MainActor
+    private func waitForRequests(
+        _ count: Int,
+        from sleeper: TimelineSleepGate
+    ) async {
+        while await sleeper.requestCount() < count {
+            await Task.yield()
+        }
+    }
+
+    @MainActor
+    private func waitForPendingCount(
+        _ count: Int,
+        from sleeper: TimelineSleepGate
+    ) async {
+        while await sleeper.pendingCount() != count {
+            await Task.yield()
+        }
+    }
 }
+
+@MainActor
+private final class TimelineTickCounter {
+    private(set) var count = 0
+
+    func record() {
+        count += 1
+    }
+}
+
+private actor TimelineSleepGate {
+    private var nextID = 0
+    private var requestedDurations: [Duration] = []
+    private var waiterOrder: [Int] = []
+    private var waiters: [Int: CheckedContinuation<Void, Error>] = [:]
+
+    func sleep(for duration: Duration) async throws {
+        let id = nextID
+        nextID += 1
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                requestedDurations.append(duration)
+                waiterOrder.append(id)
+                waiters[id] = continuation
+            }
+        } onCancel: {
+            Task {
+                await self.cancel(id)
+            }
+        }
+    }
+
+    func requestCount() -> Int {
+        requestedDurations.count
+    }
+
+    func durations() -> [Duration] {
+        requestedDurations
+    }
+
+    func pendingCount() -> Int {
+        waiters.count
+    }
+
+    func resumeNext() {
+        takeNext()?.resume()
+    }
+
+    func failNext() {
+        takeNext()?.resume(throwing: TimelineSleepFailure())
+    }
+
+    private func cancel(_ id: Int) {
+        waiterOrder.removeAll { $0 == id }
+        waiters.removeValue(forKey: id)?.resume(
+            throwing: CancellationError()
+        )
+    }
+
+    private func takeNext() -> CheckedContinuation<Void, Error>? {
+        guard !waiterOrder.isEmpty else { return nil }
+        let id = waiterOrder.removeFirst()
+        return waiters.removeValue(forKey: id)
+    }
+}
+
+private struct TimelineSleepFailure: Error {}

--- a/Tests/SayItBackendTests/ServiceEventHubTests.swift
+++ b/Tests/SayItBackendTests/ServiceEventHubTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import SayItBackend
+
+@Suite("Service event hub")
+@MainActor
+struct ServiceEventHubTests {
+    @Test("Publishing one revision resumes every registered waiter")
+    func publicationResumesEveryWaiter() async throws {
+        let hub = ServiceEventHub()
+        let first = Task { @MainActor in
+            try await hub.wait(
+                after: 7,
+                currentRevision: 7,
+                timeout: .seconds(30)
+            )
+        }
+        let second = Task { @MainActor in
+            try await hub.wait(
+                after: 7,
+                currentRevision: 7,
+                timeout: .seconds(30)
+            )
+        }
+        while hub.waiterCount < 2 {
+            await Task.yield()
+        }
+
+        hub.publish(8)
+
+        try await first.value
+        try await second.value
+        #expect(hub.waiterCount == 0)
+    }
+
+    @Test("Cancellation unregisters a waiter")
+    func cancellationUnregistersWaiter() async {
+        let hub = ServiceEventHub()
+        let waiting = Task { @MainActor in
+            try await hub.wait(
+                after: 9,
+                currentRevision: 9,
+                timeout: .seconds(30)
+            )
+        }
+        while hub.waiterCount == 0 {
+            await Task.yield()
+        }
+
+        waiting.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await waiting.value
+        }
+        #expect(hub.waiterCount == 0)
+    }
+
+    @Test("A timeout resumes its waiter and records the requested heartbeat")
+    func timeoutResumesWaiter() async throws {
+        let recorder = EventSleepRecorder()
+        let hub = ServiceEventHub { duration in
+            await recorder.record(duration)
+        }
+
+        try await hub.wait(
+            after: 11,
+            currentRevision: 11,
+            timeout: .seconds(30)
+        )
+
+        #expect(await recorder.recordedDurations() == [.seconds(30)])
+        #expect(hub.waiterCount == 0)
+    }
+}
+
+private actor EventSleepRecorder {
+    private var durations: [Duration] = []
+
+    func record(_ duration: Duration) {
+        durations.append(duration)
+    }
+
+    func recordedDurations() -> [Duration] {
+        durations
+    }
+}

--- a/Tests/SayItBackendTests/SpeechQueuePolicyTests.swift
+++ b/Tests/SayItBackendTests/SpeechQueuePolicyTests.swift
@@ -620,6 +620,7 @@ struct SpeechQueuePolicyTests {
 @MainActor
 private final class MockPlaybackController: BackendPlaybackControlling {
     var onFailure: (@MainActor (String) -> Void)?
+    var onExternalControl: (@MainActor () -> Void)?
     private(set) var state: PlaybackState = .idle
     private(set) var elapsed: TimeInterval = 0
     private(set) var generatedDuration: TimeInterval = 0

--- a/Tests/SayItHTTPTests/HTTPEventStreamTests.swift
+++ b/Tests/SayItHTTPTests/HTTPEventStreamTests.swift
@@ -1,0 +1,129 @@
+import Hummingbird
+import SayItProtocol
+import Testing
+@testable import SayItHTTP
+
+@Suite("HTTP event stream")
+struct HTTPEventStreamTests {
+    @Test("A written event advances the stream revision")
+    func writtenEventAdvancesRevision() async throws {
+        let recorder = SSEWriteRecorder()
+        var writer: any ResponseBodyWriter = RecordingSSEWriter(
+            recorder: recorder
+        )
+        var revision: UInt64 = 7
+        let event = serviceEvent(revision: 8)
+
+        try await ServiceEventSSEWriter.write(
+            .events([event]),
+            lastRevision: &revision,
+            to: &writer
+        )
+
+        #expect(revision == 8)
+        let payloads = await recorder.payloads()
+        #expect(payloads.count == 1)
+        #expect(payloads[0].hasPrefix("id: 8\nevent: snapshot\ndata: "))
+        #expect(payloads[0].hasSuffix("\n\n"))
+    }
+
+    @Test("A failed event write leaves the stream revision unchanged")
+    func failedEventDoesNotAdvanceRevision() async {
+        let recorder = SSEWriteRecorder()
+        var writer: any ResponseBodyWriter = RecordingSSEWriter(
+            recorder: recorder,
+            writeError: SSETestError.writeFailed
+        )
+        var revision: UInt64 = 7
+
+        await #expect(throws: SSETestError.self) {
+            try await ServiceEventSSEWriter.write(
+                .events([serviceEvent(revision: 8)]),
+                lastRevision: &revision,
+                to: &writer
+            )
+        }
+
+        #expect(revision == 7)
+        #expect(await recorder.payloads().isEmpty)
+    }
+
+    @Test("An empty long-poll response writes an SSE heartbeat")
+    func emptyResponseWritesHeartbeat() async throws {
+        let recorder = SSEWriteRecorder()
+        var writer: any ResponseBodyWriter = RecordingSSEWriter(
+            recorder: recorder
+        )
+        var revision: UInt64 = 7
+
+        try await ServiceEventSSEWriter.write(
+            .events([]),
+            lastRevision: &revision,
+            to: &writer
+        )
+
+        #expect(revision == 7)
+        #expect(await recorder.payloads() == [": heartbeat\n\n"])
+    }
+}
+
+private actor SSEWriteRecorder {
+    private var recordedPayloads: [String] = []
+
+    func record(_ buffer: ByteBuffer) {
+        recordedPayloads.append(
+            String(decoding: buffer.readableBytesView, as: UTF8.self)
+        )
+    }
+
+    func payloads() -> [String] {
+        recordedPayloads
+    }
+}
+
+private struct RecordingSSEWriter: ResponseBodyWriter {
+    let recorder: SSEWriteRecorder
+    var writeError: (any Error)?
+
+    init(
+        recorder: SSEWriteRecorder,
+        writeError: (any Error)? = nil
+    ) {
+        self.recorder = recorder
+        self.writeError = writeError
+    }
+
+    mutating func write(_ buffer: ByteBuffer) async throws {
+        if let writeError {
+            throw writeError
+        }
+        await recorder.record(buffer)
+    }
+
+    consuming func finish(_ trailingHeaders: HTTPFields?) async throws {}
+}
+
+private enum SSETestError: Error {
+    case writeFailed
+}
+
+private func serviceEvent(revision: UInt64) -> ServiceEvent {
+    ServiceEvent(
+        id: revision,
+        snapshot: ServiceSnapshot(
+            serviceVersion: "test",
+            revision: revision,
+            statusText: "Ready to speak",
+            lastError: nil,
+            activeJob: nil,
+            queuedJobs: [],
+            playback: PlaybackSnapshot(),
+            download: nil,
+            installedModelIDs: [],
+            settings: BackendSettingsSnapshot(),
+            modelsRevision: 0,
+            historyRevision: 0,
+            diagnosticsRevision: 0
+        )
+    )
+}

--- a/Tests/SayItHTTPTests/HTTPInfrastructureTests.swift
+++ b/Tests/SayItHTTPTests/HTTPInfrastructureTests.swift
@@ -342,6 +342,7 @@ private final class HTTPBackendFixture {
 @MainActor
 private final class HTTPTestPlayback: BackendPlaybackControlling {
     var onFailure: (@MainActor (String) -> Void)?
+    var onExternalControl: (@MainActor () -> Void)?
     private(set) var state: PlaybackState = .idle
     private(set) var elapsed: TimeInterval = 0
     private(set) var generatedDuration: TimeInterval = 0

--- a/Tests/SayItHTTPTests/HTTPVoiceRouteIntegrationTests.swift
+++ b/Tests/SayItHTTPTests/HTTPVoiceRouteIntegrationTests.swift
@@ -283,6 +283,7 @@ private extension HTTPVoiceRouteIntegrationTests {
 @MainActor
 private final class HTTPVoiceTestPlayback: BackendPlaybackControlling {
     var onFailure: (@MainActor (String) -> Void)?
+    var onExternalControl: (@MainActor () -> Void)?
     private(set) var state: PlaybackState = .idle
     private(set) var elapsed: TimeInterval = 0
     private(set) var generatedDuration: TimeInterval = 0

--- a/Tests/SayItPlaybackTests/PlaybackSnapshotApplicationTests.swift
+++ b/Tests/SayItPlaybackTests/PlaybackSnapshotApplicationTests.swift
@@ -46,11 +46,76 @@ struct PlaybackSnapshotApplicationTests {
         #expect(controller.spokenChunks.count == 1)
     }
 
-    @Test("Coalesced service revisions are monotonically accepted")
-    func acceptsCoalescedRevisions() {
+    @Test("Event revisions advance monotonically within one connection")
+    func appliesMonotonicEventRevisions() {
         #expect(AppState.shouldApplyEvent(id: 12, after: 7))
         #expect(!AppState.shouldApplyEvent(id: 7, after: 7))
         #expect(!AppState.shouldApplyEvent(id: 6, after: 7))
+        #expect(AppState.shouldApplyEvent(id: 6, after: nil))
+    }
+
+    @Test("Delayed service responses cannot replace newer state")
+    func rejectsDelayedServiceResponses() {
+        #expect(
+            AppState.isServiceStateRequestCurrent(
+                requestedRevision: 7,
+                currentRevision: 7,
+                requestedGeneration: 3,
+                currentGeneration: 3
+            )
+        )
+        #expect(
+            !AppState.isServiceStateRequestCurrent(
+                requestedRevision: 7,
+                currentRevision: 8,
+                requestedGeneration: 3,
+                currentGeneration: 3
+            )
+        )
+        #expect(
+            !AppState.isServiceStateRequestCurrent(
+                requestedRevision: 7,
+                currentRevision: nil,
+                requestedGeneration: 3,
+                currentGeneration: 4
+            )
+        )
+    }
+
+    @Test("Playback refresh cadence follows visible playback surfaces")
+    func playbackRefreshCadence() {
+        #expect(
+            AppState.playbackRefreshInterval(
+                isPlaybackSurfacePresented: false
+            ) == 1
+        )
+        #expect(
+            AppState.playbackRefreshInterval(
+                isPlaybackSurfacePresented: true
+            ) == 0.25
+        )
+    }
+
+    @Test("Ribbon animation pauses while hidden or fully generated")
+    func ribbonAnimationVisibilityPolicy() {
+        #expect(
+            VoiceRibbonView.shouldPauseTimeline(
+                isPresented: false,
+                isProcessing: true
+            )
+        )
+        #expect(
+            VoiceRibbonView.shouldPauseTimeline(
+                isPresented: true,
+                isProcessing: false
+            )
+        )
+        #expect(
+            !VoiceRibbonView.shouldPauseTimeline(
+                isPresented: true,
+                isProcessing: true
+            )
+        )
     }
 
     @Test("Completed onboarding stays dismissed without requiring a model")

--- a/Tests/SayItProtocolTests/ProtocolRoundTripTests.swift
+++ b/Tests/SayItProtocolTests/ProtocolRoundTripTests.swift
@@ -54,7 +54,7 @@ struct ProtocolRoundTripTests {
             from: SayItWireCodec.encode(request)
         )
         #expect(decodedRequest == request)
-        #expect(SayItProtocolVersion.current == 6)
+        #expect(SayItProtocolVersion.current == 7)
     }
 
     @Test
@@ -103,6 +103,27 @@ struct ProtocolRoundTripTests {
             return
         }
         #expect(sequence == 42)
+    }
+
+    @Test("Waiting event requests preserve revision and playback cadence")
+    func waitingEventRequestsRoundTripThroughJSON() throws {
+        let request = ServiceRequest(
+            command: .waitForEvents(after: 42, playbackInterval: 0.25)
+        )
+        let data = try SayItWireCodec.encode(request)
+        let decoded = try SayItWireCodec.decode(
+            ServiceRequest.self,
+            from: data
+        )
+        guard case .waitForEvents(
+            let sequence,
+            let playbackInterval
+        ) = decoded.command else {
+            Issue.record("Expected a waiting event request")
+            return
+        }
+        #expect(sequence == 42)
+        #expect(playbackInterval == 0.25)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace the app and HTTP event-stream 100 ms snapshot polling loops with revision-aware waits
- build and cache one full service event per revision, then elide playback content only after a cursor was synchronized with the same service instance
- run the backend playback timeline only while audio is playing, at a 250 ms cadence
- gate clipboard polling and ribbon animation on presentation, cap the ribbon at 15 FPS, and remove the status-item's perpetual phase animation
- replace the agent's 1 Hz HTTP configuration polling with backend lifecycle callbacks

This is a fresh, current-`main` implementation of the remaining performance slice proposed in #3. It avoids the stale stacked branch and adds deterministic coverage for cancellation, reconnects, multi-waiter publication, and playback transitions.

## Resource contract

These cadence changes are derived from the code paths; they are not Energy Log measurements.

| Path | Before | After |
| --- | --- | --- |
| App state | one XPC snapshot request every 100 ms | one revision wait; 30 s idle heartbeat, 1 Hz hidden playback, 4 Hz visible playback |
| HTTP SSE | one backend snapshot every 100 ms per client | one revision wait; 30 s idle heartbeat, 1 Hz playback |
| Backend timeline | 100 ms task for the controller lifetime | 250 ms task only while playing |
| HTTP supervisor | full snapshot every second | configuration callbacks on start/change/error |
| Menu UI | clipboard timer always connected, 30 FPS ribbon, perpetual status animation | clipboard and ribbon presentation-gated, 15 FPS ribbon, static active indicator |

## Correctness details

- bump the wire protocol to v7 for `waitForEvents(after:playbackInterval:)`
- use a main-actor event hub with cancellation-aware continuations, timeout cleanup, and broadcast wakeups
- seed backend revisions with a nonzero process-local token and send a full snapshot on cursor mismatch
- guard app responses with both connection generation and requested cursor so a delayed wait cannot overwrite newer state
- publish repeated buffering-content changes even when job state/progress do not change
- publish playback transitions that happen during a wait or between requests, including replay completion
- keep cursor advancement after a successful SSE write and emit comment heartbeats for idle streams
- publish history mutation commands and diagnostic clearing through the global event revision

## Validation

- `swift test --disable-sandbox --filter 'ServiceEventHubTests|BackendServiceCommandTests|PlaybackControllerBoundaryTests|HTTPEventStreamTests|PlaybackSnapshotApplicationTests|ProtocolRoundTripTests'` — 64 tests passed in 6 suites
- `swift test --disable-sandbox --filter SayItPlaybackTests` — 32 tests passed in 8 suites
- `swift test --disable-sandbox --filter SayItHTTPTests` — 15 tests passed in 5 suites
- `swift build --disable-sandbox --target SayItAgent`
- `./Scripts/validate-catalog.sh`
- `xcodegen generate --spec project.yml`
- `git diff --check`

The full package suite compiles on this host, then aborts in the MLX runtime because the default Metal library is unavailable. `./Scripts/build-app.sh` likewise reaches the Xcode build and stops with `cannot execute tool 'metal' due to missing Metal Toolchain`; Xcode recommends `xcodebuild -downloadComponent MetalToolchain`. I did not modify the host Xcode installation, so Release-bundle validation, UI capture, and Energy Log measurement remain pending.

## Risk and follow-up

- protocol v7 requires the bundled app, agent, and CLI to update together; the existing strict version guard reports mismatches
- direct backend wait cancellation is covered, but XPC connection invalidation does not track and cancel the exported request task; a disconnected server-side waiter can remain until the bounded 30-second heartbeat
- menu/window visibility policy is covered at the state level; a manual menu/settings presentation smoke test remains appropriate once the Release app can be built
