### PR TITLE
Clear MLX cache after synthesis

### DIFF
--- a/Sources/SayItBackend/Synthesis/SynthesisActor.swift
+++ b/Sources/SayItBackend/Synthesis/SynthesisActor.swift
@@ -946,6 +946,7 @@ actor SynthesisActor: BackendSpeechSynthesizing {
     private func synchronizeMLXIfLoaded() {
         guard loadedModel != nil || retainedReferenceAudio != nil else { return }
         Stream.gpu.synchronize()
+        Memory.clearCache()
     }
 
     private func scheduleIdleUnload(for operationID: UInt64) {


### PR DESCRIPTION
## Summary

Clear MLX's recyclable allocator cache after each synthesis operation has
quiesced.

SayItAgent previously synchronized the GPU after synthesis but only called
`Memory.clearCache()` when unloading the model. Since the default model unload
delay is ten minutes and each new utterance restarts that timer, frequent CLI
usage could retain increasingly large Metal allocations indefinitely.

This keeps the loaded model resident while releasing temporary allocations
created during synthesis.

## Reproduction

During repeated Claude Code CLI narration, SayItAgent grew to a large physical
footprint. `footprint` attributed almost the entire allocation to
`IOAccelerator (graphics)`, rather than the Swift heap or PCM storage.

<img width="719" height="69" alt="Screenshot 2026-08-11 at 18 52 27" src="https://github.com/user-attachments/assets/0e60492f-3e8e-4631-aef3-04d0bb8bb5c1" />

## Testing

- Built an ad-hoc `Say It Local` release with the patched agent.
- Reused the installed Kokoro model in an isolated debug container.
- Submitted ten sequential, similarly sized CLI utterances.
- Measured the agent with `footprint` after every completed utterance.
- Physical footprint remained between 444 MB and 447 MB.
- `IOAccelerator (graphics)` remained stable at 315 MB.
- Confirmed the local app passed deep code-signature validation.
- Ran the four `SynthesisActorTests`; all passed.
- Ran the broader Swift test suite. Non-GPU tests passed, but SwiftPM GPU tests
  could not complete because that test environment did not contain MLX's
  bundled default Metal library. The Xcode application build embedded the
  Metal bundle correctly and was used for runtime verification.

## Tradeoff

Clearing recyclable MLX allocations after each operation may reduce some
allocator-cache reuse between utterances. It avoids unbounded GPU memory
retention while preserving the loaded model and its weights.

## Additional Context

- Debugged and implemented with the help of gpt-5.6-sol
- not sure if this is the right fix as it clearly also has tradeoffs
- not sure if reported already in other channels
- I used the default voice model