### PR TITLE
Allow playback volume to reach silence

### DIFF
--- a/Sources/SayIt/AppShell/AppSettings.swift
+++ b/Sources/SayIt/AppShell/AppSettings.swift
@@ -302,8 +302,9 @@ final class AppSettings {
         ) ?? .natural
         let storedRate = defaults.double(forKey: Key.playbackRate)
         playbackRate = storedRate == 0 ? 1 : storedRate
-        let storedVolume = defaults.double(forKey: Key.volume)
-        volume = storedVolume == 0 ? 1 : storedVolume
+        volume = defaults.object(forKey: Key.volume) == nil
+            ? 1
+            : defaults.double(forKey: Key.volume)
         let storedRewind = defaults.double(forKey: Key.rewindInterval)
         rewindInterval = storedRewind == 0 ? 15 : storedRewind
         let storedForward = defaults.double(forKey: Key.forwardInterval)

--- a/Sources/SayIt/Playback/VolumeControlView.swift
+++ b/Sources/SayIt/Playback/VolumeControlView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct VolumeControlView: View {
-    static let minimumVolume = 0.2
+    static let minimumVolume = 0.0
     static let maximumVolume = 2.0
 
     @Environment(AppState.self) private var state
@@ -39,6 +39,8 @@ struct VolumeControlView: View {
 
     static func symbol(for volume: Double) -> String {
         switch volume {
+        case 0:
+            return "speaker.slash.fill"
         case ..<0.75:
             return "speaker.wave.1.fill"
         case ..<1.5:
@@ -59,14 +61,14 @@ struct VolumeControlView: View {
         )
     }
 
-    private static func position(forVolume volume: Double) -> Double {
+    static func position(forVolume volume: Double) -> Double {
         if volume <= 1 {
             return (volume - minimumVolume) / (1 - minimumVolume) * 0.5
         }
         return 0.5 + (volume - 1) / (maximumVolume - 1) * 0.5
     }
 
-    private static func volume(forPosition position: Double) -> Double {
+    static func volume(forPosition position: Double) -> Double {
         if position <= 0.5 {
             return minimumVolume + position * 2 * (1 - minimumVolume)
         }

--- a/Sources/SayItBackend/Service/SayItBackendService.swift
+++ b/Sources/SayItBackend/Service/SayItBackendService.swift
@@ -2192,7 +2192,7 @@ public final class SayItBackendService: SayItService {
         guard validated == volume else {
             throw ServiceFailure(
                 code: "playback.invalid_volume",
-                message: "Volume must be between 0.2 and 2."
+                message: "Volume must be between 0 and 2."
             )
         }
         playback.volume = validated
@@ -2867,10 +2867,10 @@ public final class SayItBackendService: SayItService {
                 message: "Playback rate must be between 0.5 and 2."
             )
         }
-        guard (0.2...2).contains(settings.volume) else {
+        guard (0...2).contains(settings.volume) else {
             throw ServiceFailure(
                 code: "settings.invalid_volume",
-                message: "Volume must be between 0.2 and 2."
+                message: "Volume must be between 0 and 2."
             )
         }
         guard (1...5_000).contains(settings.chunkCharacterTarget) else {
@@ -3049,7 +3049,7 @@ public final class SayItBackendService: SayItService {
     }
 
     private func validatedVolume(_ value: Double) -> Double {
-        min(max(value, 0.2), 2)
+        min(max(value, 0), 2)
     }
 
     private func nonEmpty(_ value: String) -> String? {

--- a/Tests/SayItBackendTests/BackendServiceCommandTests.swift
+++ b/Tests/SayItBackendTests/BackendServiceCommandTests.swift
@@ -532,7 +532,16 @@ struct BackendServiceCommandTests {
         )
         #expect(fixture.playback.volume == 1.5)
 
-        for volume in [0.19, 2.01, Double.nan, Double.infinity] {
+        #expect(
+            isAccepted(
+                await fixture.service.handle(
+                    .init(command: .setVolume(0))
+                )
+            )
+        )
+        #expect(fixture.playback.volume == 0)
+
+        for volume in [-0.01, 2.01, Double.nan, Double.infinity] {
             let response = await fixture.service.handle(
                 .init(command: .setVolume(volume))
             )
@@ -577,7 +586,7 @@ struct BackendServiceCommandTests {
         value.playbackRate = 0.4
         invalidCases.append((value, "settings.invalid_playback_rate"))
         value = original
-        value.volume = 0.1
+        value.volume = -0.1
         invalidCases.append((value, "settings.invalid_volume"))
         value = original
         value.chunkCharacterTarget = 0
@@ -604,6 +613,7 @@ struct BackendServiceCommandTests {
 
         var updated = original
         updated.playbackRate = 1.5
+        updated.volume = 0
         updated.rewindInterval = 7
         updated.forwardInterval = 42
         updated.showNowPlayingTitles = true
@@ -622,6 +632,7 @@ struct BackendServiceCommandTests {
             )
         )
         #expect(fixture.playback.rate == 1.5)
+        #expect(fixture.playback.volume == 0)
         #expect(fixture.playback.backwardSkipInterval == 7)
         #expect(fixture.playback.forwardSkipInterval == 42)
         #expect(fixture.playback.showTitleInNowPlaying)

--- a/Tests/SayItPlaybackTests/AppSettingsTests.swift
+++ b/Tests/SayItPlaybackTests/AppSettingsTests.swift
@@ -61,6 +61,24 @@ struct AppSettingsTests {
         #expect(restoredSettings.speakingPace == .fast)
     }
 
+    @Test("Silent playback volume persists")
+    @MainActor
+    func silentPlaybackVolumePersists() throws {
+        let suiteName = "SayItTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.volume == 1)
+
+        settings.volume = 0
+
+        let restoredSettings = AppSettings(defaults: defaults)
+        #expect(restoredSettings.volume == 0)
+    }
+
     @Test("Voice selections persist independently for each model")
     @MainActor
     func voiceSelectionsPersistPerModel() throws {

--- a/Tests/SayItPlaybackTests/VolumeControlViewTests.swift
+++ b/Tests/SayItPlaybackTests/VolumeControlViewTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import SayIt
+
+@Suite("Volume control view")
+struct VolumeControlViewTests {
+    @Test("Slider spans silence through double volume")
+    @MainActor
+    func sliderVolumeRange() {
+        #expect(VolumeControlView.position(forVolume: 0) == 0)
+        #expect(VolumeControlView.position(forVolume: 1) == 0.5)
+        #expect(VolumeControlView.position(forVolume: 2) == 1)
+
+        #expect(VolumeControlView.volume(forPosition: 0) == 0)
+        #expect(VolumeControlView.volume(forPosition: 0.5) == 1)
+        #expect(VolumeControlView.volume(forPosition: 1) == 2)
+    }
+
+    @Test("Silence uses the muted speaker symbol")
+    @MainActor
+    func silenceSymbol() {
+        #expect(VolumeControlView.symbol(for: 0) == "speaker.slash.fill")
+    }
+}


### PR DESCRIPTION
## Summary

- expand the dropdown player volume control from 0% to 200% while keeping 100% centered
- show a muted speaker at 0% and allow silent volume through backend validation
- persist an explicit 0% volume and add UI, settings, and backend regression coverage

## Testing

- swift test --disable-sandbox --filter VolumeControlViewTests
- swift test --disable-sandbox --filter AppSettingsTests
- swift test --disable-sandbox --filter BackendServiceCommandTests
- Full swift test --disable-sandbox compiled successfully, then the runner aborted in the unrelated KittenVoiceArchiveConverterTests MLX/Metal device lookup in this environment