### PR TITLE
Install unavailable voice models from the picker

### DIFF
--- a/Sources/SayIt/Voices/VoicesSettingsView.swift
+++ b/Sources/SayIt/Voices/VoicesSettingsView.swift
@@ -48,10 +48,14 @@ struct VoicesSettingsView: View {
 
                     if !isSelectedModelActive {
                         Button(
-                            "Use \(model.displayName) for Speech",
-                            action: selectModelForSpeech
+                            selectedModelActionTitle(for: model),
+                            action: activateSelectedModel
                         )
-                        .disabled(!isSelectedModelInstalled)
+                        .disabled(
+                            !state.isServiceOnline
+                                || (!isSelectedModelInstalled
+                                    && state.modelInstallIsBusy)
+                        )
                     }
                 }
             }
@@ -211,6 +215,16 @@ struct VoicesSettingsView: View {
         settings.activeModelID == selectedModelID
     }
 
+    private func selectedModelActionTitle(
+        for model: ModelDescriptor
+    ) -> String {
+        if isSelectedModelInstalled {
+            "Use \(model.displayName) for Speech"
+        } else {
+            "Download and Use \(model.displayName) for Speech"
+        }
+    }
+
     private var isCreationUnavailable: Bool {
         !isSelectedModelInstalled
             || isPlaybackBusy
@@ -241,11 +255,16 @@ struct VoicesSettingsView: View {
             ?? .automaticStable
     }
 
-    private func selectModelForSpeech() {
-        guard let model = selectedModel, isSelectedModelInstalled else {
-            return
+    private func activateSelectedModel() {
+        guard let model = selectedModel else { return }
+        if isSelectedModelInstalled {
+            state.selectModel(model)
+        } else {
+            state.installModel(
+                model.id,
+                selectAfterInstallation: true
+            )
         }
-        state.selectModel(model)
     }
 
     private func moveVoice(_ draggedID: UUID, before targetID: UUID) {


### PR DESCRIPTION
## Summary
- keep uninstalled voice models visible so saved voice libraries remain discoverable
- replace the disabled speech-model action with a direct download-and-use action
- activate the selected model automatically after its verified installation completes
- disable model actions while the service is offline or another installation is active

## Testing
- `swift test --disable-sandbox --filter SayItPlaybackTests` (37 tests passed)
- `./Scripts/validate-catalog.sh`
- `git diff --check`
- `swift test --disable-sandbox` builds the app target, but the complete run is blocked by the existing `KittenVoiceArchiveConverterTests/convertsStoredNPZ` MLX test aborting when no Metal device is available

Closes #10