### PR TITLE
Fix duplicate NIOCore linkage

### DIFF
--- a/SayIt.xcodeproj/project.pbxproj
+++ b/SayIt.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		079CED75E397190489D69C24 /* SayItHTTP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E0D0C006406346A39E5C37E /* SayItHTTP.framework */; };
 		080F4D50872D29D3C1590F8D /* SpeechJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57904CB7418B385CE9136D3 /* SpeechJob.swift */; };
 		081AA4944F9C57FA66BAD189 /* SelectedTextReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF4631A47E3A2C9DBA64C88 /* SelectedTextReader.swift */; };
+		08AD98C46CD4B71D9F7C60B8 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 0E358E4263F4B393DA65F90A /* OrderedCollections */; };
 		08E0D54EA40A2A9DBCE513F7 /* UpdateResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C640391D6C6DECE4012194E /* UpdateResult.swift */; };
 		0922BE8F5F7353F975466383 /* SayItCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E5B162BA286FB4707D990A4 /* SayItCore.framework */; };
 		0933C3DB1F15CB642A263B79 /* HistoryItemSnapshot+ServiceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE13E5BA1B40745372B9772E /* HistoryItemSnapshot+ServiceSnapshot.swift */; };
@@ -58,6 +59,7 @@
 		168A63FEEDC7C157E117CB1C /* ServiceEventHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24BB3FA53E080276A116642 /* ServiceEventHubTests.swift */; };
 		16A5F34E0F821CFCC1C608D0 /* APITokenMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDEF4E9A880944ACA9E6A4AA /* APITokenMetadata.swift */; };
 		19488C0CF76ABE8972AE4980 /* QueuePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E857E910DF547DDF281E5A /* QueuePolicy.swift */; };
+		19B6090764A4FAC7C2557148 /* openapi.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 4D514FBB81728B5F7E53FCCE /* openapi.yaml */; };
 		1AB6750260BF70B395B0F9E5 /* HistorySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFDA6836016ADDCDC5ACF3AF /* HistorySettingsView.swift */; };
 		1ACA6FA960940632C8EE1B46 /* SeekCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED5A1F0B187E695CA0512A6 /* SeekCommand.swift */; };
 		1AE36C4DA4C8909EAD163A6A /* GlobalShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93E5EE6D37AD52B74C09BA2 /* GlobalShortcut.swift */; };
@@ -84,6 +86,7 @@
 		25C973535C87B9998DBFE308 /* PasteboardPayloadReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3DE2FFBD6C986ADC44745A /* PasteboardPayloadReader.swift */; };
 		26837F03C8591D15D7A5C6EA /* CLIOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A39863383170BD4A8E9A68C /* CLIOutput.swift */; };
 		276A0290B85378B837C59629 /* TestBundleToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A48A60CD4D89DFA933338B /* TestBundleToken.swift */; };
+		2790FF938C2667A993615997 /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = 966CEFC1C422D50A7DA22CD1 /* DequeModule */; };
 		27E2E55268349CF87002F66F /* AudioRouteRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0407AB9A49921D4AD219BA8F /* AudioRouteRecoveryPolicy.swift */; };
 		29C02690A693E87D5A2FAC2C /* VoiceRecordingAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D23D58A8E035AA7F530EBA /* VoiceRecordingAnalysis.swift */; };
 		2AA1EDF6AE8183DA3C9C6B6F /* PlaybackControllerBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34A1926523800EBB0B6959D /* PlaybackControllerBoundaryTests.swift */; };
@@ -118,6 +121,7 @@
 		3F22D38886E6E44E0156F0F7 /* VoiceDiscoveryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AD71761AE179BEA6A20967 /* VoiceDiscoveryRequest.swift */; };
 		40F3797F2C6B54BD494E8C74 /* APITokenDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8697FFA4EB481A4A7FB1A3A /* APITokenDigestTests.swift */; };
 		419CB00AB6F80C7F4A3F46BC /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */; };
+		41DE1A049C2D3BFE630D7177 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 12D3C7903194A06085F4C99C /* Atomics */; };
 		4251B261B2659D5CB44E474C /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C074F8772DC89E43CE2A267 /* DesignTokens.swift */; };
 		435E896B82A959E7FDFB0403 /* SayItApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CEBAFD3BF5D864C5BD06D /* SayItApplication.swift */; };
 		457DDAEE9ECE2D7E62DD35D7 /* SayItBackend.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E8C6A20E706CC206C44FC28 /* SayItBackend.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -127,7 +131,6 @@
 		47B3E985C906D5B4EEF241C5 /* PCMStreamConditionerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C2FE18267ED3F1A992644F /* PCMStreamConditionerTests.swift */; };
 		47F2189FF5531A33CA2B00DE /* SayItXPCExportedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B452881D666854D351A6EF /* SayItXPCExportedService.swift */; };
 		48D749D47ED1BD0895F0A364 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B4E9368A75CA1F818245E /* HistoryView.swift */; };
-		49FDF14558C27BFE52DEA9F3 /* openapi.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 4D514FBB81728B5F7E53FCCE /* openapi.yaml */; };
 		4AD11952B99AA60C9269CB49 /* VoiceFingerprintView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFFB903F1FBBCD6596888E8 /* VoiceFingerprintView.swift */; };
 		4BC00C950E7DD2A85A22890D /* HTTPVoiceRouteIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6262901F90523430DD888CF9 /* HTTPVoiceRouteIntegrationTests.swift */; };
 		4C03756876697C1768B8C149 /* SayItBackend.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E8C6A20E706CC206C44FC28 /* SayItBackend.framework */; };
@@ -153,7 +156,6 @@
 		51127FFBC1F50184CAD5A540 /* VoiceReferenceFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5784B7D83A0972C04D932513 /* VoiceReferenceFormat.swift */; };
 		51A0401365D51889E07375E6 /* ModelManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70E0C325CC84370C425EF07 /* ModelManagerError.swift */; };
 		51C0584024264406E5670233 /* MenuBarRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8077FB8567737F537A02DE3B /* MenuBarRootView.swift */; };
-		52502DAC4AEAFB4BD4596A9D /* openapi-generator-config.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 2996022F566B1CA2CFAB59AD /* openapi-generator-config.yaml */; };
 		5284097D44147769C8F5DE13 /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = 5EE1786A722735766F45829F /* MLXAudioTTS */; };
 		53280083429EC40EB5447394 /* SettingsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0F462BFFCCB9F7F8B10A64 /* SettingsPane.swift */; };
 		5335E77D09F3E4133ACBB024 /* HuggingFaceLFSInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAAB79ECE86C6928C43363F /* HuggingFaceLFSInfo.swift */; };
@@ -167,7 +169,6 @@
 		560E27275E9D1815E261F41E /* TimeInterval+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7392C8CFFBB121658EBD9597 /* TimeInterval+Formatting.swift */; };
 		56ECCB4BAC727F46AA2408EF /* VoiceCloneRequirements.swift in Sources */ = {isa = PBXBuildFile; fileRef = E052AB297B6730E47BF28A4D /* VoiceCloneRequirements.swift */; };
 		56F431F50DFF88F2785B215B /* SpeechTitleGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF89D0850C4A3A612A71C738 /* SpeechTitleGeneratorTests.swift */; };
-		57BFA8CA39699493AD5E0F97 /* SayItHTTP.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E0D0C006406346A39E5C37E /* SayItHTTP.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		58F83E662C322E4BC40E6F4B /* MenuBarLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC9632EA8823DD86F4CA8B4 /* MenuBarLabel.swift */; };
 		59A9A6B109F8C906DF06087F /* ModelCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8D307832CC5ACBCD2B6430 /* ModelCatalogTests.swift */; };
 		5A2DF64A186464BD8109F198 /* VoiceRibbonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396BF40EFF07BE5F08721894 /* VoiceRibbonView.swift */; };
@@ -203,7 +204,7 @@
 		6C69A69B7EEEEBDFFFF0952E /* DiagnosticSeverity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810121170E2B03BC942F9CF3 /* DiagnosticSeverity.swift */; };
 		6C9383ACB1F0BB34CD533B11 /* VoiceRecordingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BFC2964BF2ABF447564986 /* VoiceRecordingError.swift */; };
 		6D7BC63EED554722AFF0B04F /* PauseCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4527699AF5875AD4FC468DF5 /* PauseCommand.swift */; };
-		6E52A0435904D6D6FDB609BF /* OpenAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = FD20A7112C89EF1EA775887A /* OpenAPIRuntime */; };
+		6E52A0435904D6D6FDB609BF /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = B085212FC4B8B933B6D6E28B /* Yams */; };
 		6E71E36C113B1EEBE1E36576 /* SayItXPC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 00445B56A690FA19B85A8F34 /* SayItXPC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6F00A9E66B1543D0A1FA4014 /* ModelDependencyDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2146938E2B5731D39082E5 /* ModelDependencyDescriptor.swift */; };
 		6F30447F2036B526BAC72C0C /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 278065AA0ADDB8B2D63C98CC /* AppKit.framework */; };
@@ -225,7 +226,6 @@
 		79B2A90D313E92D540E57C1D /* AudioChunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = B118CD87A4B24F27D08007B9 /* AudioChunk.swift */; };
 		7A1728F9E6F89BA0549FAB93 /* ModelInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB00365B7888BA872FDEED0C /* ModelInstallationTests.swift */; };
 		7A8C3D617826E8577AA252BC /* HistoryCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382FC0930FEB1526D9B8C8ED /* HistoryCommand.swift */; };
-		7A9CE2127601A523727C4683 /* SayItHTTP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E0D0C006406346A39E5C37E /* SayItHTTP.framework */; };
 		7AE751EA7DE12B38E00969F8 /* SayItBackendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E46EB83C78D6FE379603B90 /* SayItBackendService.swift */; };
 		7B2FC5474684463F29330890 /* ModelLicense.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0607E47123E83EC79342535 /* ModelLicense.swift */; };
 		7B74C3E06CFE1D1CC86C1B4B /* ServiceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F395CE405E435EB38E630E /* ServiceSettingsView.swift */; };
@@ -263,7 +263,7 @@
 		8BDF28F41CB4FA4456F56A74 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 278065AA0ADDB8B2D63C98CC /* AppKit.framework */; };
 		8C37C42D200745BF0203A5AD /* PlaybackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD7CD1882C35D31525620E7 /* PlaybackError.swift */; };
 		8C75E37B81E956CB8F3ADC37 /* SayItHTTPServer+Responses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2263B37D07FDBD6AAD94452F /* SayItHTTPServer+Responses.swift */; };
-		8C86A585B42AAC5091C2515A /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = B085212FC4B8B933B6D6E28B /* Yams */; };
+		8C93C64F92F3FB922B2A0137 /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = B11D4CCFD0C68E9C0B589FD0 /* NIOCore */; };
 		8D08AB490ED1B2BF6F6DFA8A /* WindowActivator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6030AC42D5609C7FE1624815 /* WindowActivator.swift */; };
 		8D4E3A679632C065A6CA4B17 /* TextCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0AC916C8F3D571E4E78407 /* TextCleaner.swift */; };
 		8D4EBDD04C3B06E93203E143 /* APIRateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356A58229DE0CCCFD9915867 /* APIRateLimiter.swift */; };
@@ -285,7 +285,6 @@
 		969D61B2F282C219FF951296 /* DiagnosticSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8F4DCDC453E07A4518905B /* DiagnosticSnapshot.swift */; };
 		975420AF9C82FB50C0F04794 /* AppErrorRecoveryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6AEFFFEB026A11B8235D5 /* AppErrorRecoveryAction.swift */; };
 		97FFD241C34F9894CF4E8B9E /* SynthesisOperationLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40828984E8B5F3F75C795F92 /* SynthesisOperationLifecycleTests.swift */; };
-		980814CF3D25517505F78C03 /* SayItHTTP.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E0D0C006406346A39E5C37E /* SayItHTTP.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		98E075B62EF1F0140D7056EF /* SayItStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB95F4768AD968BE1C4CBCD1 /* SayItStyles.swift */; };
 		99144A0E1446A1EC04D2EA22 /* TriggerSource+SpeechJobSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C68503A5952C88A89C91E4 /* TriggerSource+SpeechJobSource.swift */; };
 		994F2821AF4E8EE03D19D8CE /* VoiceTuning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16680CBF5882BDEE50A857B6 /* VoiceTuning.swift */; };
@@ -400,6 +399,7 @@
 		D4D31CB39994BECADB00C9B1 /* PlaybackSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F08886A5C4C21F1818E471 /* PlaybackSectionView.swift */; };
 		D6412CDA4CB9297F9C24C1DA /* SpeechSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087891890981FE4C0A6CD185 /* SpeechSettingsView.swift */; };
 		D65FDDFC9889D3AD5650B13B /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD8B7FE7FADB3FA2DEA3D88 /* GeneralSettingsView.swift */; };
+		D67A9EF822F5729F3536E29A /* openapi.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 4D514FBB81728B5F7E53FCCE /* openapi.yaml */; };
 		D6C53887860DA1FAB00BFA00 /* AppDirectories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AA1834FC29849DD67B79F9 /* AppDirectories.swift */; };
 		D79283FE5159C575C4D7762E /* OnboardingModelPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE8A05905D6BF51D650E4B5 /* OnboardingModelPickerView.swift */; };
 		D7D5E8A66E0E403C7ACDAC9E /* HTTPVoiceSubmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0B498E2479F4BBFF960B12 /* HTTPVoiceSubmissionTests.swift */; };
@@ -436,7 +436,6 @@
 		EAB83A101EC282E4ECE6B458 /* SelectionServiceResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D598DAD634E881BB35574A93 /* SelectionServiceResponse.swift */; };
 		EAF7E09BEA31B7D94288EEB9 /* VoicesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFB14EE60274EDCD63FE749 /* VoicesCommand.swift */; };
 		EB9A60DB0D9FC7A16FB2B097 /* JobJournalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DAC08EDC3B2C762800ACFE /* JobJournalStore.swift */; };
-		EC4704F893DBF5310D765684 /* OpenAPIHummingbird in Frameworks */ = {isa = PBXBuildFile; productRef = 31863F3224A3AC66E6B10238 /* OpenAPIHummingbird */; };
 		EC57B9AE415924E0DF0B7BC4 /* SayItCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E5B162BA286FB4707D990A4 /* SayItCore.framework */; };
 		EC9841D91F602C9A42D56702 /* KeychainTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7947A1B766A97606F2097C /* KeychainTokenStore.swift */; };
 		EDB302CC129BB4E3169C971F /* SynthesisMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6383581E3DD184F3105CF5 /* SynthesisMetrics.swift */; };
@@ -445,7 +444,6 @@
 		F1117CAFD7B8384CBDD42C9E /* TextIngestionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714FE91E9E9B6DD5FD7EEA80 /* TextIngestionError.swift */; };
 		F1C9759FFD7F42B474603F0F /* HistoryItemSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90333F6EA2A7FFDB276CCF77 /* HistoryItemSnapshot.swift */; };
 		F23CE722598CD3E8CD87A3BF /* BackendPrimitiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9BFBF98DB02E32E3E824EF6 /* BackendPrimitiveTests.swift */; };
-		F28F487934493AC30A5BD120 /* SayItHTTP.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E0D0C006406346A39E5C37E /* SayItHTTP.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F3C0BE22B46B4C9096F9D3AE /* CleanedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE5F90F8700618CBFF89611 /* CleanedText.swift */; };
 		F4DEB3192F7FFA8A44F37867 /* OnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798F5FF5F67AAD0DB93DC48F /* OnboardingStep.swift */; };
 		F56C34C0B55FBF947F5D58FE /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37945BFC52B9996B8971313A /* SemanticVersion.swift */; };
@@ -625,13 +623,6 @@
 			remoteGlobalIDString = B4824402F65B5745F1B19F74;
 			remoteInfo = SayItProtocol;
 		};
-		A6A9618335832C32F8452DB0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 7BB6086046F49669100D0BE4 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 805D294C1B998FB17D83063C;
-			remoteInfo = SayItHTTP;
-		};
 		B88D9B03254FCCA6A05D3C33 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7BB6086046F49669100D0BE4 /* Project object */;
@@ -724,7 +715,6 @@
 			files = (
 				46AA742DBE34EAA5E41B2A71 /* SayItBackend.framework in Embed Frameworks */,
 				A932D7435C65BDBFC9FD74D4 /* SayItCore.framework in Embed Frameworks */,
-				57BFA8CA39699493AD5E0F97 /* SayItHTTP.framework in Embed Frameworks */,
 				5FBEFE4EA78B23047757B007 /* SayItProtocol.framework in Embed Frameworks */,
 				BB2DBFDEFA34F9BDBB2841E7 /* SayItXPC.framework in Embed Frameworks */,
 			);
@@ -739,7 +729,6 @@
 			files = (
 				A10D0A04E5DB9D764612E847 /* SayItCore.framework in Embed Frameworks */,
 				457DDAEE9ECE2D7E62DD35D7 /* SayItBackend.framework in Embed Frameworks */,
-				F28F487934493AC30A5BD120 /* SayItHTTP.framework in Embed Frameworks */,
 				1D5288C9C07F6DE54DCD93AF /* SayItProtocol.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -778,7 +767,6 @@
 				2F98443BCC6A9CE666AFF7D2 /* SayItCore.framework in Embed Frameworks */,
 				0C7EBC1DACDEBFA00133A526 /* SayItProtocol.framework in Embed Frameworks */,
 				024B45D91C00924421BDCB87 /* SayItXPC.framework in Embed Frameworks */,
-				980814CF3D25517505F78C03 /* SayItHTTP.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -861,7 +849,6 @@
 		278065AA0ADDB8B2D63C98CC /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		27E87200AD4AB249FAD50398 /* OnboardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPage.swift; sourceTree = "<group>"; };
 		2837701977770F5911182C7A /* HistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStore.swift; sourceTree = "<group>"; };
-		2996022F566B1CA2CFAB59AD /* openapi-generator-config.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "openapi-generator-config.yaml"; sourceTree = "<group>"; };
 		29E134E4C59A27E9192DF8D2 /* RecentHistoryRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentHistoryRowView.swift; sourceTree = "<group>"; };
 		2C8B25B86087F7FC6D9EBD10 /* PlaybackContentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackContentState.swift; sourceTree = "<group>"; };
 		2CE9FEAEE8B390CA9BE7F2E8 /* TextSourcePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSourcePayload.swift; sourceTree = "<group>"; };
@@ -1228,9 +1215,7 @@
 				4C03756876697C1768B8C149 /* SayItBackend.framework in Frameworks */,
 				1D99CE2AEC265E0091F26C5D /* SayItProtocol.framework in Frameworks */,
 				F584C1627A6C318C06C8A4E5 /* Hummingbird in Frameworks */,
-				6E52A0435904D6D6FDB609BF /* OpenAPIRuntime in Frameworks */,
-				EC4704F893DBF5310D765684 /* OpenAPIHummingbird in Frameworks */,
-				8C86A585B42AAC5091C2515A /* Yams in Frameworks */,
+				6E52A0435904D6D6FDB609BF /* Yams in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1254,6 +1239,10 @@
 				079CED75E397190489D69C24 /* SayItHTTP.framework in Frameworks */,
 				C96E3BB72911998A81131B5E /* SayItProtocol.framework in Frameworks */,
 				B04D737763D887612F91CA02 /* SayItXPC.framework in Frameworks */,
+				8C93C64F92F3FB922B2A0137 /* NIOCore in Frameworks */,
+				41DE1A049C2D3BFE630D7177 /* Atomics in Frameworks */,
+				2790FF938C2667A993615997 /* DequeModule in Frameworks */,
+				08AD98C46CD4B71D9F7C60B8 /* OrderedCollections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1284,7 +1273,6 @@
 				5E463C8DB9A3EE6B6DCD969B /* SayItCore.framework in Frameworks */,
 				A55D01E23657A9AEC04FF8AF /* SayItProtocol.framework in Frameworks */,
 				D2104E9CE0AB13E222B9047C /* SayItXPC.framework in Frameworks */,
-				7A9CE2127601A523727C4683 /* SayItHTTP.framework in Frameworks */,
 				BD604084C8E309239D84FEBE /* MLXAudioCore in Frameworks */,
 				5284097D44147769C8F5DE13 /* MLXAudioTTS in Frameworks */,
 				64E597F0729C5832060A65D1 /* ArgumentParser in Frameworks */,
@@ -2102,7 +2090,6 @@
 				068C859B80F661F56E0DDCA6 /* IdempotencyEntry.swift */,
 				CC719FAC8BB29024BACE25E2 /* IdempotencyStore.swift */,
 				33C679C3BD54B83C5BCE6E2E /* ModelArchiveImporter.swift */,
-				2996022F566B1CA2CFAB59AD /* openapi-generator-config.yaml */,
 				4D514FBB81728B5F7E53FCCE /* openapi.yaml */,
 				5AA4152BB6F9DD6B8ECC9E54 /* PlaybackRateRequest.swift */,
 				01D5840F137CD49046F6AD9C /* RateLimitWindow.swift */,
@@ -2230,6 +2217,7 @@
 			buildConfigurationList = D3F6A5C279689CC31AB435B9 /* Build configuration list for PBXNativeTarget "SayItAgent" */;
 			buildPhases = (
 				EEF708522C037F1C84E4D938 /* Sources */,
+				EA8022A4020E3D778E433C8B /* Resources */,
 				694B96306AEE986493C6187D /* Frameworks */,
 				70AFBA110878095671F391E1 /* Embed Frameworks */,
 			);
@@ -2244,6 +2232,10 @@
 			);
 			name = SayItAgent;
 			packageProductDependencies = (
+				B11D4CCFD0C68E9C0B589FD0 /* NIOCore */,
+				12D3C7903194A06085F4C99C /* Atomics */,
+				966CEFC1C422D50A7DA22CD1 /* DequeModule */,
+				0E358E4263F4B393DA65F90A /* OrderedCollections */,
 			);
 			productName = SayItAgent;
 			productReference = A8C3FAB8E768F21BF7E8DFA3 /* SayItAgent.app */;
@@ -2337,6 +2329,7 @@
 			buildConfigurationList = 55EB2E2FFB67C4CE511F24BF /* Build configuration list for PBXNativeTarget "SayItHTTPTests" */;
 			buildPhases = (
 				A558142DA75AC3235339EFEA /* Sources */,
+				37CA988140313F7D2959A5DA /* Resources */,
 				CB1DAEBB36926E9019E4C860 /* Frameworks */,
 				A3982C98462CE213A19502C7 /* Embed Frameworks */,
 			);
@@ -2401,8 +2394,8 @@
 			buildConfigurationList = 7B90EB6F2ABE269DA4F80846 /* Build configuration list for PBXNativeTarget "SayItHTTP" */;
 			buildPhases = (
 				E24BB7B9A63C461C7FBAFCDE /* Sources */,
-				9CB10E3BEAB46F4358C47451 /* Resources */,
 				12722A47E6878920783450B0 /* Frameworks */,
+				E710F3A6446C1616EB39499E /* Use Shared NIOCore Framework */,
 			);
 			buildRules = (
 			);
@@ -2413,13 +2406,11 @@
 			name = SayItHTTP;
 			packageProductDependencies = (
 				A39050CFC31E1CAFAD4CAFB6 /* Hummingbird */,
-				FD20A7112C89EF1EA775887A /* OpenAPIRuntime */,
-				31863F3224A3AC66E6B10238 /* OpenAPIHummingbird */,
 				B085212FC4B8B933B6D6E28B /* Yams */,
 			);
 			productName = SayItHTTP;
 			productReference = 7E0D0C006406346A39E5C37E /* SayItHTTP.framework */;
-			productType = "com.apple.product-type.framework";
+			productType = "com.apple.product-type.framework.static";
 		};
 		8F86AD8C9F6B4A4C4524329A /* SayIt */ = {
 			isa = PBXNativeTarget;
@@ -2438,7 +2429,6 @@
 				E90BD671C29202C9F169783B /* PBXTargetDependency */,
 				B3ED80D7E17459C561261E8D /* PBXTargetDependency */,
 				6A7DDE750A3392396AF2C2B8 /* PBXTargetDependency */,
-				303EFC37664F9E6C1F32CEE9 /* PBXTargetDependency */,
 				F614977EAEC81544F1FF06FD /* PBXTargetDependency */,
 				8715D3C1039790C615F07826 /* PBXTargetDependency */,
 				C8C7527B9E9029D750C97BE7 /* PBXTargetDependency */,
@@ -2635,8 +2625,9 @@
 				0FB0C4A704F0962960BDE609 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
 				DE2AC70706798290F46011A7 /* XCRemoteSwiftPackageReference "hummingbird" */,
 				EDE9B52C93821E68A0BAF348 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */,
-				DA53DAD9A435295BFDF0116F /* XCRemoteSwiftPackageReference "swift-openapi-hummingbird" */,
-				8B218DEFA2D4D5EF7E32680E /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */,
+				8C57CA57D58F0367C9CA83E8 /* XCRemoteSwiftPackageReference "swift-atomics" */,
+				C93AA06F3A6E248872ED93BC /* XCRemoteSwiftPackageReference "swift-collections" */,
+				2E71412ABA0D3631AC8F7E2B /* XCRemoteSwiftPackageReference "swift-nio" */,
 				8FA3A87EEEF8E0DC0F7CA93B /* XCRemoteSwiftPackageReference "Yams" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -2665,6 +2656,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		37CA988140313F7D2959A5DA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				19B6090764A4FAC7C2557148 /* openapi.yaml in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4DA98FA79E2F8D680FF21C4E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2691,12 +2690,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9CB10E3BEAB46F4358C47451 /* Resources */ = {
+		EA8022A4020E3D778E433C8B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52502DAC4AEAFB4BD4596A9D /* openapi-generator-config.yaml in Resources */,
-				49FDF14558C27BFE52DEA9F3 /* openapi.yaml in Resources */,
+				D67A9EF822F5729F3536E29A /* openapi.yaml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2721,6 +2719,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\nservice_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchServices\"\nagent_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchAgents\"\ncli_dir=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Helpers\"\ntimestamp_option=\nif [[ \"${SAYIT_DISABLE_SECURE_TIMESTAMP:-NO}\" == \"YES\" ]]; then\n  timestamp_option=--timestamp=none\nfi\nmkdir -p \"${service_dir}\" \"${agent_dir}\" \"${cli_dir}\"\nrm -f \\\n  \"${service_dir}/SayItAgent\" \\\n  \"${service_dir}/SayItSelectionAgent\" \\\n  \"${cli_dir}/SayItSelectionAgent\" \\\n  \"${cli_dir}/sayit\" \\\n  \"${agent_dir}/com.sayit.mac.agent.plist\" \\\n  \"${agent_dir}/com.sayit.mac.selection.plist\" \\\n  \"${agent_dir}/sh.sayit.mac.selection.plist\" \\\n  \"${agent_dir}/sh.sayit.mac.selection-helper.plist\"\nrm -rf \\\n  \"${service_dir}/SayItAgent.app\" \\\n  \"${cli_dir}/SayItCLI.app\"\nditto \"${BUILT_PRODUCTS_DIR}/SayItAgent.app\" \"${service_dir}/SayItAgent.app\"\nditto \"${BUILT_PRODUCTS_DIR}/SayItSelectionAgent\" \"${cli_dir}/SayItSelectionAgent\"\nif [[ -n \"${SAYIT_SELECTION_SIGN_IDENTITY:-}\" ]]; then\n  /usr/bin/codesign \\\n    --force \\\n    --sign \"${SAYIT_SELECTION_SIGN_IDENTITY}\" \\\n    ${timestamp_option} \\\n    --options runtime \\\n    --identifier \"${SAYIT_SELECTION_BUNDLE_IDENTIFIER}\" \\\n    \"${cli_dir}/SayItSelectionAgent\"\nfi\nditto \"${BUILT_PRODUCTS_DIR}/mlx-swift_Cmlx.bundle\" \"${service_dir}/mlx-swift_Cmlx.bundle\"\nditto \"${BUILT_PRODUCTS_DIR}/SayItCLI.app\" \"${cli_dir}/SayItCLI.app\"\nln -s \"SayItCLI.app/Contents/MacOS/sayit\" \"${cli_dir}/sayit\"\nditto \"${SRCROOT}/Config/sh.sayit.mac.agent.plist\" \"${agent_dir}/sh.sayit.mac.agent.plist\"\n\n# Compiled Swift module metadata is only needed by developers linking\n# against a framework. Removing it from the distributed app also\n# prevents local source and package-cache paths from leaking.\napp_dir=\"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\"\nfind \"${app_dir}\" \\\n  -type d \\\n  -name '*.swiftmodule' \\\n  -prune \\\n  -exec rm -rf {} +\n\n# Embedded code is signed before this post-build phase. If this is a\n# certificate-signed build, restore those nested signatures after\n# removing their development metadata; Xcode signs the outer app last.\nif [[ \"${CODE_SIGNING_ALLOWED:-NO}\" == \"YES\" \\\n    && -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]]; then\n  find \"${app_dir}\" \\\n    -type f \\\n    -name '*.dylib' \\\n    -exec /usr/bin/codesign \\\n      --force \\\n      --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \\\n      ${timestamp_option} \\\n      --preserve-metadata=identifier,entitlements,requirements,flags,runtime \\\n      {} \\;\n\n  find \"${app_dir}\" \\\n    -type d \\\n    -name '*.framework' \\\n    -exec /usr/bin/codesign \\\n      --force \\\n      --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \\\n      ${timestamp_option} \\\n      --preserve-metadata=identifier,entitlements,requirements,flags,runtime \\\n      {} \\;\n\n  find \"${app_dir}/Contents\" \\\n    -type d \\\n    -name '*.app' \\\n    -exec /usr/bin/codesign \\\n      --force \\\n      --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \\\n      ${timestamp_option} \\\n      --preserve-metadata=identifier,entitlements,requirements,flags,runtime \\\n      {} \\;\nfi\n";
+		};
+		E710F3A6446C1616EB39499E /* Use Shared NIOCore Framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Use Shared NIOCore Framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\"${SRCROOT}/Scripts/prepare-static-http-linkage.sh\" \\\n  \"${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -3256,11 +3273,6 @@
 			isa = PBXTargetDependency;
 			target = 6A4303A3D2D6CF1067B59EC0 /* SayItXPC */;
 			targetProxy = 85CE6BF315C31999FAA12131 /* PBXContainerItemProxy */;
-		};
-		303EFC37664F9E6C1F32CEE9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 805D294C1B998FB17D83063C /* SayItHTTP */;
-			targetProxy = A6A9618335832C32F8452DB0 /* PBXContainerItemProxy */;
 		};
 		347A27BF2027222C2B958A0C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4351,12 +4363,20 @@
 				version = 1.8.2;
 			};
 		};
-		8B218DEFA2D4D5EF7E32680E /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */ = {
+		2E71412ABA0D3631AC8F7E2B /* XCRemoteSwiftPackageReference "swift-nio" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/apple/swift-openapi-runtime";
+			repositoryURL = "https://github.com/apple/swift-nio.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.8.2;
+				minimumVersion = 2.83.0;
+			};
+		};
+		8C57CA57D58F0367C9CA83E8 /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-atomics.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		8FA3A87EEEF8E0DC0F7CA93B /* XCRemoteSwiftPackageReference "Yams" */ = {
@@ -4367,12 +4387,12 @@
 				version = 6.2.2;
 			};
 		};
-		DA53DAD9A435295BFDF0116F /* XCRemoteSwiftPackageReference "swift-openapi-hummingbird" */ = {
+		C93AA06F3A6E248872ED93BC /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/swift-server/swift-openapi-hummingbird";
+			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
-				kind = exactVersion;
-				version = 2.0.1;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		DE2AC70706798290F46011A7 /* XCRemoteSwiftPackageReference "hummingbird" */ = {
@@ -4394,10 +4414,15 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		31863F3224A3AC66E6B10238 /* OpenAPIHummingbird */ = {
+		0E358E4263F4B393DA65F90A /* OrderedCollections */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = DA53DAD9A435295BFDF0116F /* XCRemoteSwiftPackageReference "swift-openapi-hummingbird" */;
-			productName = OpenAPIHummingbird;
+			package = C93AA06F3A6E248872ED93BC /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
+		};
+		12D3C7903194A06085F4C99C /* Atomics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C57CA57D58F0367C9CA83E8 /* XCRemoteSwiftPackageReference "swift-atomics" */;
+			productName = Atomics;
 		};
 		520A2134F17626EE9570DDA2 /* HummingbirdTesting */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -4419,6 +4444,11 @@
 			package = EDE9B52C93821E68A0BAF348 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */;
 			productName = MLXAudioCore;
 		};
+		966CEFC1C422D50A7DA22CD1 /* DequeModule */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C93AA06F3A6E248872ED93BC /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = DequeModule;
+		};
 		A39050CFC31E1CAFAD4CAFB6 /* Hummingbird */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = DE2AC70706798290F46011A7 /* XCRemoteSwiftPackageReference "hummingbird" */;
@@ -4434,6 +4464,11 @@
 			package = 8FA3A87EEEF8E0DC0F7CA93B /* XCRemoteSwiftPackageReference "Yams" */;
 			productName = Yams;
 		};
+		B11D4CCFD0C68E9C0B589FD0 /* NIOCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2E71412ABA0D3631AC8F7E2B /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = NIOCore;
+		};
 		D32C1E8AC5B0B86155A50698 /* MLXAudioCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = EDE9B52C93821E68A0BAF348 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */;
@@ -4443,11 +4478,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0FB0C4A704F0962960BDE609 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
 			productName = ArgumentParser;
-		};
-		FD20A7112C89EF1EA775887A /* OpenAPIRuntime */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 8B218DEFA2D4D5EF7E32680E /* XCRemoteSwiftPackageReference "swift-openapi-runtime" */;
-			productName = OpenAPIRuntime;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/SayIt.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SayIt.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "df4dca862186f6333a97a4e83683b74a7f4b2e66062029eb3ecc7d61c83e702f",
+  "originHash" : "1097e84391dd6f367e127401d98272aff49976c4cadc1167c4f3d1aca6103e6a",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -251,24 +251,6 @@
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-openapi-hummingbird",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-openapi-hummingbird",
-      "state" : {
-        "revision" : "026b50b17e9afe74d4d82c883d9c37154a8b30bf",
-        "version" : "2.0.1"
-      }
-    },
-    {
-      "identity" : "swift-openapi-runtime",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-openapi-runtime",
-      "state" : {
-        "revision" : "3d3a8457661daf7fb260ceeb9f0e24e5204ba5fb",
-        "version" : "1.12.0"
       }
     },
     {

--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -114,4 +114,5 @@ fi
 
 codesign --verify --deep --strict "$app_root"
 "$project_root/Scripts/validate-selection-bundle.sh" "$app_root"
+"$project_root/Scripts/validate-package-linkage.sh" "$app_root"
 echo "$app_root"

--- a/Scripts/prepare-static-http-linkage.sh
+++ b/Scripts/prepare-static-http-linkage.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+http_archive=${1:?Usage: prepare-static-http-linkage.sh /path/to/SayItHTTP}
+nio_archive_member=NIOCore.o
+nio_metadata_symbol='_$s7NIOCore10ByteBufferVMn'
+
+fail() {
+    echo "Static HTTP linkage preparation failed: $*" >&2
+    exit 1
+}
+
+[ -f "$http_archive" ] || fail "the SayItHTTP archive is missing."
+
+# Hummingbird's static package aggregate includes NIOCore.o even though the
+# agent links the shared NIOCore package framework required by EventSource.
+# Remove that one archive member so the process loads exactly one NIOCore.
+if /usr/bin/ar -t "$http_archive" \
+    | /usr/bin/grep -Fx "$nio_archive_member" >/dev/null; then
+    /usr/bin/ar -d "$http_archive" "$nio_archive_member"
+    /usr/bin/ranlib "$http_archive"
+fi
+
+if /usr/bin/nm --defined-only "$http_archive" 2>/dev/null \
+    | /usr/bin/grep -F "$nio_metadata_symbol" >/dev/null; then
+    fail "NIOCore metadata remains in the SayItHTTP archive."
+fi
+
+echo "Static HTTP linkage prepared."

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -210,6 +210,7 @@ verify_release_code \
     "$app_root/Contents/Helpers/SayItSelectionAgent" \
     "the selection helper"
 "$project_root/Scripts/validate-selection-bundle.sh" "$app_root"
+"$project_root/Scripts/validate-package-linkage.sh" "$app_root"
 
 find "$app_root" -type f -name '*.dylib' -print \
     | while IFS= read -r dylib_path; do
@@ -295,6 +296,7 @@ verify_release_code \
     "$mounted_app/Contents/Helpers/SayItSelectionAgent" \
     "the mounted selection helper"
 "$project_root/Scripts/validate-selection-bundle.sh" "$mounted_app"
+"$project_root/Scripts/validate-package-linkage.sh" "$mounted_app"
 
 find "$mounted_app" -type f -name '*.dylib' -print \
     | while IFS= read -r dylib_path; do

--- a/Scripts/validate-package-linkage.sh
+++ b/Scripts/validate-package-linkage.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+app_root=${1:?Usage: validate-package-linkage.sh /path/to/SayIt.app}
+nio_metadata_symbol='_$s7NIOCore10ByteBufferVMn'
+
+fail() {
+    echo "Package linkage validation failed: $*" >&2
+    exit 1
+}
+
+[ -d "$app_root" ] || fail "the app bundle is missing."
+
+# ByteBuffer's nominal type descriptor is a stable NIOCore-owned marker. A
+# binary that defines it while loading the package framework has two copies.
+/usr/bin/find "$app_root" -type f -print \
+    | while IFS= read -r binary_path; do
+        linked_libraries=$(
+            /usr/bin/otool -l "$binary_path" 2>/dev/null
+        ) || continue
+        if ! printf '%s\n' "$linked_libraries" \
+            | /usr/bin/awk '
+                $1 == "cmd" && $2 ~ /^LC_(LOAD|REEXPORT)_/ {
+                    reading_load = 1
+                    next
+                }
+                reading_load && $1 == "name" {
+                    print $2
+                    reading_load = 0
+                }
+            ' \
+            | /usr/bin/grep -E \
+                '/NIOCore_[^/]*_PackageProduct\.framework/' >/dev/null; then
+            continue
+        fi
+
+        if /usr/bin/nm --defined-only "$binary_path" 2>/dev/null \
+            | /usr/bin/grep -F "$nio_metadata_symbol" >/dev/null; then
+            binary_name=$(/usr/bin/basename "$binary_path")
+            fail "$binary_name both defines NIOCore metadata and links an embedded NIOCore package framework."
+        fi
+    done
+
+echo "Package linkage validation passed."

--- a/project.yml
+++ b/project.yml
@@ -11,15 +11,18 @@ packages:
   MLXAudio:
     url: https://github.com/Blaizzy/mlx-audio-swift.git
     exactVersion: 0.1.3
-  OpenAPIRuntime:
-    url: https://github.com/apple/swift-openapi-runtime
-    from: 1.8.2
   Hummingbird:
     url: https://github.com/hummingbird-project/hummingbird.git
     exactVersion: 2.22.0
-  OpenAPIHummingbird:
-    url: https://github.com/swift-server/swift-openapi-hummingbird
-    exactVersion: 2.0.1
+  SwiftNIO:
+    url: https://github.com/apple/swift-nio.git
+    from: 2.83.0
+  SwiftAtomics:
+    url: https://github.com/apple/swift-atomics.git
+    from: 1.0.0
+  SwiftCollections:
+    url: https://github.com/apple/swift-collections.git
+    from: 1.0.0
   ArgumentParser:
     url: https://github.com/apple/swift-argument-parser
     exactVersion: 1.8.2
@@ -130,19 +133,20 @@ targets:
         SKIP_INSTALL: true
 
   SayItHTTP:
-    type: framework
+    # Keep Hummingbird in the agent executable so it can use the same dynamic
+    # NIOCore package framework as MLXAudio's EventSource dependency.
+    type: framework.static
     platform: macOS
     sources:
       - path: Sources/SayItHTTP
+        excludes:
+          - openapi-generator-config.yaml
+          - openapi.yaml
     dependencies:
       - target: SayItBackend
       - target: SayItProtocol
       - package: Hummingbird
         product: Hummingbird
-      - package: OpenAPIRuntime
-        product: OpenAPIRuntime
-      - package: OpenAPIHummingbird
-        product: OpenAPIHummingbird
       - package: Yams
         product: Yams
     settings:
@@ -152,12 +156,21 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: sh.sayit.mac.http
         PRODUCT_NAME: SayItHTTP
         SKIP_INSTALL: true
+    postBuildScripts:
+      - name: Use Shared NIOCore Framework
+        basedOnDependencyAnalysis: false
+        script: |
+          set -euo pipefail
+          "${SRCROOT}/Scripts/prepare-static-http-linkage.sh" \
+            "${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"
 
   SayItAgent:
     type: application
     platform: macOS
     sources:
       - path: Sources/SayItAgent
+      - path: Sources/SayItHTTP/openapi.yaml
+        buildPhase: resources
     entitlements:
       path: Config/SayItAgent.entitlements
       properties:
@@ -172,6 +185,16 @@ targets:
       - target: SayItHTTP
       - target: SayItProtocol
       - target: SayItXPC
+      # Static SayItHTTP leaves these shared package products for the final
+      # executable link instead of embedding private copies.
+      - package: SwiftNIO
+        product: NIOCore
+      - package: SwiftAtomics
+        product: Atomics
+      - package: SwiftCollections
+        product: DequeModule
+      - package: SwiftCollections
+        product: OrderedCollections
     settings:
       base:
         CODE_SIGN_IDENTITY: "$(SAYIT_SIGN_IDENTITY)"
@@ -294,8 +317,6 @@ targets:
       - target: SayItProtocol
         embed: true
       - target: SayItXPC
-        embed: true
-      - target: SayItHTTP
         embed: true
       - target: SayItAgent
         link: false
@@ -471,6 +492,8 @@ targets:
     platform: macOS
     sources:
       - path: Tests/SayItHTTPTests
+      - path: Sources/SayItHTTP/openapi.yaml
+        buildPhase: resources
     dependencies:
       - target: SayItCore
       - target: SayItBackend


### PR DESCRIPTION
## Summary
- link SayItHTTP statically into the background agent so Hummingbird shares the dynamic NIOCore package framework already required by EventSource
- keep the OpenAPI document in the agent and HTTP test bundles while removing unused Xcode OpenAPI package products
- add build and release audits that reject any binary defining NIOCore metadata while loading the embedded package framework

## Validation
- reproduced against the exact published v0.1.3 DMG; the new guard rejects it
- clean Scripts/build-app.sh
- targeted SayItHTTP suite (15 tests)
- full Swift suite using the release workflow MLX Metal setup (275 tests)
- Scripts/validate-catalog.sh
- packaged and mounted a local DMG; signature, helper, privacy, resource, and linkage audits passed

Closes #9