### PR TITLE
Simplify update controls and failure status

### DIFF
--- a/Sources/SayIt/AppShell/MenuBarRootView.swift
+++ b/Sources/SayIt/AppShell/MenuBarRootView.swift
@@ -57,18 +57,6 @@ struct MenuBarRootView: View {
             }
 
             Divider()
-            Button(
-                state.updates.hasUpdate ? "Update Now…" : "Check for Updates…",
-                systemImage: "arrow.down.circle"
-            ) {
-                if state.updates.hasUpdate { state.updates.updateNow() }
-                else { state.checkForUpdates() }
-            }
-            .buttonStyle(.plain)
-            .disabled(state.updates.phase == .unavailable)
-            .padding(.horizontal, DesignTokens.generousSpacing)
-            .padding(.vertical, DesignTokens.compactSpacing)
-            Divider()
             MenuFooterView()
                 .padding(.horizontal, DesignTokens.generousSpacing)
                 .padding(.vertical, DesignTokens.compactSpacing)

--- a/Sources/SayIt/Updates/UpdateController.swift
+++ b/Sources/SayIt/Updates/UpdateController.swift
@@ -275,7 +275,7 @@ extension UpdateController: SPUUserDriver {
         case Int(SUError.installationCanceledError.rawValue), Int(SUError.authenticationFailure.rawValue):
             status = "Installation was canceled or couldn’t be authorized. Check for updates when you’re ready to try again."
         default:
-            status = "The update couldn’t be completed. Check your connection and try again. If this keeps happening, quit and reopen Say It."
+            status = "Update failed. Try again."
         }
         self.acknowledgement = acknowledgement
         showWindow()


### PR DESCRIPTION
Remove the Check for Updates / Update Now row and its extra divider from the dropdown player, restoring MenuBarRootView exactly to its layout before #22. Update controls remain in Settings, and automatic update behavior is unchanged.

Shorten the generic update failure status to “Update failed. Try again.” so it fits the Status row in Settings → About.

Validation: Swift frontend syntax parsing of both changed files and `git diff --check` passed. Confirmed the dropdown view matches the pre-#22 source exactly. No full build or UI screenshot was produced for these small UI changes.
