### PR TITLE
Compare Signalsmith pitch-preserving playback

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .executable(name: "SayIt", targets: ["SayIt"])
     ],
     dependencies: [
+        .package(path: "Packages/PlaybackDSP"),
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.6"),
         .package(
             url: "https://github.com/Blaizzy/mlx-audio-swift.git",
@@ -71,6 +72,7 @@ let package = Package(
         .target(
             name: "SayItBackend",
             dependencies: [
+                .product(name: "PlaybackDSP", package: "PlaybackDSP"),
                 "SayItCore",
                 "SayItProtocol",
                 .product(name: "MLXAudioCore", package: "mlx-audio-swift"),

--- a/Packages/PlaybackDSP/Package.swift
+++ b/Packages/PlaybackDSP/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "PlaybackDSP",
+    platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "PlaybackDSP", targets: ["PlaybackDSP"]),
+        .executable(name: "PlaybackDSPRender", targets: ["PlaybackDSPRender"])
+    ],
+    targets: [
+        .target(
+            name: "CPlaybackDSP",
+            exclude: ["vendor"],
+            sources: ["TimeStretch.cpp"],
+            publicHeadersPath: "include",
+            cxxSettings: [.headerSearchPath("vendor"), .define("SIGNALSMITH_USE_ACCELERATE")],
+            linkerSettings: [.linkedFramework("Accelerate")]
+        ),
+        .target(name: "PlaybackDSP", dependencies: ["CPlaybackDSP"]),
+        .testTarget(name: "PlaybackDSPTests", dependencies: ["PlaybackDSP"]),
+        .executableTarget(name: "PlaybackDSPRender", dependencies: ["PlaybackDSP"])
+    ],
+    cxxLanguageStandard: .cxx17
+)

--- a/Packages/PlaybackDSP/README.md
+++ b/Packages/PlaybackDSP/README.md
@@ -1,0 +1,24 @@
+# Signalsmith playback comparison
+
+This experimental branch replaces Apple's playback time stretcher with Signalsmith
+Stretch 1.3.2. Playback speed remains 0.5–2× and pitch remains unchanged. At 1× the
+original PCM bypasses processing. A continuous processor spans scheduling chunks;
+its latency is removed and its tail drained. Source audio and exports stay original.
+
+Vendored sources (unmodified): Signalsmith-Audio/signalsmith-stretch at `57b93f4`
+and Signalsmith-Audio/linear at `ec38d33`, both MIT licensed. License notices are
+beside the sources. Apple Accelerate supplies FFTs; no runtime library install is needed.
+
+Run `swift test --package-path Packages/PlaybackDSP -c release` for DSP tests, then
+`./Scripts/build-app.sh` for the local app. Compare the same voice/text and keep
+native Speaking Pace at Natural. Test 0.5, 0.75, 1, 1.25, 1.5 and 2×, including
+mid-sentence rate changes, pause/resume, seek, progressive generation, and replay.
+This is a listening experiment, not a claim of perceptual superiority.
+
+To render a saved speech file at every comparison speed without changing the app,
+run `swift run -c release --package-path Packages/PlaybackDSP PlaybackDSPRender input.wav output-directory`.
+Use a fresh output directory for each engine. The CSV output reports sample counts
+and DSP processing time, and the six WAV files can be compared directly. No audio
+or measurements are uploaded by this command.
+
+Only run one comparison app at a time; the variants share the local app identity and settings.

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/TimeStretch.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/TimeStretch.cpp
@@ -1,0 +1,77 @@
+#include "TimeStretch.h"
+#include "vendor/signalsmith-stretch.h"
+#include <cmath>
+#include <cstdint>
+#include <vector>
+#include <stdexcept>
+
+namespace {
+struct Stream {
+    signalsmith::stretch::SignalsmithStretch<float> stretch{0};
+    double rate;
+    int64_t inputFrames = 0, rawFrames = 0, deliveredFrames = 0;
+    int64_t skip;
+    bool finished = false;
+    std::vector<float> output;
+
+    Stream(double sampleRate, double playbackRate) : rate(playbackRate) {
+        stretch.presetDefault(1, sampleRate);
+        skip = std::llround(stretch.inputLatency() / rate) + stretch.outputLatency();
+    }
+
+    void render(const float *input, int count, int outputCount) {
+        std::vector<float> block(outputCount);
+        const float *inputs[] = {input};
+        float *outputs[] = {block.data()};
+        stretch.process(inputs, count, outputs, outputCount);
+        auto drop = std::min<int64_t>(skip, outputCount);
+        skip -= drop;
+        auto remaining = std::llround(inputFrames / rate) - deliveredFrames;
+        auto keep = std::min<int64_t>(outputCount - drop, remaining);
+        output.insert(output.end(), block.begin() + drop, block.begin() + drop + keep);
+        deliveredFrames += keep;
+    }
+
+    void process(const float *input, int count, bool final) {
+        if (finished) throw std::runtime_error("Stream already finalized");
+        output.clear();
+        inputFrames += count;
+        if (rate == 1) {
+            if (count) output.assign(input, input + count);
+            deliveredFrames += count;
+        } else {
+            auto nextRawFrames = std::llround(inputFrames / rate);
+            if (count) render(input, count, int(nextRawFrames - rawFrames));
+            rawFrames = nextRawFrames;
+            if (final) {
+                // Feed silence through the same continuous engine to drain its lookahead.
+                auto missing = nextRawFrames - deliveredFrames;
+                int padding = int(std::ceil((missing + skip + stretch.outputLatency()) * rate))
+                    + stretch.blockSamples();
+                std::vector<float> silence(padding, 0);
+                render(silence.data(), padding, int(std::ceil(padding / rate)));
+                if (deliveredFrames != nextRawFrames) throw std::runtime_error("Incomplete tail");
+            }
+        }
+        finished = final;
+    }
+};
+}
+
+extern "C" void *sayit_stretch_create(double sampleRate, double rate) {
+    if (!std::isfinite(sampleRate) || sampleRate < 8000 || sampleRate > 192000
+        || !std::isfinite(rate) || rate < 0.5 || rate > 2) return nullptr;
+    try { return new Stream(sampleRate, rate); } catch (...) { return nullptr; }
+}
+extern "C" void sayit_stretch_destroy(void *handle) { delete static_cast<Stream *>(handle); }
+extern "C" const float *sayit_stretch_process(void *handle, const float *input, int count,
+                                             int final, int *outputCount) {
+    *outputCount = -1;
+    if (!handle || count < 0 || (count && !input)) return nullptr;
+    try {
+        auto &stream = *static_cast<Stream *>(handle);
+        stream.process(input, count, final != 0);
+        *outputCount = int(stream.output.size());
+        return stream.output.data();
+    } catch (...) { return nullptr; }
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/include/TimeStretch.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/include/TimeStretch.h
@@ -1,0 +1,15 @@
+#ifndef SAYIT_TIME_STRETCH_H
+#define SAYIT_TIME_STRETCH_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Each handle belongs to one serial processing context. No audio callback work.
+void *sayit_stretch_create(double sample_rate, double playback_rate);
+void sayit_stretch_destroy(void *handle);
+// Output is owned by handle until the next call. A negative count signals failure.
+const float *sayit_stretch_process(void *handle, const float *input, int count,
+                                  int final, int *output_count);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/STRETCH-LICENSE.txt
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/STRETCH-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Geraint Luff / Signalsmith Audio Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/LICENSE.txt
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Signalsmith Audio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/approx.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/approx.h
@@ -1,0 +1,191 @@
+#ifndef SIGNALSMITH_AUDIO_LINEAR_APPROX_H
+#define SIGNALSMITH_AUDIO_LINEAR_APPROX_H
+
+#include <cmath>
+#include <complex>
+
+namespace signalsmith { namespace linear {
+
+template<typename Sample, size_t level=0>
+struct Approx {
+
+	Approx() : pcg32(std::random_device{}) {}
+	
+	std::complex<Sample> unitPolar(Sample radians) {
+		return std::polar(Sample(1), radians);
+	}
+	Sample sin(Sample radians) {
+		return std::sin(radians);
+	}
+	Sample cos(Sample radians) {
+		return std::cos(radians);
+	}
+	Sample atan2(Sample x, Sample y) {
+		return std::atan2(x, y);
+	}
+	Sample arg(std::complex<Sample> v) {
+		return std::arg(v);
+	}
+	Sample sqrt(Sample v) {
+		return std::sqrt(v);
+	}
+	Sample invSqrt(Sample v) {
+		return 1/std::sqrt(v);
+	}
+	
+	void setAbs(std::complex<Sample> &v, Sample newAbs=1) {
+		Sample norm = v.real()*v.real() + v.imag()*v.imag();
+		if (norm < Sample(1e-30)) {
+			v = newAbs;
+		} else {
+			v *= newAbs*invSqrt(norm);
+		}
+	}
+	void setAbs(std::complex<Sample> *v, const Sample *newAbs, size_t count) {
+		for (size_t i = 0; i < count; ++i) {
+			setAbs(v[i], newAbs[i]);
+		}
+	}
+	void setAbs(Sample *real, Sample *imag, const Sample *newAbs, size_t count) {
+		for (size_t i = 0; i < count; ++i) {
+			std::complex<Sample> v{real[i], imag[i]};
+			setAbs(v, newAbs[i]);
+			real[i] = v.real();
+			imag[i] = v.imag();
+		}
+	}
+	
+	void setNorm(std::complex<Sample> &v, Sample newNorm=1) {
+		Sample norm = v.real()*v.real() + v.imag()*v.imag();
+		if (norm < Sample(1e-30)) {
+			v = sqrt(newNorm);
+		} else {
+			v *= sqrt(newNorm/norm);
+		}
+	}
+	void setNorm(std::complex<Sample> *v, const Sample *newNorm, size_t count) {
+		for (size_t i = 0; i < count; ++i) {
+			setNorm(v[i], newNorm[i]);
+		}
+	}
+	void setNorm(Sample *real, Sample *imag, const Sample *newNorm, size_t count) {
+		for (size_t i = 0; i < count; ++i) {
+			std::complex<Sample> v{real[i], imag[i]};
+			setNorm(v, newNorm[i]);
+			real[i] = v.real();
+			imag[i] = v.imag();
+		}
+	}
+	
+	Sample random(bool allow1=false) {
+		const Sample scale = 1/Sample(allow1 ? 4294967295 : 4294967296);
+		return pcg32()*scale;
+	}
+	void fillRandom32(Sample *array, size_t count, bool allow1=false) {
+		const Sample scale = 1/Sample(allow1 ? 4294967295 : 4294967296);
+		for (size_t i = 0; i < count; ++i) {
+			array[i] = pcg32()*scale;
+		}
+	}
+	void fillRandom16(Sample *array, size_t count, bool allow1=true) {
+		const Sample scale = 1/Sample(allow1 ? 65535 : 65536);
+		for (size_t i = 0; i < count/2; ++i) {
+			auto r32 = pcg32();
+			// Little-endian way around
+			array[2*i] = (r32&0xFFFF)*scale;
+			array[2*i + 1] = (r32>>16)*scale;
+		}
+		if (count&1) {
+			array[count^1] = (pcg32()&0xFFFF)*scale;
+		}
+	}
+
+	struct Pcg32 {
+		uint32_t operator()() {
+			uint64_t prevState = state;
+			state = prevState*multiply + add;
+			auto xorShift = uint32_t(((prevState>>18)^prevState)>>27);
+			auto rotateBits = uint32_t(prevState>>59);
+			return (xorShift>>rotateBits)|(xorShift<<((-rotateBits)&31));
+		}
+
+		template<class SeedSource>
+		Pcg32(SeedSource &&seed) {
+			size_t bits = 0;
+			while (bits < 64) {
+				auto r1 = seed(), r2 = seed();
+				state = (state<<sizeof(r1))|r1;
+				add = (add<<sizeof(r2))|r2;
+				bits += sizeof(r1);
+			}
+		}
+	private:
+		uint64_t state;
+		static constexpr uint64_t multiply = 6364136223846793005ULL;
+		uint64_t add;
+	} pcg32;
+
+protected:
+	static constexpr Sample inv16 = 1/Sample(65536);
+	static constexpr Sample inv32 = 1/Sample(4294967296);
+};
+
+// Base double implementation is casting to/from float
+template<>
+struct Approx<double, 0> {
+
+	std::complex<double> unitPolar(double radians) {
+		auto v = floats.unitPolar(float(radians));
+		return {double(v.real()), double(v.imag())};
+	}
+	double sin(double v) {
+		return double(floats.sin(float(v)));
+	}
+	double cos(double v) {
+		return double(floats.cos(float(v)));
+	}
+	double atan2(double x, double y) {
+		return double(floats.atan2(float(x), float(y)));
+	}
+	double arg(std::complex<double> v) {
+		return double(floats.arg({float(v.real()), float(v.imag())}));
+	}
+	double sqrt(double v) {
+		return double(floats.sqrt(float(v)));
+	}
+	double invSqrt(double v) {
+		return double(floats.invSqrt(float(v)));
+	}
+	
+	double random(bool allow1=false) {
+		return double(floats.random(allow1));
+	}
+	void fillRandom32(double *array, size_t count, bool allow1=false) {
+		const double scale = 1/double(allow1 ? 4294967295 : 4294967296);
+		for (size_t i = 0; i < count; ++i) {
+			array[i] = floats.pcg32()*scale;
+		}
+	}
+	void fillRandom16(double *array, size_t count, bool allow1=true) {
+		const double scale = 1/double(allow1 ? 65535 : 65536);
+		for (size_t i = 0; i < count/2; ++i) {
+			auto r32 = floats.pcg32();
+			// Little-endian way around
+			array[2*i] = (r32&0xFFFF)*scale;
+			array[2*i + 1] = (r32>>16)*scale;
+		}
+		if (count&1) {
+			array[count^1] = (floats.pcg32()&0xFFFF)*scale;
+		}
+	}
+private:
+	Approx<float, 0> floats;
+};
+
+}} // namespace
+
+#if defined(SIGNALSMITH_USE_CMSISDSP)
+#	include "./platform/fft-cmsisdsp.h"
+#endif
+
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/fft.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/fft.h
@@ -1,0 +1,1386 @@
+#ifndef SIGNALSMITH_AUDIO_LINEAR_FFT_H
+#define SIGNALSMITH_AUDIO_LINEAR_FFT_H
+
+#include <complex>
+#include <vector>
+#include <cmath>
+#include <cstring>
+
+#if defined(__FAST_MATH__) && (__apple_build_version__ >= 16000000) && (__apple_build_version__ <= 16000099) && !defined(SIGNALSMITH_IGNORE_BROKEN_APPLECLANG)
+#	error Apple Clang 16.0.0 generates incorrect SIMD for ARM. If you HAVE to use this version of Clang, turn off -ffast-math.
+#endif
+
+#ifndef M_PI
+#	define M_PI 3.14159265358979323846
+#endif
+
+namespace signalsmith { namespace linear {
+
+namespace _impl {
+	// Helpers for complex arithmetic, ignoring the NaN/Inf edge-cases you get without `-ffast-math`
+	template<class V>
+	void complexMul(std::complex<V> *a, const std::complex<V> *b, const std::complex<V> *c, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			auto bi = b[i], ci = c[i];
+			a[i] = {bi.real()*ci.real() - bi.imag()*ci.imag(), bi.imag()*ci.real() + bi.real()*ci.imag()};
+		}
+	}
+	template<class V>
+	void complexMulConj(std::complex<V> *a, const std::complex<V> *b, const std::complex<V> *c, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			auto bi = b[i], ci = c[i];
+			a[i] = {bi.real()*ci.real() + bi.imag()*ci.imag(), bi.imag()*ci.real() - bi.real()*ci.imag()};
+		}
+	}
+	template<class V>
+	void complexMul(V *ar, V *ai, const V *br, const V *bi, const V *cr, const V *ci, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			V rr = br[i]*cr[i] - bi[i]*ci[i];
+			V ri = br[i]*ci[i] + bi[i]*cr[i];
+			ar[i] = rr;
+			ai[i] = ri;
+		}
+	}
+	template<class V>
+	void complexMulConj(V *ar, V *ai, const V *br, const V *bi, const V *cr, const V *ci, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			V rr = cr[i]*br[i] + ci[i]*bi[i];
+			V ri = cr[i]*bi[i] - ci[i]*br[i];
+			ar[i] = rr;
+			ai[i] = ri;
+		}
+	}
+
+	// Input: aStride elements next to each other -> output with bStride
+	template<size_t aStride, class V>
+	void interleaveCopy(const V *a, V *b, size_t bStride) {
+		for (size_t bi = 0; bi < bStride; ++bi) {
+			const V *offsetA = a + bi*aStride;
+			V *offsetB = b + bi;
+			for (size_t ai = 0; ai < aStride; ++ai) {
+				offsetB[ai*bStride] = offsetA[ai];
+			}
+		}
+	}
+	template<class V>
+	void interleaveCopy(const V *a, V *b, size_t aStride, size_t bStride) {
+		for (size_t bi = 0; bi < bStride; ++bi) {
+			const V *offsetA = a + bi*aStride;
+			V *offsetB = b + bi;
+			for (size_t ai = 0; ai < aStride; ++ai) {
+				offsetB[ai*bStride] = offsetA[ai];
+			}
+		}
+	}
+	template<size_t aStride, class V>
+	void interleaveCopy(const V *aReal, const V *aImag, V *bReal, V *bImag, size_t bStride) {
+		for (size_t bi = 0; bi < bStride; ++bi) {
+			const V *offsetAr = aReal + bi*aStride;
+			const V *offsetAi = aImag + bi*aStride;
+			V *offsetBr = bReal + bi;
+			V *offsetBi = bImag + bi;
+			for (size_t ai = 0; ai < aStride; ++ai) {
+				offsetBr[ai*bStride] = offsetAr[ai];
+				offsetBi[ai*bStride] = offsetAi[ai];
+			}
+		}
+	}
+	template<class V>
+	void interleaveCopy(const V *aReal, const V *aImag, V *bReal, V *bImag, size_t aStride, size_t bStride) {
+		for (size_t bi = 0; bi < bStride; ++bi) {
+			const V *offsetAr = aReal + bi*aStride;
+			const V *offsetAi = aImag + bi*aStride;
+			V *offsetBr = bReal + bi;
+			V *offsetBi = bImag + bi;
+			for (size_t ai = 0; ai < aStride; ++ai) {
+				offsetBr[ai*bStride] = offsetAr[ai];
+				offsetBi[ai*bStride] = offsetAi[ai];
+			}
+		}
+	}
+}
+
+/// Fairly simple and very portable power-of-2 FFT
+template<typename Sample>
+struct SimpleFFT {
+	using Complex = std::complex<Sample>;
+	
+	SimpleFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		twiddles.resize(size*3/4);
+		for (size_t i = 0; i < size*3/4; ++i) {
+			Sample twiddlePhase = -2*M_PI*i/size;
+			twiddles[i] = std::polar(Sample(1), twiddlePhase);
+		}
+		working.resize(size);
+	}
+	
+	void fft(const Complex *time, Complex *freq) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*freq = *time;
+			return;
+		}
+		fftPass<false>(size, 1, time, freq, working.data());
+	}
+
+	void ifft(const Complex *freq, Complex *time) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*time = *freq;
+			return;
+		}
+		fftPass<true>(size, 1, freq, time, working.data());
+	}
+
+	void fft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*outR = *inR;
+			*outI = *inI;
+			return;
+		}
+		Sample *workingR = (Sample *)working.data(), *workingI = workingR + size;
+		fftPass<false>(size, 1, inR, inI, outR, outI, workingR, workingI);
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*outR = *inR;
+			*outI = *inI;
+			return;
+		}
+		Sample *workingR = (Sample *)working.data(), *workingI = workingR + size;
+		fftPass<true>(size, 1, inR, inI, outR, outI, workingR, workingI);
+	}
+private:
+	std::vector<Complex> twiddles;
+	std::vector<Complex> working;
+	
+	template<bool conjB>
+	static Complex mul(const Complex &a, const Complex &b) {
+		return conjB ? Complex{
+			a.real()*b.real() + a.imag()*b.imag(),
+			a.imag()*b.real() - a.real()*b.imag()
+		} : Complex{
+			a.real()*b.real() - a.imag()*b.imag(),
+			a.imag()*b.real() + a.real()*b.imag()
+		};
+	}
+
+	// Calculate a [size]-point FFT, where each element is a block of [stride] values
+	template<bool inverse>
+	void fftPass(size_t size, size_t stride, const Complex *input, Complex *output, Complex *working) {
+		if (size/4 > 1) {
+			// Calculate four quarter-size FFTs
+			fftPass<inverse>(size/4, stride*4, input, working, output);
+			combine4<inverse>(size, stride, working, output);
+		} else if (size == 4) {
+			combine4<inverse>(4, stride, input, output);
+		} else {
+			// 2-point FFT
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = input[s];
+				Complex b = input[s + stride];
+				output[s] = a + b;
+				output[s + stride] = a - b;
+			}
+		}
+	}
+
+	// Combine interleaved results into a single spectrum
+	template<bool inverse>
+	void combine4(size_t size, size_t stride, const Complex *input, Complex *output) const {
+		auto twiddleStep = working.size()/size;
+		for (size_t i = 0; i < size/4; ++i) {
+			Complex twiddleB = twiddles[i*twiddleStep];
+			Complex twiddleC = twiddles[i*2*twiddleStep];
+			Complex twiddleD = twiddles[i*3*twiddleStep];
+			
+			const Complex *inputA = input + 4*i*stride;
+			const Complex *inputB = input + (4*i + 1)*stride;
+			const Complex *inputC = input + (4*i + 2)*stride;
+			const Complex *inputD = input + (4*i + 3)*stride;
+			Complex *outputA = output + i*stride;
+			Complex *outputB = output + (i + size/4)*stride;
+			Complex *outputC = output + (i + size/4*2)*stride;
+			Complex *outputD = output + (i + size/4*3)*stride;
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = inputA[s];
+				Complex b = mul<inverse>(inputB[s], twiddleB);
+				Complex c = mul<inverse>(inputC[s], twiddleC);
+				Complex d = mul<inverse>(inputD[s], twiddleD);
+				Complex ac0 = a + c, ac1 = a - c;
+				Complex bd0 = b + d, bd1 = inverse ? (b - d) : (d - b);
+				Complex bd1i = {-bd1.imag(), bd1.real()};
+				outputA[s] = ac0 + bd0;
+				outputB[s] = ac1 + bd1i;
+				outputC[s] = ac0 - bd0;
+				outputD[s] = ac1 - bd1i;
+			}
+		}
+	}
+
+	// The same thing, but translated for split-complex input/output
+	template<bool inverse>
+	void fftPass(size_t size, size_t stride, const Sample *inputR, const Sample *inputI, Sample *outputR, Sample *outputI, Sample *workingR, Sample *workingI) const {
+		if (size/4 > 1) {
+			// Calculate four quarter-size FFTs
+			fftPass<inverse>(size/4, stride*4, inputR, inputI, workingR, workingI, outputR, outputI);
+			combine4<inverse>(size, stride, workingR, workingI, outputR, outputI);
+		} else if (size == 4) {
+			combine4<inverse>(4, stride, inputR, inputI, outputR, outputI);
+		} else {
+			// 2-point FFT
+			for (size_t s = 0; s < stride; ++s) {
+				Sample ar = inputR[s], ai = inputI[s];
+				Sample br = inputR[s + stride], bi = inputI[s + stride];
+				outputR[s] = ar + br;
+				outputI[s] = ai + bi;
+				outputR[s + stride] = ar - br;
+				outputI[s + stride] = ai - bi;
+			}
+		}
+	}
+
+	// Combine interleaved results into a single spectrum
+	template<bool inverse>
+	void combine4(size_t size, size_t stride, const Sample *inputR, const Sample *inputI, Sample *outputR, Sample *outputI) const {
+		auto twiddleStep = working.size()/size;
+		for (size_t i = 0; i < size/4; ++i) {
+			Complex twiddleB = twiddles[i*twiddleStep];
+			Complex twiddleC = twiddles[i*2*twiddleStep];
+			Complex twiddleD = twiddles[i*3*twiddleStep];
+			
+			const Sample *inputAr = inputR + 4*i*stride, *inputAi = inputI + 4*i*stride;
+			const Sample *inputBr = inputR + (4*i + 1)*stride, *inputBi = inputI + (4*i + 1)*stride;
+			const Sample *inputCr = inputR + (4*i + 2)*stride, *inputCi = inputI + (4*i + 2)*stride;
+			const Sample *inputDr = inputR + (4*i + 3)*stride, *inputDi = inputI + (4*i + 3)*stride;
+			Sample *outputAr = outputR + i*stride, *outputAi = outputI + i*stride;
+			Sample *outputBr = outputR + (i + size/4)*stride, *outputBi = outputI + (i + size/4)*stride;
+			Sample *outputCr = outputR + (i + size/4*2)*stride, *outputCi = outputI + (i + size/4*2)*stride;
+			Sample *outputDr = outputR + (i + size/4*3)*stride, *outputDi = outputI + (i + size/4*3)*stride;
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = {inputAr[s], inputAi[s]};
+				Complex b = mul<inverse>({inputBr[s], inputBi[s]}, twiddleB);
+				Complex c = mul<inverse>({inputCr[s], inputCi[s]}, twiddleC);
+				Complex d = mul<inverse>({inputDr[s], inputDi[s]}, twiddleD);
+				Complex ac0 = a + c, ac1 = a - c;
+				Complex bd0 = b + d, bd1 = inverse ? (b - d) : (d - b);
+				Complex bd1i = {-bd1.imag(), bd1.real()};
+				outputAr[s] = ac0.real() + bd0.real();
+				outputAi[s] = ac0.imag() + bd0.imag();
+				outputBr[s] = ac1.real() + bd1i.real();
+				outputBi[s] = ac1.imag() + bd1i.imag();
+				outputCr[s] = ac0.real() - bd0.real();
+				outputCi[s] = ac0.imag() - bd0.imag();
+				outputDr[s] = ac1.real() - bd1i.real();
+				outputDi[s] = ac1.imag() - bd1i.imag();
+			}
+		}
+	}
+};
+
+/// A power-of-2 only FFT, specialised with platform-specific fast implementations where available
+template<typename Sample>
+struct Pow2FFT {
+	static constexpr bool prefersSplit = true; // whether this FFT implementation is faster when given split-complex inputs
+	using Complex = std::complex<Sample>;
+	
+	Pow2FFT(size_t size=0) {
+		resize(size);
+	}
+	// Allow move, but not copy
+	Pow2FFT(const Pow2FFT &other) = delete;
+	Pow2FFT(Pow2FFT &&other) : tmp(std::move(other.tmp)), simpleFFT(std::move(other.simpleFFT)) {}
+	
+	void resize(size_t size) {
+		simpleFFT.resize(size);
+		tmp.resize(size);
+	}
+	
+	void fft(const Complex *time, Complex *freq) {
+		simpleFFT.fft(time, freq);
+	}
+	void fft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		simpleFFT.fft(inR, inI, outR, outI);
+	}
+
+	void ifft(const Complex *freq, Complex *time) {
+		simpleFFT.ifft(freq, time);
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		simpleFFT.ifft(inR, inI, outR, outI);
+	}
+
+private:
+	std::vector<Complex> tmp;
+	SimpleFFT<Sample> simpleFFT;
+};
+
+/// An FFT which can handle multiples of 3 and 5, and can be computed in chunks
+template<typename Sample, bool splitComputation=false>
+struct SplitFFT {
+	using Complex = std::complex<Sample>;
+	static constexpr bool prefersSplit = Pow2FFT<Sample>::prefersSplit;
+	
+	static constexpr size_t maxSplit = splitComputation ? 4 : 1;
+	static constexpr size_t minInnerSize = 32;
+	
+	static size_t fastSizeAbove(size_t size) {
+		size_t pow2 = 1;
+		while (pow2 < 16 && pow2 < size) pow2 *= 2;
+		while (pow2*8 < size) pow2 *= 2;
+		size_t multiple = (size + pow2 - 1)/pow2; // will be 1-8
+		if (multiple == 7) ++multiple;
+		return multiple*pow2;
+	}
+	
+	SplitFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		innerSize = 1;
+		outerSize = size;
+
+		dftTmp.resize(0);
+		dftTwists.resize(0);
+		plan.resize(0);
+		if (!size) return;
+		
+		// Inner size = largest power of 2 such that either the inner size >= minInnerSize, or we have the target number of splits
+		while (!(outerSize&1) && (outerSize > maxSplit || innerSize < minInnerSize)) {
+			innerSize *= 2;
+			outerSize /= 2;
+		}
+		tmpFreq.resize(size);
+		innerFFT.resize(innerSize);
+		
+		outerTwiddles.resize(innerSize*(outerSize - 1));
+		outerTwiddlesR.resize(innerSize*(outerSize - 1));
+		outerTwiddlesI.resize(innerSize*(outerSize - 1));
+		for (size_t i = 0; i < innerSize; ++i) {
+			for (size_t s = 1; s < outerSize; ++s) {
+				Sample twiddlePhase = Sample(-2*M_PI*i/innerSize*s/outerSize);
+				outerTwiddles[i + (s - 1)*innerSize] = std::polar(Sample(1), twiddlePhase);
+			}
+		}
+		for (size_t i = 0; i < outerTwiddles.size(); ++i) {
+			outerTwiddlesR[i] = outerTwiddles[i].real();
+			outerTwiddlesI[i] = outerTwiddles[i].imag();
+		}
+
+		StepType interleaveStep = StepType::interleaveOrderN;
+		StepType finalStep = StepType::finalOrderN;
+		if (outerSize == 2) {
+			interleaveStep = StepType::interleaveOrder2;
+			finalStep = StepType::finalOrder2;
+		}
+		if (outerSize == 3) {
+			interleaveStep = StepType::interleaveOrder3;
+			finalStep = StepType::finalOrder3;
+		}
+		if (outerSize == 4) {
+			interleaveStep = StepType::interleaveOrder4;
+			finalStep = StepType::finalOrder4;
+		}
+		if (outerSize == 5) {
+			interleaveStep = StepType::interleaveOrder5;
+			finalStep = StepType::finalOrder5;
+		}
+		
+		if (outerSize <= 1) {
+			if (size > 0) plan.push_back(Step{StepType::passthrough, 0});
+		} else {
+			plan.push_back({interleaveStep, 0});
+			plan.push_back({StepType::firstFFT, 0});
+			for (size_t s = 1; s < outerSize; ++s) {
+				plan.push_back({StepType::middleFFT, s*innerSize});
+			}
+			plan.push_back({StepType::twiddles, 0});
+			plan.push_back({finalStep, 0});
+
+			if (finalStep == StepType::finalOrderN) {
+				dftTmp.resize(outerSize);
+				dftTwists.resize(outerSize);
+				for (size_t s = 0; s < outerSize; ++s) {
+					Sample dftPhase = Sample(-2*M_PI*s/outerSize);
+					dftTwists[s] = std::polar(Sample(1), dftPhase);
+				}
+			}
+		}
+	}
+	
+	size_t size() const {
+		return innerSize*outerSize;
+	}
+	size_t steps() const {
+		return plan.size();
+	}
+	
+	void fft(const Complex *time, Complex *freq) {
+		for (auto &step : plan) {
+			fftStep<false>(step, time, freq);
+		}
+	}
+	void fft(size_t step, const Complex *time, Complex *freq) {
+		fftStep<false>(plan[step], time, freq);
+	}
+	void fft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		for (auto &step : plan) {
+			fftStep<false>(step, inR, inI, outR, outI);
+		}
+	}
+	void fft(size_t step, const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		fftStep<false>(plan[step], inR, inI, outR, outI);
+	}
+	
+	void ifft(const Complex *freq, Complex *time) {
+		for (auto &step : plan) {
+			fftStep<true>(step, freq, time);
+		}
+	}
+	void ifft(size_t step, const Complex *freq, Complex *time) {
+		fftStep<true>(plan[step], freq, time);
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		for (auto &step : plan) {
+			fftStep<true>(step, inR, inI, outR, outI);
+		}
+	}
+	void ifft(size_t step, const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		fftStep<true>(plan[step], inR, inI, outR, outI);
+	}
+private:
+	using InnerFFT = Pow2FFT<Sample>;
+	InnerFFT innerFFT;
+
+	size_t innerSize, outerSize;
+	std::vector<Complex> tmpFreq;
+	std::vector<Complex> outerTwiddles;
+	std::vector<Sample> outerTwiddlesR, outerTwiddlesI;
+	std::vector<Complex> dftTwists, dftTmp;
+
+	enum class StepType {
+		passthrough,
+		interleaveOrder2, interleaveOrder3, interleaveOrder4, interleaveOrder5, interleaveOrderN,
+		firstFFT, middleFFT,
+		twiddles,
+		finalOrder2, finalOrder3, finalOrder4, finalOrder5, finalOrderN
+	};
+	struct Step {
+		StepType type;
+		size_t offset;
+	};
+	std::vector<Step> plan;
+	
+	template<bool inverse>
+	void fftStep(Step step, const Complex *time, Complex *freq) {
+		switch (step.type) {
+			case (StepType::passthrough): {
+				if (inverse) {
+					innerFFT.ifft(time, freq);
+				} else {
+					innerFFT.fft(time, freq);
+				}
+				break;
+			}
+			case (StepType::interleaveOrder2): {
+				_impl::interleaveCopy<2>(time, tmpFreq.data(), innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder3): {
+				_impl::interleaveCopy<3>(time, tmpFreq.data(), innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder4): {
+				_impl::interleaveCopy<4>(time, tmpFreq.data(), innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder5): {
+				_impl::interleaveCopy<5>(time, tmpFreq.data(), innerSize);
+				break;
+			}
+			case (StepType::interleaveOrderN): {
+				_impl::interleaveCopy(time, tmpFreq.data(), outerSize, innerSize);
+				break;
+			}
+			case (StepType::firstFFT): {
+				if (inverse) {
+					innerFFT.ifft(tmpFreq.data(), freq);
+				} else {
+					innerFFT.fft(tmpFreq.data(), freq);
+				}
+				break;
+			}
+			case (StepType::middleFFT): {
+				Complex *offsetOut = freq + step.offset;
+				if (inverse) {
+					innerFFT.ifft(tmpFreq.data() + step.offset, offsetOut);
+				} else {
+					innerFFT.fft(tmpFreq.data() + step.offset, offsetOut);
+				}
+				break;
+			}
+			case (StepType::twiddles): {
+				if (inverse) {
+					_impl::complexMulConj(freq + innerSize, freq + innerSize, outerTwiddles.data(), innerSize*(outerSize - 1));
+				} else {
+					_impl::complexMul(freq + innerSize, freq + innerSize, outerTwiddles.data(), innerSize*(outerSize - 1));
+				}
+				break;
+			}
+			case StepType::finalOrder2:
+				finalPass2(freq);
+				break;
+			case StepType::finalOrder3:
+				finalPass3<inverse>(freq);
+				break;
+			case StepType::finalOrder4:
+				finalPass4<inverse>(freq);
+				break;
+			case StepType::finalOrder5:
+				finalPass5<inverse>(freq);
+				break;
+			case StepType::finalOrderN:
+				finalPassN<inverse>(freq);
+				break;
+		}
+	}
+	template<bool inverse>
+	void fftStep(Step step, const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		Sample *tmpR = (Sample *)tmpFreq.data(), *tmpI = tmpR + tmpFreq.size();
+		switch (step.type) {
+			case (StepType::passthrough): {
+				if (inverse) {
+					innerFFT.ifft(inR, inI, outR, outI);
+				} else {
+					innerFFT.fft(inR, inI, outR, outI);
+				}
+				break;
+			}
+			case (StepType::interleaveOrder2): {
+				_impl::interleaveCopy<2>(inR, tmpR, innerSize);
+				_impl::interleaveCopy<2>(inI, tmpI, innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder3): {
+				_impl::interleaveCopy<3>(inR, tmpR, innerSize);
+				_impl::interleaveCopy<3>(inI, tmpI, innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder4): {
+				_impl::interleaveCopy<4>(inR, tmpR, innerSize);
+				_impl::interleaveCopy<4>(inI, tmpI, innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder5): {
+				_impl::interleaveCopy<5>(inR, tmpR, innerSize);
+				_impl::interleaveCopy<5>(inI, tmpI, innerSize);
+				break;
+			}
+			case (StepType::interleaveOrderN): {
+				_impl::interleaveCopy(inR, inI, tmpR, tmpI, outerSize, innerSize);
+				break;
+			}
+			case (StepType::firstFFT): {
+				if (inverse) {
+					innerFFT.ifft(tmpR, tmpI, outR, outI);
+				} else {
+					innerFFT.fft(tmpR, tmpI, outR, outI);
+				}
+				break;
+			}
+			case (StepType::middleFFT): {
+				size_t offset = step.offset;
+				Sample *offsetOutR = outR + offset;
+				Sample *offsetOutI = outI + offset;
+				if (inverse) {
+					innerFFT.ifft(tmpR + offset, tmpI + offset, offsetOutR, offsetOutI);
+				} else {
+					innerFFT.fft(tmpR + offset, tmpI + offset, offsetOutR, offsetOutI);
+				}
+				break;
+			}
+			case(StepType::twiddles): {
+				auto *twiddlesR = outerTwiddlesR.data();
+				auto *twiddlesI = outerTwiddlesI.data();
+				if (inverse) {
+					_impl::complexMulConj(outR + innerSize, outI + innerSize, outR + innerSize, outI + innerSize, twiddlesR, twiddlesI, innerSize*(outerSize - 1));
+				} else {
+					_impl::complexMul(outR + innerSize, outI + innerSize, outR + innerSize, outI + innerSize, twiddlesR, twiddlesI, innerSize*(outerSize - 1));
+				}
+				break;
+			}
+			case StepType::finalOrder2:
+				finalPass2(outR, outI);
+				break;
+			case StepType::finalOrder3:
+				finalPass3<inverse>(outR, outI);
+				break;
+			case StepType::finalOrder4:
+				finalPass4<inverse>(outR, outI);
+				break;
+			case StepType::finalOrder5:
+				finalPass5<inverse>(outR, outI);
+				break;
+			case StepType::finalOrderN:
+				finalPassN<inverse>(outR, outI);
+				break;
+		}
+	}
+	
+	void finalPass2(Complex *f0) {
+		auto *f1 = f0 + innerSize;
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex a = f0[i], b = f1[i];
+			f0[i] = a + b;
+			f1[i] = a - b;
+		}
+	}
+	void finalPass2(Sample *f0r, Sample *f0i) {
+		auto *f1r = f0r + innerSize;
+		auto *f1i = f0i + innerSize;
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample ar = f0r[i], ai = f0i[i];
+			Sample br = f1r[i], bi = f1i[i];
+			f0r[i] = ar + br;
+			f0i[i] = ai + bi;
+			f1r[i] = ar - br;
+			f1i[i] = ai - bi;
+		}
+	}
+	template<bool inverse>
+	void finalPass3(Complex *f0) {
+		auto *f1 = f0 + innerSize;
+		auto *f2 = f0 + innerSize*2;
+		const Complex tw1{Sample(-0.5), Sample(-std::sqrt(0.75)*(inverse ? -1 : 1))};
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex a = f0[i], b = f1[i], c = f2[i];
+			Complex bc0 = b + c, bc1 = b - c;
+			f0[i] = a + bc0;
+			f1[i] = {
+				a.real() + bc0.real()*tw1.real() - bc1.imag()*tw1.imag(),
+				a.imag() + bc0.imag()*tw1.real() + bc1.real()*tw1.imag()
+			};
+			f2[i] = {
+				a.real() + bc0.real()*tw1.real() + bc1.imag()*tw1.imag(),
+				a.imag() + bc0.imag()*tw1.real() - bc1.real()*tw1.imag()
+			};
+		}
+	}
+	template<bool inverse>
+	void finalPass3(Sample *f0r, Sample *f0i) {
+		auto *f1r = f0r + innerSize;
+		auto *f1i = f0i + innerSize;
+		auto *f2r = f0r + innerSize*2;
+		auto *f2i = f0i + innerSize*2;
+		const Sample tw1r = -0.5, tw1i = -std::sqrt(0.75)*(inverse ? -1 : 1);
+		
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample ar = f0r[i], ai = f0i[i], br = f1r[i], bi = f1i[i], cr = f2r[i], ci = f2i[i];
+
+			f0r[i] = ar + br + cr;
+			f0i[i] = ai + bi + ci;
+			f1r[i] = ar + br*tw1r - bi*tw1i + cr*tw1r + ci*tw1i;
+			f1i[i] = ai + bi*tw1r + br*tw1i - cr*tw1i + ci*tw1r;
+			f2r[i] = ar + br*tw1r + bi*tw1i + cr*tw1r - ci*tw1i;
+			f2i[i] = ai + bi*tw1r - br*tw1i + cr*tw1i + ci*tw1r;
+		}
+	}
+	template<bool inverse>
+	void finalPass4(Complex *f0) {
+		auto *f1 = f0 + innerSize;
+		auto *f2 = f0 + innerSize*2;
+		auto *f3 = f0 + innerSize*3;
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex a = f0[i], b = f1[i], c = f2[i], d = f3[i];
+			
+			Complex ac0 = a + c, ac1 = a - c;
+			Complex bd0 = b + d, bd1 = inverse ? (b - d) : (d - b);
+			Complex bd1i = {-bd1.imag(), bd1.real()};
+			f0[i] = ac0 + bd0;
+			f1[i] = ac1 + bd1i;
+			f2[i] = ac0 - bd0;
+			f3[i] = ac1 - bd1i;
+		}
+	}
+	template<bool inverse>
+	void finalPass4(Sample *f0r, Sample *f0i) {
+		auto *f1r = f0r + innerSize;
+		auto *f1i = f0i + innerSize;
+		auto *f2r = f0r + innerSize*2;
+		auto *f2i = f0i + innerSize*2;
+		auto *f3r = f0r + innerSize*3;
+		auto *f3i = f0i + innerSize*3;
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample ar = f0r[i], ai = f0i[i], br = f1r[i], bi = f1i[i], cr = f2r[i], ci = f2i[i], dr = f3r[i], di = f3i[i];
+			
+			Sample ac0r = ar + cr, ac0i = ai + ci;
+			Sample ac1r = ar - cr, ac1i = ai - ci;
+			Sample bd0r = br + dr, bd0i = bi + di;
+			Sample bd1r = br - dr, bd1i = bi - di;
+			
+			f0r[i] = ac0r + bd0r;
+			f0i[i] = ac0i + bd0i;
+			f1r[i] = inverse ? (ac1r - bd1i) : (ac1r + bd1i);
+			f1i[i] = inverse ? (ac1i + bd1r) : (ac1i - bd1r);
+			f2r[i] = ac0r - bd0r;
+			f2i[i] = ac0i - bd0i;
+			f3r[i] = inverse ? (ac1r + bd1i) : (ac1r - bd1i);
+			f3i[i] = inverse ? (ac1i - bd1r) : (ac1i + bd1r);
+		}
+	}
+	template<bool inverse>
+	void finalPass5(Complex *f0) {
+		auto *f1 = f0 + innerSize;
+		auto *f2 = f0 + innerSize*2;
+		auto *f3 = f0 + innerSize*3;
+		auto *f4 = f0 + innerSize*4;
+		const Sample tw1r = 0.30901699437494745;
+		const Sample tw1i = -0.9510565162951535*(inverse ? -1 : 1);
+		const Sample tw2r = -0.8090169943749473;
+		const Sample tw2i = -0.5877852522924732*(inverse ? -1 : 1);
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex a = f0[i], b = f1[i], c = f2[i], d = f3[i], e = f4[i];
+
+			Complex be0 = b + e, be1 = {e.imag() - b.imag(), b.real() - e.real()}; // (b - e)*i
+			Complex cd0 = c + d, cd1 = {d.imag() - c.imag(), c.real() - d.real()};
+			
+			Complex bcde01 = be0*tw1r + cd0*tw2r;
+			Complex bcde02 = be0*tw2r + cd0*tw1r;
+			Complex bcde11 = be1*tw1i + cd1*tw2i;
+			Complex bcde12 = be1*tw2i - cd1*tw1i;
+
+			f0[i] = a + be0 + cd0;
+			f1[i] = a + bcde01 + bcde11;
+			f2[i] = a + bcde02 + bcde12;
+			f3[i] = a + bcde02 - bcde12;
+			f4[i] = a + bcde01 - bcde11;
+		}
+	}
+	template<bool inverse>
+	void finalPass5(Sample *f0r, Sample *f0i) {
+		auto *f1r = f0r + innerSize;
+		auto *f1i = f0i + innerSize;
+		auto *f2r = f0r + innerSize*2;
+		auto *f2i = f0i + innerSize*2;
+		auto *f3r = f0r + innerSize*3;
+		auto *f3i = f0i + innerSize*3;
+		auto *f4r = f0r + innerSize*4;
+		auto *f4i = f0i + innerSize*4;
+		
+		const Sample tw1r = 0.30901699437494745;
+		const Sample tw1i = -0.9510565162951535*(inverse ? -1 : 1);
+		const Sample tw2r = -0.8090169943749473;
+		const Sample tw2i = -0.5877852522924732*(inverse ? -1 : 1);
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample ar = f0r[i], ai = f0i[i], br = f1r[i], bi = f1i[i], cr = f2r[i], ci = f2i[i], dr = f3r[i], di = f3i[i], er = f4r[i], ei = f4i[i];
+
+			Sample be0r = br + er, be0i = bi + ei;
+			Sample be1r = ei - bi, be1i = br - er;
+			Sample cd0r = cr + dr, cd0i = ci + di;
+			Sample cd1r = di - ci, cd1i = cr - dr;
+
+			Sample bcde01r = be0r*tw1r + cd0r*tw2r, bcde01i = be0i*tw1r + cd0i*tw2r;
+			Sample bcde02r = be0r*tw2r + cd0r*tw1r, bcde02i = be0i*tw2r + cd0i*tw1r;
+			Sample bcde11r = be1r*tw1i + cd1r*tw2i, bcde11i = be1i*tw1i + cd1i*tw2i;
+			Sample bcde12r = be1r*tw2i - cd1r*tw1i, bcde12i = be1i*tw2i - cd1i*tw1i;
+
+			f0r[i] = ar + be0r + cd0r;
+			f0i[i] = ai + be0i + cd0i;
+			f1r[i] = ar + bcde01r + bcde11r;
+			f1i[i] = ai + bcde01i + bcde11i;
+			f2r[i] = ar + bcde02r + bcde12r;
+			f2i[i] = ai + bcde02i + bcde12i;
+			f3r[i] = ar + bcde02r - bcde12r;
+			f3i[i] = ai + bcde02i - bcde12i;
+			f4r[i] = ar + bcde01r - bcde11r;
+			f4i[i] = ai + bcde01i - bcde11i;
+		}
+	}
+
+	template<bool inverse>
+	void finalPassN(Complex *f0) {
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex *offsetFreq = f0 + i;
+			Complex sum = 0;
+			for (size_t i2 = 0; i2 < outerSize; ++i2) {
+				sum += (dftTmp[i2] = offsetFreq[i2*innerSize]);
+			}
+			offsetFreq[0] = sum;
+			
+			for (size_t f = 1; f < outerSize; ++f) {
+				Complex sum = dftTmp[0];
+
+				for (size_t i2 = 1; i2 < outerSize; ++i2) {
+					size_t twistIndex = (i2*f)%outerSize;
+					Complex twist = inverse ? std::conj(dftTwists[twistIndex]) : dftTwists[twistIndex];
+					sum += Complex{
+						dftTmp[i2].real()*twist.real() - dftTmp[i2].imag()*twist.imag(),
+						dftTmp[i2].imag()*twist.real() + dftTmp[i2].real()*twist.imag()
+					};
+				}
+
+				offsetFreq[f*innerSize] = sum;
+			}
+		}
+	}
+	template<bool inverse>
+	void finalPassN(Sample *f0r, Sample *f0i) {
+		Sample *tmpR = (Sample *)dftTmp.data(), *tmpI = tmpR + outerSize;
+		
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample *offsetR = f0r + i;
+			Sample *offsetI = f0i + i;
+			Sample sumR = 0, sumI = 0;
+			for (size_t i2 = 0; i2 < outerSize; ++i2) {
+				sumR += (tmpR[i2] = offsetR[i2*innerSize]);
+				sumI += (tmpI[i2] = offsetI[i2*innerSize]);
+			}
+			offsetR[0] = sumR;
+			offsetI[0] = sumI;
+			
+			for (size_t f = 1; f < outerSize; ++f) {
+				Sample sumR = *tmpR, sumI = *tmpI;
+
+				for (size_t i2 = 1; i2 < outerSize; ++i2) {
+					size_t twistIndex = (i2*f)%outerSize;
+					Complex twist = inverse ? std::conj(dftTwists[twistIndex]) : dftTwists[twistIndex];
+					sumR += tmpR[i2]*twist.real() - tmpI[i2]*twist.imag();
+					sumI += tmpI[i2]*twist.real() + tmpR[i2]*twist.imag();
+				}
+
+				offsetR[f*innerSize] = sumR;
+				offsetI[f*innerSize] = sumI;
+			}
+		}
+	}
+};
+
+template<typename Sample, bool splitComputation=false>
+using FFT = SplitFFT<Sample, splitComputation>;
+
+// Wraps a complex FFT into a real one
+template<typename Sample, class ComplexFFT=Pow2FFT<Sample>>
+struct SimpleRealFFT {
+	using Complex = std::complex<Sample>;
+	
+	static constexpr bool prefersSplit = ComplexFFT::prefersSplit;
+
+	SimpleRealFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		complexFft.resize(size);
+		tmpTime.resize(size);
+		tmpFreq.resize(size);
+	}
+	
+	void fft(const Sample *time, Complex *freq) {
+		for (size_t i = 0; i < tmpTime.size(); ++i) {
+			tmpTime[i] = time[i];
+		}
+		complexFft.fft(tmpTime.data(), tmpFreq.data());
+		for (size_t i = 0; i < tmpFreq.size()/2; ++i) {
+			freq[i] = tmpFreq[i];
+		}
+		freq[0] = {
+			tmpFreq[0].real(),
+			tmpFreq[tmpFreq.size()/2].real()
+		};
+	}
+	void fft(const Sample *inR, Sample *outR, Sample *outI) {
+		Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + tmpFreq.size();
+		for (size_t i = 0; i < tmpTime.size()/2; ++i) {
+			tmpTime[i] = 0;
+		}
+		complexFft.fft(inR, (const Sample *)tmpTime.data(), tmpFreqR, tmpFreqI);
+		for (size_t i = 0; i < tmpTime.size()/2; ++i) {
+			outR[i] = tmpFreqR[i];
+			outI[i] = tmpFreqI[i];
+		}
+		outI[0] = tmpFreqR[tmpFreq.size()/2];
+	}
+
+	void ifft(const Complex *freq, Sample *time) {
+		tmpFreq[0] = freq[0].real();
+		tmpFreq[tmpFreq.size()/2] = freq[0].imag();
+		for (size_t i = 1; i < tmpFreq.size()/2; ++i) {
+			tmpFreq[i] = freq[i];
+			tmpFreq[tmpFreq.size() - i] = std::conj(freq[i]);
+		}
+		complexFft.ifft(tmpFreq.data(), tmpTime.data());
+		for (size_t i = 0; i < tmpTime.size(); ++i) {
+			time[i] = tmpTime[i].real();
+		}
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR) {
+		Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + tmpFreq.size();
+		tmpFreqR[0] = inR[0];
+		tmpFreqR[tmpFreq.size()/2] = inI[0];
+		tmpFreqI[0] = 0;
+		tmpFreqI[tmpFreq.size()/2] = 0;
+		for (size_t i = 1; i < tmpFreq.size()/2; ++i) {
+			tmpFreqR[i] = inR[i];
+			tmpFreqI[i] = inI[i];
+			tmpFreqR[tmpFreq.size() - i] = inR[i];
+			tmpFreqI[tmpFreq.size() - i] = -inI[i];
+		}
+		complexFft.ifft(tmpFreqR, tmpFreqI, outR, (Sample *)tmpTime.data());
+	}
+
+private:
+	ComplexFFT complexFft;
+	std::vector<Complex> tmpTime, tmpFreq;
+};
+
+/// A default power-of-2 FFT, specialised with platform-specific fast implementations where available
+template<typename Sample>
+struct Pow2RealFFT : public SimpleRealFFT<Sample> {
+	static constexpr bool prefersSplit = SimpleRealFFT<Sample>::prefersSplit;
+	
+	using SimpleRealFFT<Sample>::SimpleRealFFT;
+
+	// Prevent copying, since it might be a problem for specialisations
+	Pow2RealFFT(const Pow2RealFFT &other) = delete;
+	// Pass move-constructor through, just to be explicit about it
+	Pow2RealFFT(Pow2RealFFT &&other) : SimpleRealFFT<Sample>(std::move(other)) {}
+};
+
+/// A Real FFT which can handle multiples of 3 and 5, and can be computed in chunks
+template<typename Sample, bool splitComputation=false, bool halfBinShift=false>
+struct RealFFT {
+	using Complex = std::complex<Sample>;
+	static constexpr bool prefersSplit = SplitFFT<Sample, splitComputation>::prefersSplit;
+
+	static size_t fastSizeAbove(size_t size) {
+		return ComplexFFT::fastSizeAbove((size + 1)/2)*2;
+	}
+	
+	RealFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		size_t hSize = size/2;
+		complexFft.resize(hSize);
+		tmpFreq.resize(hSize);
+		tmpTime.resize(hSize);
+		
+		twiddles.resize(hSize/2 + 1);
+		
+		if (!halfBinShift) {
+			for (size_t i = 0; i < twiddles.size(); ++i) {
+				Sample rotPhase = i*(-2*M_PI/size) - M_PI/2; // bake rotation by (-i) into twiddles
+				twiddles[i] = std::polar(Sample(1), rotPhase);
+			}
+		} else {
+			for (size_t i = 0; i < twiddles.size(); ++i) {
+				Sample rotPhase = (i + 0.5)*(-2*M_PI/size) - M_PI/2;
+				twiddles[i] = std::polar(Sample(1), rotPhase);
+			}
+	
+			halfBinTwists.resize(hSize);
+			for (size_t i = 0; i < hSize; ++i) {
+				Sample twistPhase = -2*M_PI*i/size;
+				halfBinTwists[i] = std::polar(Sample(1), twistPhase);
+			}
+		}
+	}
+	
+	size_t size() const {
+		return complexFft.size()*2;
+	}
+	size_t steps() const {
+		return complexFft.steps() + (splitComputation ? 3 : 2);
+	}
+	
+	void fft(const Sample *time, Complex *freq) {
+		for (size_t s = 0; s < steps(); ++s) {
+			fft(s, time, freq);
+		}
+	}
+	void fft(size_t step, const Sample *time, Complex *freq) {
+		if (complexPrefersSplit) {
+			size_t hSize = complexFft.size();
+			Sample *tmpTimeR = (Sample *)tmpTime.data(), *tmpTimeI = tmpTimeR + hSize;
+			Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + hSize;
+			if (step-- == 0) {
+				size_t hSize = complexFft.size();
+				if (halfBinShift) {
+					for (size_t i = 0; i < hSize; ++i) {
+						Sample tr = time[2*i], ti = time[2*i + 1];
+						Complex twist = halfBinTwists[i];
+						tmpTimeR[i] = tr*twist.real() - ti*twist.imag();
+						tmpTimeI[i] = ti*twist.real() + tr*twist.imag();
+					}
+				} else {
+					for (size_t i = 0; i < hSize; ++i) {
+						tmpTimeR[i] = time[2*i];
+						tmpTimeI[i] = time[2*i + 1];
+					}
+				}
+			} else if (step < complexFft.steps()) {
+				complexFft.fft(step, tmpTimeR, tmpTimeI, tmpFreqR, tmpFreqI);
+			} else {
+				if (!halfBinShift) {
+					Sample bin0r = tmpFreqR[0], bin0i = tmpFreqI[0];
+					freq[0] = {bin0r + bin0i, bin0r - bin0i};
+				}
+
+				size_t startI = halfBinShift ? 0 : 1;
+				size_t endI = hSize/2 + 1;
+				if (splitComputation) { // Do this last twiddle in two halves
+					if (step == complexFft.steps()) {
+						endI = (startI + endI)/2;
+					} else {
+						startI = (startI + endI)/2;
+					}
+				}
+				for (size_t i = startI; i < endI; ++i) {
+					size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+					Complex twiddle = twiddles[i];
+
+					Sample oddR = (tmpFreqR[i] + tmpFreqR[conjI])*Sample(0.5);
+					Sample oddI = (tmpFreqI[i] - tmpFreqI[conjI])*Sample(0.5);
+					Sample evenIR = (tmpFreqR[i] - tmpFreqR[conjI])*Sample(0.5);
+					Sample evenII = (tmpFreqI[i] + tmpFreqI[conjI])*Sample(0.5);
+					Sample evenRotMinusIR = evenIR*twiddle.real() - evenII*twiddle.imag();
+					Sample evenRotMinusII = evenII*twiddle.real() + evenIR*twiddle.imag();
+
+					freq[i] = {oddR + evenRotMinusIR, oddI + evenRotMinusII};
+					freq[conjI] = {oddR - evenRotMinusIR, evenRotMinusII - oddI};
+				}
+			}
+		} else {
+			bool canUseTime = !halfBinShift && !(size_t(time)%alignof(Complex));
+			if (step-- == 0) {
+				size_t hSize = complexFft.size();
+				if (halfBinShift) {
+					for (size_t i = 0; i < hSize; ++i) {
+						Sample tr = time[2*i], ti = time[2*i + 1];
+						Complex twist = halfBinTwists[i];
+						tmpTime[i] = {
+							tr*twist.real() - ti*twist.imag(),
+							ti*twist.real() + tr*twist.imag()
+						};
+					}
+				} else if (!canUseTime) {
+					std::memcpy(static_cast<void *>(tmpTime.data()), static_cast<const void *>(time), sizeof(Complex)*hSize);
+				}
+			} else if (step < complexFft.steps()) {
+				complexFft.fft(step, canUseTime ? (const Complex *)time : tmpTime.data(), tmpFreq.data());
+			} else {
+				if (!halfBinShift) {
+					Complex bin0 = tmpFreq[0];
+					freq[0] = { // pack DC & Nyquist together
+						bin0.real() + bin0.imag(),
+						bin0.real() - bin0.imag()
+					};
+				}
+				
+				size_t hSize = complexFft.size();
+				size_t startI = halfBinShift ? 0 : 1;
+				size_t endI = hSize/2 + 1;
+				if (splitComputation) { // Do this last twiddle in two halves
+					if (step == complexFft.steps()) {
+						endI = (startI + endI)/2;
+					} else {
+						startI = (startI + endI)/2;
+					}
+				}
+				for (size_t i = startI; i < endI; ++i) {
+					size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+					Complex twiddle = twiddles[i];
+
+					Complex odd = (tmpFreq[i] + std::conj(tmpFreq[conjI]))*Sample(0.5);
+					Complex evenI = (tmpFreq[i] - std::conj(tmpFreq[conjI]))*Sample(0.5);
+					Complex evenRotMinusI = { // twiddle includes a factor of -i
+						evenI.real()*twiddle.real() - evenI.imag()*twiddle.imag(),
+						evenI.imag()*twiddle.real() + evenI.real()*twiddle.imag()
+					};
+
+					freq[i] = odd + evenRotMinusI;
+					freq[conjI] = {odd.real() - evenRotMinusI.real(), evenRotMinusI.imag() - odd.imag()};
+				}
+			}
+		}
+	}
+	void fft(const Sample *inR, Sample *outR, Sample *outI) {
+		for (size_t s = 0; s < steps(); ++s) {
+			fft(s, inR, outR, outI);
+		}
+	}
+	void fft(size_t step, const Sample *inR, Sample *outR, Sample *outI) {
+		size_t hSize = complexFft.size();
+		Sample *tmpTimeR = (Sample *)tmpTime.data(), *tmpTimeI = tmpTimeR + hSize;
+		Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + hSize;
+		if (step-- == 0) {
+			size_t hSize = complexFft.size();
+			if (halfBinShift) {
+				for (size_t i = 0; i < hSize; ++i) {
+					Sample tr = inR[2*i], ti = inR[2*i + 1];
+					Complex twist = halfBinTwists[i];
+					tmpTimeR[i] = tr*twist.real() - ti*twist.imag();
+					tmpTimeI[i] = ti*twist.real() + tr*twist.imag();
+				}
+			} else {
+				for (size_t i = 0; i < hSize; ++i) {
+					tmpTimeR[i] = inR[2*i];
+					tmpTimeI[i] = inR[2*i + 1];
+				}
+			}
+		} else if (step < complexFft.steps()) {
+			complexFft.fft(step, tmpTimeR, tmpTimeI, tmpFreqR, tmpFreqI);
+		} else {
+			if (!halfBinShift) {
+				Sample bin0r = tmpFreqR[0], bin0i = tmpFreqI[0];
+				outR[0] = bin0r + bin0i;
+				outI[0] = bin0r - bin0i;
+			}
+
+			size_t startI = halfBinShift ? 0 : 1;
+			size_t endI = hSize/2 + 1;
+			if (splitComputation) { // Do this last twiddle in two halves
+				if (step == complexFft.steps()) {
+					endI = (startI + endI)/2;
+				} else {
+					startI = (startI + endI)/2;
+				}
+			}
+			for (size_t i = startI; i < endI; ++i) {
+				size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+				Complex twiddle = twiddles[i];
+
+				Sample oddR = (tmpFreqR[i] + tmpFreqR[conjI])*Sample(0.5);
+				Sample oddI = (tmpFreqI[i] - tmpFreqI[conjI])*Sample(0.5);
+				Sample evenIR = (tmpFreqR[i] - tmpFreqR[conjI])*Sample(0.5);
+				Sample evenII = (tmpFreqI[i] + tmpFreqI[conjI])*Sample(0.5);
+				Sample evenRotMinusIR = evenIR*twiddle.real() - evenII*twiddle.imag();
+				Sample evenRotMinusII = evenII*twiddle.real() + evenIR*twiddle.imag();
+
+				outR[i] = oddR + evenRotMinusIR;
+				outI[i] = oddI + evenRotMinusII;
+				outR[conjI] = oddR - evenRotMinusIR;
+				outI[conjI] = evenRotMinusII - oddI;
+			}
+		}
+	}
+	
+	void ifft(const Complex *freq, Sample *time) {
+		for (size_t s = 0; s < steps(); ++s) {
+			ifft(s, freq, time);
+		}
+	}
+	void ifft(size_t step, const Complex *freq, Sample *time) {
+		if (complexPrefersSplit) {
+			size_t hSize = complexFft.size();
+			Sample *tmpTimeR = (Sample *)tmpTime.data(), *tmpTimeI = tmpTimeR + hSize;
+			Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + hSize;
+
+			bool splitFirst = splitComputation && (step-- == 0);
+			if (splitFirst || step-- == 0) {
+				Complex bin0 = freq[0];
+				if (!halfBinShift) {
+					tmpFreqR[0] = bin0.real() + bin0.imag();
+					tmpFreqI[0] = bin0.real() - bin0.imag();
+				}
+				size_t startI = halfBinShift ? 0 : 1;
+				size_t endI = hSize/2 + 1;
+				if (splitComputation) { // Do this first twiddle in two halves
+					if (splitFirst) {
+						endI = (startI + endI)/2;
+					} else {
+						startI = (startI + endI)/2;
+					}
+				}
+				for (size_t i = startI; i < endI; ++i) {
+					size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+					Complex twiddle = twiddles[i];
+
+					Complex odd = freq[i] + std::conj(freq[conjI]);
+					Complex evenRotMinusI = freq[i] - std::conj(freq[conjI]);
+					Complex evenI = { // Conjugate twiddle
+						evenRotMinusI.real()*twiddle.real() + evenRotMinusI.imag()*twiddle.imag(),
+						evenRotMinusI.imag()*twiddle.real() - evenRotMinusI.real()*twiddle.imag()
+					};
+
+					tmpFreqR[i] = odd.real() + evenI.real();
+					tmpFreqI[i] = odd.imag() + evenI.imag();
+					tmpFreqR[conjI] = odd.real() - evenI.real();
+					tmpFreqI[conjI] = evenI.imag() - odd.imag();
+				}
+			} else if (step < complexFft.steps()) {
+				complexFft.ifft(step, tmpFreqR, tmpFreqI, tmpTimeR, tmpTimeI);
+			} else {
+				size_t hSize = complexFft.size();
+				if (halfBinShift) {
+					for (size_t i = 0; i < hSize; ++i) {
+						Sample tr = tmpTimeR[i], ti = tmpTimeI[i];
+						Complex twist = halfBinTwists[i];
+						time[2*i] = 	tr*twist.real() + ti*twist.imag();
+						time[2*i + 1] = ti*twist.real() - tr*twist.imag();
+					}
+				} else {
+					for (size_t i = 0; i < hSize; ++i) {
+						time[2*i] = tmpTimeR[i];
+						time[2*i + 1] = tmpTimeI[i];
+					}
+				}
+			}
+		} else {
+			bool canUseTime = !halfBinShift && !(size_t(time)%alignof(Complex));
+			bool splitFirst = splitComputation && (step-- == 0);
+			if (splitFirst || step-- == 0) {
+				Complex bin0 = freq[0];
+				if (!halfBinShift) {
+					tmpFreq[0] = {
+						bin0.real() + bin0.imag(),
+						bin0.real() - bin0.imag()
+					};
+				}
+				size_t hSize = complexFft.size();
+				size_t startI = halfBinShift ? 0 : 1;
+				size_t endI = hSize/2 + 1;
+				if (splitComputation) { // Do this first twiddle in two halves
+					if (splitFirst) {
+						endI = (startI + endI)/2;
+					} else {
+						startI = (startI + endI)/2;
+					}
+				}
+				for (size_t i = startI; i < endI; ++i) {
+					size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+					Complex twiddle = twiddles[i];
+
+					Complex odd = freq[i] + std::conj(freq[conjI]);
+					Complex evenRotMinusI = freq[i] - std::conj(freq[conjI]);
+					Complex evenI = { // Conjugate twiddle
+						evenRotMinusI.real()*twiddle.real() + evenRotMinusI.imag()*twiddle.imag(),
+						evenRotMinusI.imag()*twiddle.real() - evenRotMinusI.real()*twiddle.imag()
+					};
+
+					tmpFreq[i] = odd + evenI;
+					tmpFreq[conjI] = {odd.real() - evenI.real(), evenI.imag() - odd.imag()};
+				}
+			} else if (step < complexFft.steps()) {
+				// Can't just use time as (Complex *), since it might not be aligned properly
+				complexFft.ifft(step, tmpFreq.data(), canUseTime ? (Complex *)time : tmpTime.data());
+			} else {
+				size_t hSize = complexFft.size();
+				if (halfBinShift) {
+					for (size_t i = 0; i < hSize; ++i) {
+						Complex t = tmpTime[i];
+						Complex twist = halfBinTwists[i];
+						time[2*i] = 	t.real()*twist.real() + t.imag()*twist.imag();
+						time[2*i + 1] = t.imag()*twist.real() - t.real()*twist.imag();
+					}
+				} else if (!canUseTime) {
+					std::memcpy(static_cast<void *>(time), static_cast<const void *>(tmpTime.data()), sizeof(Complex)*hSize);
+				}
+			}
+		}
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR) {
+		for (size_t s = 0; s < steps(); ++s) {
+			ifft(s, inR, inI, outR);
+		}
+	}
+	void ifft(size_t step, const Sample *inR, const Sample *inI, Sample *outR) {
+		size_t hSize = complexFft.size();
+		Sample *tmpTimeR = (Sample *)tmpTime.data(), *tmpTimeI = tmpTimeR + hSize;
+		Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + hSize;
+
+		bool splitFirst = splitComputation && (step-- == 0);
+		if (splitFirst || step-- == 0) {
+			Sample bin0r = inR[0], bin0i = inI[0];
+			if (!halfBinShift) {
+				tmpFreqR[0] = bin0r + bin0i;
+				tmpFreqI[0] = bin0r - bin0i;
+			}
+			size_t startI = halfBinShift ? 0 : 1;
+			size_t endI = hSize/2 + 1;
+			if (splitComputation) { // Do this first twiddle in two halves
+				if (splitFirst) {
+					endI = (startI + endI)/2;
+				} else {
+					startI = (startI + endI)/2;
+				}
+			}
+			for (size_t i = startI; i < endI; ++i) {
+				size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+				Complex twiddle = twiddles[i];
+				Sample fir = inR[i], fii = inI[i];
+				Sample fcir = inR[conjI], fcii = inI[conjI];
+
+				Complex odd = {fir + fcir, fii - fcii};
+				Complex evenRotMinusI = {fir - fcir, fii + fcii};
+				Complex evenI = { // Conjugate twiddle
+					evenRotMinusI.real()*twiddle.real() + evenRotMinusI.imag()*twiddle.imag(),
+					evenRotMinusI.imag()*twiddle.real() - evenRotMinusI.real()*twiddle.imag()
+				};
+
+				tmpFreqR[i] = odd.real() + evenI.real();
+				tmpFreqI[i] = odd.imag() + evenI.imag();
+				tmpFreqR[conjI] = odd.real() - evenI.real();
+				tmpFreqI[conjI] = evenI.imag() - odd.imag();
+			}
+		} else if (step < complexFft.steps()) {
+			// Can't just use time as (Complex *), since it might not be aligned properly
+			complexFft.ifft(step, tmpFreqR, tmpFreqI, tmpTimeR, tmpTimeI);
+		} else {
+			if (halfBinShift) {
+				for (size_t i = 0; i < hSize; ++i) {
+					Sample tr = tmpTimeR[i], ti = tmpTimeI[i];
+					Complex twist = halfBinTwists[i];
+					outR[2*i] = 	tr*twist.real() + ti*twist.imag();
+					outR[2*i + 1] = ti*twist.real() - tr*twist.imag();
+				}
+			} else {
+				for (size_t i = 0; i < hSize; ++i) {
+					outR[2*i] = tmpTimeR[i];
+					outR[2*i + 1] = tmpTimeI[i];
+				}
+			}
+		}
+	}
+private:
+	using ComplexFFT = SplitFFT<Sample, splitComputation>;
+	ComplexFFT complexFft;
+
+	static constexpr bool complexPrefersSplit = ComplexFFT::prefersSplit;
+	std::vector<Complex> tmpFreq, tmpTime;
+	std::vector<Complex> twiddles, halfBinTwists;
+};
+
+template<typename Sample, bool splitComputation=false>
+using ModifiedRealFFT = RealFFT<Sample, splitComputation, true>;
+
+}} // namespace
+
+// Override `Pow2FFT` / `Pow2RealFFT` templates with faster implementations
+#if defined(SIGNALSMITH_USE_PFFFT) || defined(SIGNALSMITH_USE_PFFFT_DOUBLE)
+#	if defined(SIGNALSMITH_USE_PFFFT)
+#		include "./platform/fft-pffft.h"
+#	endif
+#	if defined(SIGNALSMITH_USE_PFFFT_DOUBLE)
+#		include "./platform/fft-pffft-double.h"
+#	endif
+#elif defined(SIGNALSMITH_USE_ACCELERATE)
+#	include "./platform/fft-accelerate.h"
+#elif defined(SIGNALSMITH_USE_IPP)
+#	include "./platform/fft-ipp.h"
+#elif defined(SIGNALSMITH_USE_CMSISDSP)
+#	include "./platform/fft-cmsisdsp.h"
+#elif defined(SIGNALSMITH_USE_XSIMD)
+//	This is the same as the basic one
+#	include "./platform/fft-linear.h"
+#endif
+
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/linear.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/linear.h
@@ -1,0 +1,1122 @@
+#ifndef SIGNALSMITH_AUDIO_LINEAR_H
+#define SIGNALSMITH_AUDIO_LINEAR_H
+
+#if defined(__FAST_MATH__) && (__apple_build_version__ >= 16000000) && (__apple_build_version__ <= 16000099) && !defined(SIGNALSMITH_IGNORE_BROKEN_APPLECLANG)
+#	error Apple Clang 16.0.0 generates incorrect SIMD for ARM. If you HAVE to use this version of Clang, turn off -ffast-math.
+#endif
+
+#if defined(_MSC_VER)
+// MSVC can misreport is_trivially_copyable for CRTP bases; approximate intent.
+#	define SIGNALSMITH_IS_TRIVIALLY_COPYABLE(T) (std::is_trivially_copy_constructible<T>::value && std::is_trivially_destructible<T>::value)
+#else
+#	define SIGNALSMITH_IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
+#endif
+
+#ifndef M_PI
+#	define M_PI 3.14159265358979323846
+#endif
+
+#include <cmath>
+#include <cassert>
+#include <complex>
+#include <array>
+#include <vector>
+#include <type_traits>
+#include <functional>
+#include <random>
+
+#ifdef SIGNALSMITH_LOG_WARNINGS
+#	include <iostream>
+#endif
+
+namespace signalsmith { namespace linear {
+
+template<typename V>
+using ConstRealPointer = const V *;
+template<typename V>
+using RealPointer = V *;
+
+template<typename V>
+using ConstComplexPointer = const std::complex<V> *;
+template<typename V>
+using ComplexPointer = std::complex<V> *;
+
+template<typename V>
+struct ConstSplitPointer {
+	ConstRealPointer<V> real, imag;
+	ConstSplitPointer(ConstRealPointer<V> real, ConstRealPointer<V> imag) : real(real), imag(imag) {}
+
+	// Array-like access for convenience
+	const std::complex<V> operator[](std::ptrdiff_t i) const {
+		return {real[i], imag[i]};
+	}
+};
+
+template<typename V>
+struct SplitPointer {
+	using Complex = std::complex<V>;
+
+	RealPointer<V> real, imag;
+	SplitPointer(RealPointer<V> real, RealPointer<V> imag) : real(real), imag(imag) {}
+	operator ConstSplitPointer<V>() const {
+		return {real, imag};
+	}
+
+	// Array-like access for convenience
+	const Complex operator[](std::ptrdiff_t i) const {
+		return {real[i], imag[i]};
+	}
+	
+	// Assignable (if not const) and converts to `std::complex<V>`
+	struct Value : public Complex {
+		Value(V &_real, V &_imag) : Complex(_real, _imag),  _real(_real), _imag(_imag) {}
+	
+		V real() const {
+			return _real;
+		}
+		void real(V v) {
+			_real = v;
+			Complex::real(v);
+		}
+		V imag() const {
+			return _imag;
+		}
+		void imag(V v) {
+			_imag = v;
+			Complex::imag(v);
+		}
+
+#define LINEAR_SPLIT_POINTER_ASSIGNMENT_OP(OP) \
+		Value & operator OP(const std::complex<V> &other) { \
+			std::complex<V>::operator OP(other); \
+			_real = Complex::real(); \
+			_imag = Complex::imag(); \
+			return *this; \
+		}
+		LINEAR_SPLIT_POINTER_ASSIGNMENT_OP(=);
+		LINEAR_SPLIT_POINTER_ASSIGNMENT_OP(+=);
+		LINEAR_SPLIT_POINTER_ASSIGNMENT_OP(-=);
+		LINEAR_SPLIT_POINTER_ASSIGNMENT_OP(*=);
+		LINEAR_SPLIT_POINTER_ASSIGNMENT_OP(/=);
+#undef LINEAR_SPLIT_POINTER_ASSIGNMENT_OP
+
+	private:
+		V &_real;
+		V &_imag;
+	};
+
+	Value operator[](std::ptrdiff_t i) {
+		return {real[i], imag[i]};
+	}
+};
+
+template<bool=true>
+struct LinearImpl;
+using Linear = LinearImpl<true>;
+
+// Everything we deal with is actually one of these
+template<class BaseExpr>
+struct Expression;
+template<class BaseExpr>
+struct WritableExpression;
+
+#define EXPRESSION_NAME(Class, nameExpr) \
+	static std::string name() {\
+		return nameExpr; \
+	}
+
+// Expression templates, which always hold const pointers
+namespace expression {
+	// All base Exprs inherit from this, so we can SFINAE-test for them
+	struct Base {};
+	inline void mustBeExpr(const Base &) {}
+
+	struct BaseUnary : public Base {};
+	struct BaseBinary : public Base {};
+	struct BasePointer : public Base {};
+	struct BaseConstant : public Base {};
+
+	template<typename V>
+	struct ConstantExpr : public BaseConstant {
+		EXPRESSION_NAME(Constant, "V");
+		using Unwrapped = ConstantExpr;
+		V value;
+
+		static_assert(SIGNALSMITH_IS_TRIVIALLY_COPYABLE(V), "ConstantExpr<V> values must be trivially copyable");
+
+		ConstantExpr(V value) : value(value) {}
+		
+		const V get(std::ptrdiff_t) const {
+			return value;
+		}
+	};
+	
+	template<typename V>
+	using Arithmetic = decltype(std::declval<V>() + std::declval<V>());
+
+	// If the constant is one of our assignable complex proxies, use the basic one instead
+	template<>
+	struct ConstantExpr<typename SplitPointer<float>::Value> : public ConstantExpr<std::complex<float>> {
+		using ConstantExpr<std::complex<float>>::ConstantExpr;
+	};
+	template<>
+	struct ConstantExpr<typename SplitPointer<double>::Value> : public ConstantExpr<std::complex<double>> {
+		using ConstantExpr<std::complex<double>>::ConstantExpr;
+	};
+
+	template<class V, typename=void>
+	struct ExprTest {
+		using Constant = ConstantExpr<Arithmetic<V>>;
+
+		static_assert(SIGNALSMITH_IS_TRIVIALLY_COPYABLE(Constant), "ConstantExpr<V> must be trivially copyable");
+
+		static Constant wrap(const V &v) {
+			return {v};
+		}
+	};
+	template<class Expr>
+	struct ExprTest<Expr, decltype(mustBeExpr(std::declval<Expr>()))> {
+		static Expr wrap(const Expr &expr) {
+			return expr;
+		}
+	};
+	// Constant class, only defined for non-Expr types
+	template<class Expr>
+	using Constant = typename ExprTest<Expr>::Constant;
+	
+	template<class Expr>
+	auto ensureExpr(const Expr &expr) -> decltype(ExprTest<Expr>::wrap(expr)) {
+		return ExprTest<Expr>::wrap(expr);
+	};
+
+	// Expressions that just read from a pointer
+	template<typename V>
+	struct ReadableReal : public BasePointer {
+		EXPRESSION_NAME(ReadableReal, "V*");
+		using Unwrapped = ReadableReal;
+		ConstRealPointer<V> pointer;
+
+		ReadableReal(ConstRealPointer<V> pointer) : pointer(pointer) {}
+		
+		V get(std::ptrdiff_t i) const {
+			return pointer[i];
+		}
+	};
+	template<typename V>
+	struct ReadableComplex : public BasePointer {
+		EXPRESSION_NAME(ReadableComplex, "VC*");
+		using Unwrapped = ReadableComplex;
+		ConstComplexPointer<V> pointer;
+
+		ReadableComplex(ConstComplexPointer<V> pointer) : pointer(pointer) {}
+
+		std::complex<V> get(std::ptrdiff_t i) const {
+			return pointer[i];
+		}
+	};
+	template<typename V>
+	struct ReadableSplit : public BasePointer {
+		EXPRESSION_NAME(ReadableSplit, "VS*");
+		using Unwrapped = ReadableSplit;
+		ConstSplitPointer<V> pointer;
+
+		ReadableSplit(ConstSplitPointer<V> pointer) : pointer(pointer) {}
+
+		std::complex<V> get(std::ptrdiff_t i) const {
+			return {pointer.real[i], pointer.imag[i]};
+		}
+	};
+	
+	// Remove `Expression<>` or `WritableExpression<>` layers, and add const to pointers
+	template<class E>
+	typename E::Unwrapped unwrap(E e) {
+		return e;
+	}
+	template<class E>
+	typename E::Unwrapped unwrap(Expression<E> e) {
+		return e;
+	}
+	template<class E>
+	typename E::Unwrapped unwrap(WritableExpression<E> e) {
+		return e;
+	}
+	template<class E>
+	using Unwrap = decltype(unwrap(std::declval<E>()));
+
+	template<class Expr>
+	using ElementType = typename std::decay<decltype(std::declval<Expr>().get(0))>::type;
+	
+	template<class T>
+	static constexpr bool isSplittable() {
+		return std::is_same<T, std::complex<float>>::value || std::is_same<T, std::complex<double>>::value;
+	}
+}
+	
+// + - * / % ^ & | ~ ! = < > += -= *= /= %= ^= &= |= << >> >>= <<= == != <= >= <=>(since C++20) && || ++ -- , ->* -> ( ) [ ]
+
+#define SIGNALSMITH_AUDIO_LINEAR_UNARY_PREFIX(Name, OP) \
+namespace expression { \
+	template<class A> \
+	struct Name : public BaseUnary { \
+		EXPRESSION_NAME(Name, (#Name "<") + A::name() + ">"); \
+		using Unwrapped = Name<Unwrap<A>>; \
+		A a; \
+		Name(const A &a) : a(a) {} \
+		auto get(std::ptrdiff_t i) const -> decltype(OP a.get(i)) const { \
+			return OP a.get(i); \
+		} \
+		template<class T> \
+		using ReplaceWith = Name<T>;\
+	}; \
+	template<class A> \
+	Name<Unwrap<A>> make##Name(A a) { \
+		return {a}; \
+	} \
+} \
+template<class A> \
+Expression<expression::Name<expression::Unwrap<A>>> operator OP(const Expression<A> &a) { \
+	return {a}; \
+}
+SIGNALSMITH_AUDIO_LINEAR_UNARY_PREFIX(Neg, -)
+// Two negatives cancel out
+template<class A>
+Expression<A> operator-(const Expression<expression::Neg<A>> &expr) { \
+	return expr.a;
+}
+#undef SIGNALSMITH_AUDIO_LINEAR_UNARY_PREFIX
+
+#define SIGNALSMITH_AUDIO_LINEAR_BINARY_INFIX(Name, OP) \
+namespace expression { \
+	template<class A, class B> \
+	struct Name : public BaseBinary { \
+		EXPRESSION_NAME(Name, (#Name "<") + A::name() + "," + B::name() + ">"); \
+		using Unwrapped = Name<Unwrap<A>, Unwrap<B>>; \
+		A a; \
+		B b; \
+		Name(const A &a, const B &b) : a(a), b(b) {} \
+		auto get(std::ptrdiff_t i) const -> decltype(a.get(i) OP b.get(i)) const { \
+			return a.get(i) OP b.get(i); \
+		} \
+		template<class T1, class T2> \
+		using ReplaceWith = Name<T1, T2>;\
+		template<class T> \
+		using ReplaceWithL = Name<T, B>;\
+		template<class T> \
+		using ReplaceWithR = Name<A, T>;\
+	}; \
+	template<class A, class B> \
+	Name<Unwrap<A>, Unwrap<B>> make##Name(A a, B b) { \
+		return {a, b}; \
+	} \
+} \
+template<class A, class B> \
+const Expression<expression::Name<expression::Unwrap<A>, expression::Unwrap<B>>> operator OP(const Expression<A> &a, const Expression<B> &b) { \
+	return {a, b}; \
+} \
+template<class A, class B> \
+const Expression<expression::Name<expression::Unwrap<A>, expression::Constant<B>>> operator OP(const Expression<A> &a, const B &b) { \
+	return {a, b}; \
+} \
+template<class A, class B> \
+const Expression<expression::Name<expression::Constant<A>, expression::Unwrap<B>>> operator OP(const A &a, const Expression<B> &b) { \
+	return {a, b}; \
+}
+SIGNALSMITH_AUDIO_LINEAR_BINARY_INFIX(Add, +)
+SIGNALSMITH_AUDIO_LINEAR_BINARY_INFIX(Mul, *)
+SIGNALSMITH_AUDIO_LINEAR_BINARY_INFIX(Sub, -)
+SIGNALSMITH_AUDIO_LINEAR_BINARY_INFIX(Div, /)
+#undef SIGNALSMITH_AUDIO_LINEAR_BINARY_INFIX
+
+namespace expression {
+#define SIGNALSMITH_AUDIO_LINEAR_FUNC1(Name, func) \
+	template<class A> \
+	struct Name; \
+	template<class A> \
+	Name<Unwrap<A>> make##Name(A a) { \
+		return {a}; \
+	} \
+	template<class A> \
+	struct Name : public BaseUnary { \
+		EXPRESSION_NAME(Name, (#Name "<") + A::name() + ">"); \
+		using Unwrapped = Name<Unwrap<A>>; \
+		A a; \
+		Name(const A &a) : a(a) {} \
+		auto get(std::ptrdiff_t i) const -> decltype(func(a.get(i))) { \
+			return func(a.get(i)); \
+		} \
+		template<class T> \
+		using ReplaceWith = Name<T>;\
+	};
+
+	template<class A>
+	A fastAbs(const A &a) {
+		return std::abs(a);
+	}
+	template<class A>
+	A fastAbs(const std::complex<A> &a) {
+		return std::hypot(a.real(), a.imag());
+	}
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Abs, fastAbs)
+	
+	template<class A>
+	A fastNorm(const A &a) {
+		return a*a;
+	}
+	template<class A>
+	A fastNorm(const std::complex<A> &a) {
+		A real = a.real(), imag = a.imag();
+		return real*real + imag*imag;
+	}
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Norm, fastNorm)
+
+	// Single-argument functions
+	// Abs, Norm, Exp, Exp2, Log, Log2, Log10, Sqrt, Cbrt, Ceil, Floor, Trunc, Round, Conj, Real, Imag, Arg, Proj, Sin, Cos, Tan, Asin, Acos, Atan, Sinh, Cosh, Tanh, Asinh, Acosh, Atanh, Erf, Erfc, Tgamma, Lgamma
+
+	// .abs and .norm are handled above
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Exp, std::exp)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Exp2, std::exp2)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log, std::log)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log2, std::log2)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log10, std::log10)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sqrt, std::sqrt)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cbrt, std::cbrt)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Ceil, std::ceil)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Floor, std::floor)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Trunc, std::trunc)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Round, std::round)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Conj, std::conj)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Real, std::real)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Imag, std::imag)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Arg, std::arg)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Proj, std::proj)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sin, std::sin)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cos, std::cos)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tan, std::tan)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Asin, std::asin)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Acos, std::acos)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Atan, std::atan)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sinh, std::sinh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cosh, std::cosh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tanh, std::tanh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Asinh, std::asinh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Acosh, std::acosh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Atanh, std::atanh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Erf, std::erf)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Erfc, std::erfc)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tgamma, std::tgamma)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Lgamma, std::lgamma)
+#undef SIGNALSMITH_AUDIO_LINEAR_FUNC1
+
+#define SIGNALSMITH_AUDIO_LINEAR_FUNC2(Name, func) \
+	template<typename VA, typename VB> \
+	auto common##Name(VA a, VB b) -> decltype(func((decltype(a + b))a, (decltype(a + b))b)) { \
+		return func((decltype(a + b))a, (decltype(a + b))b); \
+	} \
+	template<class A, class B> \
+	struct Name : public BaseBinary { \
+		EXPRESSION_NAME(Name, (#Name "<") + A::name() + "," + B::name() + ">"); \
+		using Unwrapped = Name<Unwrap<A>, Unwrap<B>>; \
+		A a; \
+		B b; \
+		Name(const A &a, const B &b) : a(a), b(b) {} \
+		auto get(std::ptrdiff_t i) const -> decltype(common##Name(a.get(i), b.get(i))) const { \
+			return common##Name(a.get(i), b.get(i)); \
+		} \
+		template<class T1, class T2> \
+		using ReplaceWith = Name<T1, T2>;\
+		template<class T> \
+		using ReplaceWithL = Name<T, B>;\
+		template<class T> \
+		using ReplaceWithR = Name<A, T>;\
+	}; \
+	template<class A, class B> \
+	Name<Unwrap<A>, Unwrap<B>> make##Name(A a, B b) { \
+		return {a, b}; \
+	}
+	// Min, Max, Dim, Pow, Atan2, Hypot, Copysign, Polar
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Max, std::fmax);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Min, std::fmin);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Dim, std::fdim);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Pow, std::pow);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Atan2, std::atan2);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Hypot, std::hypot);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Copysign, std::copysign);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Polar, std::polar);
+#undef SIGNALSMITH_AUDIO_LINEAR_FUNC2
+
+} // expression::
+
+template<class BaseExpr>
+struct Expression : public BaseExpr {
+	template<class ...Args>
+	Expression(Args &&...args) : BaseExpr(std::forward<Args>(args)...) {
+		static_assert(SIGNALSMITH_IS_TRIVIALLY_COPYABLE(BaseExpr), "BaseExpr must be trivially copyable");
+		static_assert(SIGNALSMITH_IS_TRIVIALLY_COPYABLE(Expression), "Expression<> must be trivially copyable");
+	}
+
+	auto operator[](std::ptrdiff_t i) -> decltype(BaseExpr::get(i)) const {
+		return BaseExpr::get(i);
+	}
+
+#define SIGNALSMITH_AUDIO_LINEAR_FUNC1(ExprName, methodName) \
+	const Expression<expression::ExprName<expression::Unwrap<BaseExpr>>> methodName() const { \
+		return {*this}; \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Abs, abs)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Norm, norm)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Exp, exp)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Exp2, exp2)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log, log)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log2, log2)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log10, log10)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sqrt, sqrt)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cbrt, cbrt)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Ceil, ceil)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Floor, floor)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Trunc, trunc)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Round, round)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Conj, conj)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Real, real)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Imag, imag)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Arg, arg)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Proj, proj)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sin, sin)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cos, cos)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tan, tan)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Asin, asin)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Acos, acos)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Atan, atan)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sinh, sinh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cosh, cosh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tanh, tanh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Asinh, asinh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Acosh, acosh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Atanh, atanh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Erf, erf)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Erfc, erfc)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tgamma, tgamma)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Lgamma, lgamma)
+#undef SIGNALSMITH_AUDIO_LINEAR_FUNC1
+};
+template<class BaseExpr>
+struct WritableExpression : public Expression<BaseExpr> {
+	using Expression<BaseExpr>::Expression;
+
+	WritableExpression(const WritableExpression &other) = default;
+
+	template<class Expr>
+	WritableExpression & operator=(const Expr &expr) {
+		this->linear.fill(this->pointer, expression::ensureExpr(expr), this->size);
+		return *this;
+	}
+
+	WritableExpression & operator=(const WritableExpression &expr) {
+		this->linear.fill(this->pointer, expr, this->size);
+		return *this;
+	}
+#define SIGNALSMITH_AUDIO_ASSIGNMENT_OP(assignOp, binaryOp) \
+	template<class E>\
+	WritableExpression & operator assignOp(const E &expr) { \
+		return *this = (*this) binaryOp expr; \
+	}
+	SIGNALSMITH_AUDIO_ASSIGNMENT_OP(+=, +);
+	SIGNALSMITH_AUDIO_ASSIGNMENT_OP(-=, -);
+	SIGNALSMITH_AUDIO_ASSIGNMENT_OP(*=, *);
+	SIGNALSMITH_AUDIO_ASSIGNMENT_OP(/=, /);
+#undef SIGNALSMITH_AUDIO_ASSIGNMENT_OP
+
+	// Use the pointer's `operator[]` instead of the expression
+	auto operator[](std::ptrdiff_t i) -> decltype(this->pointer[i]) {
+		return this->pointer[i];
+	}
+
+	auto operator[](std::ptrdiff_t i) const -> decltype(this->pointer[i]) {
+		return this->pointer[i];
+	}
+};
+
+/// Helper class for temporary storage
+template<typename V, bool allowAllocation, size_t alignBytes>
+struct Temporary {
+	
+	void reserve(size_t size) {
+		if (buffer) delete[] buffer;
+		buffer = new V[size];
+		alignedBuffer = nextAligned(buffer);
+		if (alignedBuffer != buffer) {
+			delete[] buffer;
+			buffer = new V[size + extraAlignmentItems];
+			alignedBuffer = nextAligned(buffer);
+		}
+		start = alignedBuffer;
+		end = alignedBuffer + size;
+	}
+
+	void clear() {
+		start = alignedBuffer;
+		fallbacks.resize(0);
+		fallbacks.shrink_to_fit();
+	}
+
+	// You should have one of these every time you're using the temporary storage
+	struct Scoped {
+		Scoped(Temporary &temporary) : temporary(temporary), restoreStart(temporary.start), fallbackSize(temporary.fallbacks.size()) {}
+		
+		~Scoped() {
+			temporary.start = restoreStart;
+			temporary.fallbacks.resize(fallbackSize);
+		}
+		
+		V * operator()(size_t size) {
+			return temporary.getChunk(size);
+		}
+
+	private:
+		Temporary &temporary;
+		V *restoreStart;
+		size_t fallbackSize;
+	};
+
+private:
+	static constexpr size_t extraAlignmentItems = alignBytes/sizeof(V);
+	static V * nextAligned(V *ptr) {
+		return (V*)((size_t(ptr) + (alignBytes - 1))&~(alignBytes - 1));
+	}
+
+	size_t depth = 0;
+	V *start = nullptr, *end = nullptr;
+	V *buffer = nullptr, *alignedBuffer = nullptr;
+
+	std::vector<std::vector<V>> fallbacks;
+
+	/// Valid until the next call to .clear() or .reserve()
+	V * getChunk(size_t size) {
+		V *result = start;
+		V *newStart = start + size;
+		if (newStart > end) {
+#ifdef SIGNALSMITH_LOG_WARNINGS
+		std::cerr << "Signalsmith Linear: insufficient temporary storage (" << (newStart > buffer) << "\n";
+#endif
+			if (!allowAllocation) return nullptr;
+			// OK, actually we ran out of temporary space, so allocate
+			fallbacks.emplace_back(size + extraAlignmentItems);
+			result = nextAligned(fallbacks.back().data());
+			// but we're not happy about it. >:(
+		}
+		start = nextAligned(newStart);
+		return result;
+	}
+};
+
+template<class Linear, bool allowAllocation=true, size_t alignBytes=64>
+struct CachedResults {
+	using TemporaryFloats = Temporary<float, allowAllocation, alignBytes>;
+	using TemporaryDoubles = Temporary<double, allowAllocation, alignBytes>;
+
+	template<typename V>
+	using WritableReal = typename Linear::template WritableReal<V>;
+	template<typename V>
+	using WritableComplex = typename Linear::template WritableComplex<V>;
+	template<typename V>
+	using WritableSplit = typename Linear::template WritableSplit<V>;
+	
+	CachedResults(Linear &linear) : linear(linear) {}
+	
+	struct ScopedFloat : public TemporaryFloats::Scoped {
+		ScopedFloat(Linear &linear, TemporaryFloats &temporary) : TemporaryFloats::Scoped(temporary), linear(linear) {}
+		
+		template<class Expr>
+		ConstRealPointer<float> real(Expr expr, size_t size) {
+			auto chunk = (*this)(size);
+			linear.fill(chunk, expr, size);
+			return chunk;
+		}
+		ConstRealPointer<float> real(expression::ReadableReal<float> expr, size_t) {
+			return expr.pointer;
+		}
+		ConstRealPointer<float> real(WritableReal<float> expr, size_t) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstRealPointer<float> real(Expr expr, size_t size, RealPointer<float> canUse) {
+			linear.fill(canUse, expr, size);
+			return canUse;
+		}
+		ConstRealPointer<float> real(expression::ReadableReal<float> expr, size_t, RealPointer<float>) {
+			return expr.pointer;
+		}
+		ConstRealPointer<float> real(WritableReal<float> expr, size_t, RealPointer<float>) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstComplexPointer<float> complex(Expr expr, size_t size) {
+			auto chunk = (*this)(size*2);
+			linear.fill((ComplexPointer<float>)chunk, expr, size);
+			return reinterpret_cast<const std::complex<float> *>(chunk);
+		}
+		ConstComplexPointer<float> complex(expression::ReadableComplex<float> expr, size_t) {
+			return expr.pointer;
+		}
+		ConstComplexPointer<float> complex(WritableComplex<float> expr, size_t) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstComplexPointer<float> complex(Expr expr, size_t size, ComplexPointer<float> canUse) {
+			linear.fill(canUse, expr, size);
+			return canUse;
+		}
+		ConstComplexPointer<float> complex(expression::ReadableComplex<float> expr, size_t, ComplexPointer<float>) {
+			return expr.pointer;
+		}
+		ConstComplexPointer<float> complex(WritableComplex<float> expr, size_t, ComplexPointer<float>) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstSplitPointer<float> split(Expr expr, size_t size) {
+			SplitPointer<float> chunk{(*this)(size), (*this)(size)};
+			linear.fill(chunk, expr, size);
+			return chunk;
+		}
+		ConstSplitPointer<float> split(expression::ReadableSplit<float> expr, size_t) {
+			return expr.pointer;
+		}
+		ConstSplitPointer<float> split(WritableSplit<float> expr, size_t) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstSplitPointer<float> split(Expr expr, size_t size, SplitPointer<float> canUse) {
+			linear.fill(canUse, expr, size);
+			return canUse;
+		}
+		ConstSplitPointer<float> split(expression::ReadableSplit<float> expr, size_t, SplitPointer<float>) {
+			return expr.pointer;
+		}
+		ConstSplitPointer<float> split(WritableSplit<float> expr, size_t, SplitPointer<float>) {
+			return expr.pointer;
+		}
+	private:
+		Linear &linear;
+	};
+	ScopedFloat floatScope() {
+		return {linear, floats};
+	}
+	void reserveFloats(size_t size) {
+		floats.reserve(size);
+	}
+	template<class Fn>
+	void reserveFloats(size_t size, Fn &&allocationWarning) {
+		floats.reserve(size);
+		floats.allocationWarning = allocationWarning;
+	}
+
+	struct ScopedDouble : public TemporaryDoubles::Scoped {
+		ScopedDouble(Linear &linear, TemporaryDoubles &temporary) : TemporaryDoubles::Scoped(temporary), linear(linear) {}
+		
+		template<class Expr>
+		ConstRealPointer<double> real(Expr expr, size_t size) {
+			auto chunk = (*this)(size);
+			linear.fill(chunk, expr, size);
+			return chunk;
+		}
+		ConstRealPointer<double> real(expression::ReadableReal<double> expr, size_t) {
+			return expr.pointer;
+		}
+		ConstRealPointer<double> real(WritableReal<double> expr, size_t) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstRealPointer<double> real(Expr expr, size_t size, RealPointer<double> canUse) {
+			linear.fill(canUse, expr, size);
+			return canUse;
+		}
+		ConstRealPointer<double> real(expression::ReadableReal<double> expr, size_t, RealPointer<double>) {
+			return expr.pointer;
+		}
+		ConstRealPointer<double> real(WritableReal<double> expr, size_t, RealPointer<double>) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstComplexPointer<double> complex(Expr expr, size_t size) {
+			auto chunk = (*this)(size*2);
+			linear.fill((ComplexPointer<double>)chunk, expr, size);
+			return reinterpret_cast<const std::complex<double> *>(chunk);
+		}
+		ConstComplexPointer<double> complex(expression::ReadableComplex<double> expr, size_t) {
+			return expr.pointer;
+		}
+		ConstComplexPointer<double> complex(WritableComplex<double> expr, size_t) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstComplexPointer<double> complex(Expr expr, size_t size, ComplexPointer<double> canUse) {
+			linear.fill(canUse, expr, size);
+			return canUse;
+		}
+		ConstComplexPointer<double> complex(expression::ReadableComplex<double> expr, size_t, ComplexPointer<double>) {
+			return expr.pointer;
+		}
+		ConstComplexPointer<double> complex(WritableComplex<double> expr, size_t, ComplexPointer<double>) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstSplitPointer<double> split(Expr expr, size_t size) {
+			SplitPointer<double> chunk{(*this)(size), (*this)(size)};
+			linear.fill(chunk, expr, size);
+			return chunk;
+		}
+		ConstSplitPointer<double> split(expression::ReadableSplit<double> expr, size_t) {
+			return expr.pointer;
+		}
+		ConstSplitPointer<double> split(WritableSplit<double> expr, size_t) {
+			return expr.pointer;
+		}
+		template<class Expr>
+		ConstSplitPointer<double> split(Expr expr, size_t size, SplitPointer<double> canUse) {
+			linear.fill(canUse, expr, size);
+			return canUse;
+		}
+		ConstSplitPointer<double> split(expression::ReadableSplit<double> expr, size_t, SplitPointer<double>) {
+			return expr.pointer;
+		}
+		ConstSplitPointer<double> split(WritableSplit<double> expr, size_t, SplitPointer<double>) {
+			return expr.pointer;
+		}
+	private:
+		Linear &linear;
+	};
+	ScopedDouble doubleScope() {
+		return {linear, doubles};
+	}
+	void reserveDoubles(size_t size) {
+		doubles.reserve(size);
+	}
+	template<class Fn>
+	void reserveDoubles(size_t size, Fn &&allocationWarning) {
+		doubles.reserve(size);
+		doubles.allocationWarning = allocationWarning;
+	}
+	
+private:
+	TemporaryFloats floats;
+	TemporaryDoubles doubles;
+	Linear &linear;
+};
+
+template<bool useLinear=true>
+struct LinearImplBase {
+	using Linear = LinearImpl<useLinear>;
+
+	template<class V>
+	void reserve(size_t) {}
+
+	template<typename V>
+	struct WritableReal {
+		EXPRESSION_NAME(WritableReal, "rw V*");
+		Linear &linear;
+		RealPointer<V> pointer;
+		size_t size;
+		WritableReal(Linear &linear, RealPointer<V> pointer, size_t size) : linear(linear), pointer(pointer), size(size) {
+			static_assert(SIGNALSMITH_IS_TRIVIALLY_COPYABLE(WritableReal), "must be trivially copyable");
+		}
+		
+		using Unwrapped = expression::ReadableReal<V>;
+		operator Unwrapped() const {
+			return {pointer};
+		}
+		
+		V get(std::ptrdiff_t i) const {
+			return pointer[i];
+		}
+
+		V & operator[](std::ptrdiff_t i) {
+			return pointer[i];
+		}
+		const V & operator[](std::ptrdiff_t i) const {
+			return pointer[i];
+		}
+	};
+	template<typename V>
+	struct WritableComplex {
+		EXPRESSION_NAME(WritableComplex, "rw VC*");
+		Linear &linear;
+		ComplexPointer<V> pointer;
+		size_t size;
+		WritableComplex(Linear &linear, ComplexPointer<V> pointer, size_t size) : linear(linear), pointer(pointer), size(size) {}
+
+		using Unwrapped = expression::ReadableComplex<V>;
+		operator Unwrapped() const {
+			return {pointer};
+		}
+
+		std::complex<V> get(std::ptrdiff_t i) const {
+			return pointer[i];
+		}
+
+		std::complex<V> & operator[](std::ptrdiff_t i) {
+			return pointer[i];
+		}
+		const std::complex<V> & operator[](std::ptrdiff_t i) const {
+			return pointer[i];
+		}
+	};
+	template<typename V>
+	struct WritableSplit {
+		EXPRESSION_NAME(WritableSplit, "rw VS*");
+		Linear &linear;
+		SplitPointer<V> pointer;
+		size_t size;
+		WritableSplit(Linear &linear, SplitPointer<V> pointer, size_t size) : linear(linear), pointer(pointer), size(size) {}
+
+		using Unwrapped = expression::ReadableSplit<V>;
+		operator Unwrapped() const {
+			return {pointer};
+		}
+
+		std::complex<V> get(std::ptrdiff_t i) const {
+			return {pointer.real[i], pointer.imag[i]};
+		}
+		auto operator[](std::ptrdiff_t i) -> decltype(pointer[i]) {
+			return pointer[i];
+		}
+		auto operator[](std::ptrdiff_t i) const -> decltype(pointer[i]) {
+			return pointer[i];
+		}
+	};
+
+	// Arithmetic values get turned into constants
+	template<typename V, typename=typename std::enable_if<std::is_arithmetic<V>::value, V>::type>
+	Expression<expression::Constant<V>> wrap(V v) {
+		return {v};
+	}
+
+	// Pass `Expression`s through
+	template<class V>
+	Expression<V> wrap(Expression<V> expr) {
+		return expr;
+	}
+
+	// Wrap a pointer as an expression
+	template<typename V>
+	Expression<expression::ReadableReal<V>> wrap(ConstRealPointer<V> pointer) {
+		return {pointer};
+	}
+	template<typename V>
+	Expression<expression::ReadableComplex<V>> wrap(ConstComplexPointer<V> pointer) {
+		return {pointer};
+	}
+	template<typename V>
+	Expression<expression::ReadableSplit<V>> wrap(ConstSplitPointer<V> pointer) {
+		return {pointer};
+	}
+	template<typename V>
+	Expression<expression::ReadableSplit<V>> wrap(ConstRealPointer<V> real, ConstRealPointer<V> imag) {
+		return {ConstSplitPointer<V>{real, imag}};
+	}
+
+	// When a length is supplied, make it writable
+	template<typename V>
+	WritableExpression<WritableReal<V>> wrap(RealPointer<V> pointer, size_t size) {
+		return {self(), pointer, size};
+	}
+	template<typename V>
+	WritableExpression<WritableComplex<V>> wrap(ComplexPointer<V> pointer, size_t size) {
+		return {self(), pointer, size};
+	}
+	template<typename V>
+	WritableExpression<WritableSplit<V>> wrap(SplitPointer<V> pointer, size_t size) {
+		return {self(), pointer, size};
+	}
+	template<typename V>
+	WritableExpression<WritableSplit<V>> wrap(RealPointer<V> real, RealPointer<V> imag, size_t size) {
+		return {self(), SplitPointer<V>{real, imag}, size};
+	}
+
+	template<typename V>
+	WritableExpression<WritableReal<V>> wrap(std::vector<V> &vector) {
+		return {self(), vector.data(), vector.size()};
+	}
+	template<typename V>
+	WritableExpression<WritableComplex<V>> wrap(std::vector<std::complex<V>> &vector) {
+		return {self(), vector.data(), vector.size()};
+	}
+	template<typename V>
+	WritableExpression<WritableSplit<V>> wrap(std::vector<V> &real, std::vector<V> &imag) {
+		SplitPointer<V> pointer{real.data(), imag.data()};
+		size_t size = std::min<size_t>(real.size(), imag.size());
+		return {self(), pointer, size};
+	}
+
+	template<typename V>
+	Expression<expression::ReadableReal<V>> wrap(const std::vector<V> &vector) {
+		return {vector.data()};
+	}
+	template<typename V>
+	Expression<expression::ReadableComplex<V>> wrap(const std::vector<std::complex<V>> &vector) {
+		return {vector.data()};
+	}
+	template<typename V>
+	Expression<expression::ReadableSplit<V>> wrap(const std::vector<V> &real, const std::vector<V> &imag) {
+		ConstSplitPointer<V> pointer{real.data(), imag.data()};
+		return {pointer};
+	}
+
+	template<class ...Args>
+	auto operator()(Args &&...args) -> decltype(wrap(std::forward<Args>(args)...)) {
+		return wrap(std::forward<Args>(args)...);
+	}
+
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, Expr expr, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			pointer[i] = expr.get(i);
+		}
+	}
+	template<class V, class Expr>
+	void fill(SplitPointer<V> pointer, Expr expr, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			std::complex<V> v = expr.get(i);
+			pointer.real[i] = v.real();
+			pointer.imag[i] = v.imag();
+		}
+	}
+
+	// Remove the Expression<...> layer, so the simplification template-matching works
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, Expression<Expr> expr, size_t size) {
+		return self().fill(pointer, (Expr &)expr, size);
+	};
+	// Separate otherwise it's ambiguous between the two previous ones
+	template<class V, class Expr>
+	void fill(SplitPointer<V> pointer, Expression<Expr> expr, size_t size) {
+		return self().fill(pointer, (Expr &)expr, size);
+	};
+
+
+#define SIGNALSMITH_AUDIO_LINEAR_FUNC1(ExprName, methodName) \
+	template<class A> \
+	auto methodName(A a) -> Expression<decltype(expression::make##ExprName(wrap(a)))> { \
+		return expression::make##ExprName(wrap(a)); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Abs, abs)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Norm, norm)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Exp, exp)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Exp2, exp2)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log, log)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log2, log2)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Log10, log10)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sqrt, sqrt)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cbrt, cbrt)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Ceil, ceil)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Floor, floor)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Trunc, trunc)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Round, round)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Conj, conj)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Real, real)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Imag, imag)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Arg, arg)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Proj, proj)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sin, sin)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cos, cos)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tan, tan)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Asin, asin)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Acos, acos)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Atan, atan)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Sinh, sinh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Cosh, cosh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tanh, tanh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Asinh, asinh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Acosh, acosh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Atanh, atanh)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Erf, erf)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Erfc, erfc)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Tgamma, tgamma)
+	SIGNALSMITH_AUDIO_LINEAR_FUNC1(Lgamma, lgamma)
+#undef SIGNALSMITH_AUDIO_LINEAR_FUNC1
+
+#define SIGNALSMITH_AUDIO_LINEAR_FUNC2(ExprName, methodName) \
+	template<class A, class B> \
+	auto methodName(A a, B b) -> Expression<decltype(expression::make##ExprName(wrap(a), wrap(b)))> { \
+		return expression::make##ExprName(wrap(a), wrap(b)); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Max, max);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Min, min);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Dim, dim);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Pow, pow);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Atan2, atan2);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Hypot, hypot);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Copysign, copysign);
+	SIGNALSMITH_AUDIO_LINEAR_FUNC2(Polar, polar);
+#undef SIGNALSMITH_AUDIO_LINEAR_FUNC2
+
+protected:
+	LinearImplBase(Linear *linearThis) {
+		assert((LinearImplBase *)linearThis == this);
+	}
+
+	Linear & self() {
+		return *(Linear *)this;
+	}
+};
+#undef EXPRESSION_NAME
+
+/* SFINAE template for checking that an expression naturally returns a particular item type
+
+e.g.
+	template<class A>
+	ItemType<A, float, void> fill(...)
+*/
+template<class InputExpr, typename Item, class OutputExpr>
+using ItemType = typename std::enable_if<
+	std::is_same<expression::ElementType<InputExpr>, Item>::value,
+	OutputExpr
+>::type;
+
+// Fallback implementation - this should be specialised (with useLinear=true) with faster methods where available
+template<bool useLinear>
+struct LinearImpl : public LinearImplBase<useLinear> {
+	LinearImpl() : LinearImplBase<useLinear>(this), cached(*this) {}
+
+	using LinearImplBase<useLinear>::fill;
+	
+	// Override .fill() for specific pointer/expressions which you can do quickly.  Calling `cached.realFloat()` etc. will call back to .fill()
+	template<class Expr>
+	void fill(RealPointer<float> pointer, expression::Sqrt<expression::Norm<Expr>> expr, size_t size) {
+		auto floats = cached.floatScope(); // temporary storage - usually not actually needed for specialisations
+		
+		auto normExpr = expr.a;
+		auto array = floats.real(normExpr, size); // fill the temporary storage with real values, return a pointer Expr
+		
+		// The idea is to use an existing fast function, but this is an example
+		for (size_t i = 0; i < size; ++i) {
+			pointer[i] = std::sqrt(array[i]);
+		}
+	}
+	
+	template<typename V>
+	void reserve(size_t size) {
+		// Assume it's either float or double
+		if (sizeof(V) == sizeof(double)) {
+			cached.reserveDoubles(size);
+		} else if (sizeof(V) == sizeof(float)) {
+			cached.reserveFloats(size);
+		}
+	}
+private:
+	CachedResults<LinearImpl, true, 16> cached;
+};
+
+}}; // namespace
+
+#if defined(SIGNALSMITH_USE_ACCELERATE)
+#	include "./platform/linear-accelerate.h"
+#elif defined(SIGNALSMITH_USE_XSIMD)
+#	include "./platform/linear-xsimd.h"
+#elif defined(SIGNALSMITH_USE_CMSISDSP)
+#	include "./platform/linear-cmsisdsp.h"
+//#elif defined(SIGNALSMITH_USE_IPP)
+//#	include "./platform/linear-ipp.h"
+#endif
+
+#undef SIGNALSMITH_IS_TRIVIALLY_COPYABLE
+
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/approx-cmsisdsp.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/approx-cmsisdsp.h
@@ -1,0 +1,40 @@
+#include "arm_math.h"
+
+namespace signalsmith { namespace linear {
+
+template<>
+struct Approx<float, 1> : public Approx<Sample, 0> {
+	using Approx<Sample, 0>::Approx;
+	
+	std::complex<float> unitPolar(float radians) {
+		float real, imag;
+		arm_sin_cos_f32(radians*float(M_PI/180), &real, &imag);
+		return {real, imag};
+	}
+	float sin(float radians) {
+		return arm_sin_f32(float radians);
+	}
+	float cos(float radians) {
+		return arm_sin_f32(float radians);
+	}
+	float atan2(float x, float y) {
+		float radians;
+		if (!arm_atan2_f32(x, y, &radians)) return 0;
+		return radians;
+	}
+	float arg(std::complex<float> v) {
+		return atan2(v.real(), v.imag());
+	}
+	float sqrt(float x) {
+		float result;
+		arm_sqrt_f32(x, &result);
+		return result;
+	}
+	float invSqrt(float x) {
+		return 1/sqrt(x);
+	}
+};
+
+#if defined(SIGNALSMITH_USE_CMSISDSP)
+#	include "./platform/fft-cmsisdsp.h"
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/basic-fill-warnings.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/basic-fill-warnings.h
@@ -1,0 +1,61 @@
+#pragma once
+
+namespace signalsmith { namespace linear {
+
+#ifdef SIGNALSMITH_LOG_WARNINGS
+#	include <iostream>
+template<class T>
+static std::string typeName() {
+	return "?";
+}
+template<>
+std::string typeName<float>() {
+	return "float";
+}
+template<>
+std::string typeName<double>() {
+	return "double";
+}
+template<>
+std::string typeName<std::complex<float>>() {
+	return "complex<float>";
+}
+template<>
+std::string typeName<std::complex<double>>() {
+	return "complex<double>";
+}
+template<>
+std::string typeName<const std::complex<float>>() {
+	return "const complex<float>";
+}
+template<>
+std::string typeName<const std::complex<double>>() {
+	return "const complex<double>";
+}
+static size_t _basicFillWarningCounter = 1;
+static void basicFillWarningReset() {
+	// All warnings will print again
+	++_basicFillWarningCounter;
+}
+template<class Expr>
+static void basicFillWarning() {
+	static size_t counter = 0;
+	if (counter != _basicFillWarningCounter) {
+		counter = _basicFillWarningCounter;
+		std::cerr << "Signalsmith Linear: used basic .fill() for " << Expr::name() << " -> " << typeName<decltype(std::declval<Expr>().get(0))>() << "\n";
+	}
+}
+static void basicFillWarning(const char *method) {
+	static size_t counter = 0;
+	if (counter != _basicFillWarningCounter) {
+		counter = _basicFillWarningCounter;
+		std::cerr << "Signalsmith Linear: used basic ." << method << "()\n";
+	}
+}
+#else
+static void basicFillWarningReset() {}
+template<class Expr>
+static void basicFillWarning() {}
+#endif
+
+}}; // namespace

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-accelerate.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-accelerate.h
@@ -1,0 +1,340 @@
+// If possible, only include vecLib, since JUCE has conflicts with vImage
+#if defined(__has_include) && __has_include(<vecLib/vecLib.h>)
+#	include <vecLib/vecLib.h>
+#else
+#	include <Accelerate/Accelerate.h>
+#endif
+
+namespace signalsmith { namespace linear {
+
+namespace _impl {
+	template<>
+	inline void complexMul<float>(std::complex<float> *a, const std::complex<float> *b, const std::complex<float> *c, size_t size) {
+		DSPSplitComplex aSplit = {(float *)a, (float *)a + 1};
+		DSPSplitComplex bSplit = {(float *)b, (float *)b + 1};
+		DSPSplitComplex cSplit = {(float *)c, (float *)c + 1};
+		vDSP_zvmul(&cSplit, 2, &bSplit, 2, &aSplit, 2, size, 1);
+	}
+	template<>
+	inline void complexMulConj<float>(std::complex<float> *a, const std::complex<float> *b, const std::complex<float> *c, size_t size) {
+		DSPSplitComplex aSplit = {(float *)a, (float *)a + 1};
+		DSPSplitComplex bSplit = {(float *)b, (float *)b + 1};
+		DSPSplitComplex cSplit = {(float *)c, (float *)c + 1};
+		vDSP_zvmul(&cSplit, 2, &bSplit, 2, &aSplit, 2, size, -1);
+	}
+	template<>
+	inline void complexMul<float>(float *ar, float *ai, const float *br, const float *bi, const float *cr, const float *ci, size_t size) {
+		DSPSplitComplex aSplit = {ar, ai};
+		DSPSplitComplex bSplit = {(float *)br, (float *)bi};
+		DSPSplitComplex cSplit = {(float *)cr, (float *)ci};
+		vDSP_zvmul(&cSplit, 1, &bSplit, 1, &aSplit, 1, size, 1);
+	}
+	template<>
+	inline void complexMulConj<float>(float *ar, float *ai, const float *br, const float *bi, const float *cr, const float *ci, size_t size) {
+		DSPSplitComplex aSplit = {ar, ai};
+		DSPSplitComplex bSplit = {(float *)br, (float *)bi};
+		DSPSplitComplex cSplit = {(float *)cr, (float *)ci};
+		vDSP_zvmul(&cSplit, 1, &bSplit, 1, &aSplit, 1, size, -1);
+	}
+	
+	// doubles
+	template<>
+	inline void complexMul<double>(std::complex<double> *a, const std::complex<double> *b, const std::complex<double> *c, size_t size) {
+		DSPDoubleSplitComplex aSplit = {(double *)a, (double *)a + 1};
+		DSPDoubleSplitComplex bSplit = {(double *)b, (double *)b + 1};
+		DSPDoubleSplitComplex cSplit = {(double *)c, (double *)c + 1};
+		vDSP_zvmulD(&cSplit, 2, &bSplit, 2, &aSplit, 2, size, 1);
+	}
+	template<>
+	inline void complexMulConj<double>(std::complex<double> *a, const std::complex<double> *b, const std::complex<double> *c, size_t size) {
+		DSPDoubleSplitComplex aSplit = {(double *)a, (double *)a + 1};
+		DSPDoubleSplitComplex bSplit = {(double *)b, (double *)b + 1};
+		DSPDoubleSplitComplex cSplit = {(double *)c, (double *)c + 1};
+		vDSP_zvmulD(&cSplit, 2, &bSplit, 2, &aSplit, 2, size, -1);
+	}
+	template<>
+	inline void complexMul<double>(double *ar, double *ai, const double *br, const double *bi, const double *cr, const double *ci, size_t size) {
+		DSPDoubleSplitComplex aSplit = {ar, ai};
+		DSPDoubleSplitComplex bSplit = {(double *)br, (double *)bi};
+		DSPDoubleSplitComplex cSplit = {(double *)cr, (double *)ci};
+		vDSP_zvmulD(&cSplit, 1, &bSplit, 1, &aSplit, 1, size, 1);
+	}
+	template<>
+	inline void complexMulConj<double>(double *ar, double *ai, const double *br, const double *bi, const double *cr, const double *ci, size_t size) {
+		DSPDoubleSplitComplex aSplit = {ar, ai};
+		DSPDoubleSplitComplex bSplit = {(double *)br, (double *)bi};
+		DSPDoubleSplitComplex cSplit = {(double *)cr, (double *)ci};
+		vDSP_zvmulD(&cSplit, 1, &bSplit, 1, &aSplit, 1, size, -1);
+	}
+}
+
+template<>
+struct Pow2FFT<float> {
+	static constexpr bool prefersSplit = true;
+
+	using Complex = std::complex<float>;
+
+	Pow2FFT(size_t size = 0) {
+		resize(size);
+	}
+	~Pow2FFT() {
+		if (hasSetup) vDSP_destroy_fftsetup(fftSetup);
+	}
+	// Allow move, but not copy
+	Pow2FFT(const Pow2FFT &other) = delete;
+	Pow2FFT(Pow2FFT &&other) : _size(other._size), hasSetup(other.hasSetup), fftSetup(other.fftSetup), log2(other.log2), splitReal(std::move(other.splitReal)), splitImag(std::move(other.splitImag)) {
+		// Avoid double-free
+		other.hasSetup = false;
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		if (hasSetup) vDSP_destroy_fftsetup(fftSetup);
+		if (!size) {
+			hasSetup = false;
+			return;
+		}
+
+		splitReal.resize(size);
+		splitImag.resize(size);
+		log2 = std::round(std::log2(size));
+		fftSetup = vDSP_create_fftsetup(log2, FFT_RADIX2);
+		hasSetup = fftSetup;
+	}
+
+	void fft(const Complex* input, Complex* output) {
+		DSPSplitComplex splitComplex{ splitReal.data(), splitImag.data() };
+		vDSP_ctoz((DSPComplex*)input, 2, &splitComplex, 1, _size);
+		vDSP_fft_zip(fftSetup, &splitComplex, 1, log2, kFFTDirection_Forward);
+		vDSP_ztoc(&splitComplex, 1, (DSPComplex*)output, 2, _size);
+	}
+	void fft(const float *inR, const float *inI, float *outR, float *outI) {
+		DSPSplitComplex inSplit{(float *)inR, (float *)inI};
+		DSPSplitComplex outSplit{outR, outI};
+		vDSP_fft_zop(fftSetup, &inSplit, 1, &outSplit, 1, log2, kFFTDirection_Forward);
+	}
+
+	void ifft(const Complex* input, Complex* output) {
+		DSPSplitComplex splitComplex{ splitReal.data(), splitImag.data() };
+		vDSP_ctoz((DSPComplex*)input, 2, &splitComplex, 1, _size);
+		vDSP_fft_zip(fftSetup, &splitComplex, 1, log2, kFFTDirection_Inverse);
+		vDSP_ztoc(&splitComplex, 1, (DSPComplex*)output, 2, _size);
+	}
+	void ifft(const float *inR, const float *inI, float *outR, float *outI) {
+		DSPSplitComplex inSplit{(float *)inR, (float *)inI};
+		DSPSplitComplex outSplit{outR, outI};
+		vDSP_fft_zop(fftSetup, &inSplit, 1, &outSplit, 1, log2, kFFTDirection_Inverse);
+	}
+
+private:
+	size_t _size = 0;
+	bool hasSetup = false;
+	FFTSetup fftSetup;
+	int log2 = 0;
+	std::vector<float> splitReal, splitImag;
+};
+
+template<>
+struct Pow2RealFFT<float> {
+	static constexpr bool prefersSplit = true;
+
+	using Complex = std::complex<float>;
+
+	Pow2RealFFT(size_t size = 0) {
+		resize(size);
+	}
+	~Pow2RealFFT() {
+		if (hasSetup) vDSP_destroy_fftsetup(fftSetup);
+	}
+	// Allow move, but not copy
+	Pow2RealFFT(const Pow2RealFFT &other) = delete;
+	Pow2RealFFT(Pow2RealFFT &&other) : _size(other._size), hasSetup(other.hasSetup), fftSetup(other.fftSetup), log2(other.log2), splitReal(std::move(other.splitReal)), splitImag(std::move(other.splitImag)) {
+		// Avoid double-free
+		other.hasSetup = false;
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		if (hasSetup) vDSP_destroy_fftsetup(fftSetup);
+		if (!size) {
+			hasSetup = false;
+			return;
+		}
+
+		splitReal.resize(size);
+		splitImag.resize(size);
+		log2 = std::log2(size);
+		fftSetup = vDSP_create_fftsetup(log2, FFT_RADIX2);
+		hasSetup = fftSetup;
+	}
+
+	void fft(const float* input, Complex* output) {
+		float mul = 0.5f;
+		vDSP_vsmul(input, 2, &mul, splitReal.data(), 1, _size/2);
+		vDSP_vsmul(input + 1, 2, &mul, splitImag.data(), 1, _size/2);
+		DSPSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_fft_zrip(fftSetup, &tmpSplit, 1, log2, kFFTDirection_Forward);
+		vDSP_ztoc(&tmpSplit, 1, (DSPComplex *)output, 2, _size/2);
+	}
+	void fft(const float *inR, float *outR, float *outI) {
+		DSPSplitComplex outputSplit{outR, outI};
+		float mul = 0.5f;
+		vDSP_vsmul(inR, 2, &mul, outR, 1, _size/2);
+		vDSP_vsmul(inR + 1, 2, &mul, outI, 1, _size/2);
+		vDSP_fft_zrip(fftSetup, &outputSplit, 1, log2, kFFTDirection_Forward);
+	}
+
+	void ifft(const Complex * input, float * output) {
+		DSPSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_ctoz((DSPComplex*)input, 2, &tmpSplit, 1, _size/2);
+		vDSP_fft_zrip(fftSetup, &tmpSplit, 1, log2, kFFTDirection_Inverse);
+		DSPSplitComplex outputSplit{output, output + 1};
+		vDSP_zvmov(&tmpSplit, 1, &outputSplit, 2, _size/2);
+	}
+	void ifft(const float *inR, const float *inI, float *outR) {
+		DSPSplitComplex inputSplit{(float *)inR, (float *)inI};
+		DSPSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_fft_zrop(fftSetup, &inputSplit, 1, &tmpSplit, 1, log2, kFFTDirection_Inverse);
+		DSPSplitComplex outputSplit{outR, outR + 1};
+		// We can't use vDSP_ztoc without knowing the alignment
+		vDSP_zvmov(&tmpSplit, 1, &outputSplit, 2, _size/2);
+	}
+
+private:
+	size_t _size = 0;
+	bool hasSetup = false;
+	FFTSetup fftSetup;
+	int log2 = 0;
+	std::vector<float> splitReal, splitImag;
+};
+
+template<>
+struct Pow2FFT<double> {
+	static constexpr bool prefersSplit = true;
+
+	using Complex = std::complex<double>;
+
+	Pow2FFT(size_t size=0) {
+		resize(size);
+	}
+	~Pow2FFT() {
+		if (hasSetup) vDSP_destroy_fftsetupD(fftSetup);
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		if (hasSetup) vDSP_destroy_fftsetupD(fftSetup);
+		if (!size) {
+			hasSetup = false;
+			return;
+		}
+
+		log2 = std::round(std::log2(size));
+		fftSetup = vDSP_create_fftsetupD(log2, FFT_RADIX2);
+		hasSetup = fftSetup;
+
+		splitReal.resize(size);
+		splitImag.resize(size);
+	}
+
+	void fft(const Complex* input, Complex* output) {
+		DSPDoubleSplitComplex splitComplex{ splitReal.data(), splitImag.data() };
+		vDSP_ctozD((DSPDoubleComplex*)input, 2, &splitComplex, 1, _size);
+		vDSP_fft_zipD(fftSetup, &splitComplex, 1, log2, kFFTDirection_Forward);
+		vDSP_ztocD(&splitComplex, 1, (DSPDoubleComplex*)output, 2, _size);
+	}
+	void fft(const double *inR, const double *inI, double *outR, double *outI) {
+		DSPDoubleSplitComplex inSplit{(double *)inR, (double *)inI};
+		DSPDoubleSplitComplex outSplit{outR, outI};
+		vDSP_fft_zopD(fftSetup, &inSplit, 1, &outSplit, 1, log2, kFFTDirection_Forward);
+	}
+
+	void ifft(const Complex* input, Complex* output) {
+		DSPDoubleSplitComplex splitComplex{ splitReal.data(), splitImag.data() };
+		vDSP_ctozD((DSPDoubleComplex*)input, 2, &splitComplex, 1, _size);
+		vDSP_fft_zipD(fftSetup, &splitComplex, 1, log2, kFFTDirection_Inverse);
+		vDSP_ztocD(&splitComplex, 1, (DSPDoubleComplex*)output, 2, _size);
+	}
+	void ifft(const double *inR, const double *inI, double *outR, double *outI) {
+		DSPDoubleSplitComplex inSplit{(double *)inR, (double *)inI};
+		DSPDoubleSplitComplex outSplit{outR, outI};
+		vDSP_fft_zopD(fftSetup, &inSplit, 1, &outSplit, 1, log2, kFFTDirection_Inverse);
+	}
+
+private:
+	size_t _size = 0;
+	bool hasSetup = false;
+	FFTSetupD fftSetup;
+	int log2 = 0;
+	std::vector<double> splitReal, splitImag;
+};
+
+template<>
+struct Pow2RealFFT<double> {
+	static constexpr bool prefersSplit = true;
+
+	using Complex = std::complex<double>;
+
+	Pow2RealFFT(size_t size = 0) {
+		resize(size);
+	}
+	~Pow2RealFFT() {
+		if (hasSetup) vDSP_destroy_fftsetupD(fftSetup);
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		if (hasSetup) vDSP_destroy_fftsetupD(fftSetup);
+		if (!size) {
+			hasSetup = false;
+			return;
+		}
+
+		splitReal.resize(size);
+		splitImag.resize(size);
+		log2 = std::log2(size);
+		fftSetup = vDSP_create_fftsetupD(log2, FFT_RADIX2);
+		hasSetup = fftSetup;
+	}
+
+	void fft(const double* input, Complex* output) {
+		double mul = 0.5f;
+		vDSP_vsmulD(input, 2, &mul, splitReal.data(), 1, _size/2);
+		vDSP_vsmulD(input + 1, 2, &mul, splitImag.data(), 1, _size/2);
+		DSPDoubleSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_fft_zripD(fftSetup, &tmpSplit, 1, log2, kFFTDirection_Forward);
+		vDSP_ztocD(&tmpSplit, 1, (DSPDoubleComplex *)output, 2, _size/2);
+	}
+	void fft(const double *inR, double *outR, double *outI) {
+		DSPDoubleSplitComplex outputSplit{outR, outI};
+		double mul = 0.5f;
+		vDSP_vsmulD(inR, 2, &mul, outR, 1, _size/2);
+		vDSP_vsmulD(inR + 1, 2, &mul, outI, 1, _size/2);
+		vDSP_fft_zripD(fftSetup, &outputSplit, 1, log2, kFFTDirection_Forward);
+	}
+
+	void ifft(const Complex * input, double * output) {
+		DSPDoubleSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_ctozD((DSPDoubleComplex*)input, 2, &tmpSplit, 1, _size/2);
+		vDSP_fft_zripD(fftSetup, &tmpSplit, 1, log2, kFFTDirection_Inverse);
+		DSPDoubleSplitComplex outputSplit{output, output + 1};
+		vDSP_zvmovD(&tmpSplit, 1, &outputSplit, 2, _size/2);
+	}
+	void ifft(const double *inR, const double *inI, double *outR) {
+		DSPDoubleSplitComplex inputSplit{(double *)inR, (double *)inI};
+		DSPDoubleSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_fft_zropD(fftSetup, &inputSplit, 1, &tmpSplit, 1, log2, kFFTDirection_Inverse);
+		DSPDoubleSplitComplex outputSplit{outR, outR + 1};
+		// We can't use vDSP_ztoc without knowing the alignment
+		vDSP_zvmovD(&tmpSplit, 1, &outputSplit, 2, _size/2);
+	}
+
+private:
+	size_t _size = 0;
+	bool hasSetup = false;
+	FFTSetupD fftSetup;
+	int log2 = 0;
+	std::vector<double> splitReal, splitImag;
+};
+
+}} // namespace

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-cmsisdsp.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-cmsisdsp.h
@@ -1,0 +1,307 @@
+#include "arm_math.h"
+
+namespace signalsmith { namespace linear {
+
+namespace _impl {
+//	template<>
+//	inline void complexMul<float>(std::complex<float> *a, const std::complex<float> *b, const std::complex<float> *c, size_t size) {
+//		arm_cmplx_mult_cmplx_f32(reinterpret_cast<const float *>(b), reinterpret_cast<const float *>(c), reinterpret_cast<float *>(a), uint32_t(size));
+//	}
+//
+//	// doubles
+//	template<>
+//	inline void complexMul<double>(std::complex<double> *a, const std::complex<double> *b, const std::complex<double> *c, size_t size) {
+//		arm_cmplx_mult_cmplx_f64(reinterpret_cast<const double *>(b), reinterpret_cast<const double *>(c), reinterpret_cast<double *>(a), uint32_t(size));
+//	}
+}
+
+template<>
+struct Pow2FFT<float> {
+	static constexpr bool prefersSplit = false;
+
+	using Complex = std::complex<float>;
+
+	Pow2FFT(size_t size=0) {
+		resize(size);
+	}
+	~Pow2FFT() {
+		if (simpleFFT) delete simpleFFT;
+	}
+	// Allow move, but not copy
+	Pow2FFT(const Pow2FFT &other) = delete;
+	Pow2FFT(Pow2FFT &&other) : instance(other.instance), simpleFFT(other.simpleFFT), tmp(std::move(other.tmp)) {
+		// Avoid double-free
+		other.simpleFFT = nullptr;
+	}
+
+	void resize(size_t size) {
+		if (simpleFFT) delete simpleFFT;
+		simpleFFT = nullptr;
+
+		if (size >= minSize && size <= maxSize) {
+			arm_cfft_init_f32(&instance, uint16_t(size));
+			tmp.resize(size); // in case we need to translate to/from a split version
+		} else {
+			simpleFFT = new SimpleFFT<float>(size);
+			tmp.resize(0);
+		}
+		tmp.shrink_to_fit();
+	}
+
+	void fft(const Complex* input, Complex* output) {
+		if (simpleFFT) return simpleFFT->fft(input, output);
+		if (output != input) std::memcpy(output, input, sizeof(Complex)*tmp.size());
+		arm_cfft_f32(&instance, reinterpret_cast<float *>(output), 0, 1);
+	}
+	void fft(const float *inR, const float *inI, float *outR, float *outI) {
+		if (simpleFFT) return simpleFFT->fft(inR, inI, outR, outI);
+		for (size_t i = 0; i < tmp.size(); ++i) {
+			tmp[i] = {inR[i], inI[i]};
+		}
+		arm_cfft_f32(&instance, reinterpret_cast<float *>(tmp.data()), 0, 1);
+		for (size_t i = 0; i < tmp.size(); ++i) {
+			auto v = tmp[i];
+			outR[i] = v.real();
+			outI[i] = v.imag();
+		}
+	}
+
+	void ifft(const Complex* input, Complex* output) {
+		if (simpleFFT) return simpleFFT->ifft(input, output);
+		if (output != input) std::memcpy(output, input, sizeof(Complex)*tmp.size());
+		auto *outputAsFloat = reinterpret_cast<float *>(output);
+		arm_cfft_f32(&instance, outputAsFloat, 1, 1);
+		arm_scale_f32(outputAsFloat, float(tmp.size()), outputAsFloat, uint32_t(tmp.size()*2));
+	}
+	void ifft(const float *inR, const float *inI, float *outR, float *outI) {
+		if (simpleFFT) return simpleFFT->ifft(inR, inI, outR, outI);
+
+		for (size_t i = 0; i < tmp.size(); ++i) {
+			tmp[i] = {inR[i], inI[i]};
+		}
+		arm_cfft_f32(&instance, reinterpret_cast<float *>(tmp.data()), 1, 1);
+		float scale = tmp.size();
+		for (size_t i = 0; i < tmp.size(); ++i) {
+			auto v = tmp[i]*scale;
+			outR[i] = v.real();
+			outI[i] = v.imag();
+		}
+	}
+
+private:
+	static constexpr size_t minSize = 32;
+	static constexpr size_t maxSize = 4096;
+	arm_cfft_instance_f32 instance;
+	SimpleFFT<float> *simpleFFT = nullptr;
+	std::vector<Complex> tmp;
+};
+
+template<>
+struct Pow2RealFFT<float> {
+	static constexpr bool prefersSplit = false;
+
+	using Complex = std::complex<float>;
+
+	Pow2RealFFT(size_t size=0) {
+		resize(size);
+	}
+	~Pow2RealFFT() {
+		if (simpleFFT) delete simpleFFT;
+	}
+	// Allow move, but not copy
+	Pow2RealFFT(const Pow2RealFFT &other) = delete;
+	Pow2RealFFT(Pow2RealFFT &&other) : instance(other.instance), simpleFFT(other.simpleFFT), tmpTime(std::move(other.tmpTime)), tmpFreq(std::move(other.tmpFreq)) {
+		// Avoid double-free
+		other.simpleFFT = nullptr;
+	}
+
+	void resize(size_t size) {
+		if (simpleFFT) delete simpleFFT;
+		simpleFFT = nullptr;
+
+		if (size >= minSize && size <= maxSize) {
+			arm_rfft_fast_init_f32(&instance, uint16_t(size));
+			tmpTime.resize(size);
+			tmpFreq.resize(size/2);
+		} else {
+			simpleFFT = new SimpleRealFFT<float>(size);
+			tmpTime.resize(0);
+			tmpFreq.resize(0);
+		}
+		tmpTime.shrink_to_fit();
+		tmpFreq.shrink_to_fit();
+	}
+
+	void fft(const float *input, Complex* output) {
+		if (simpleFFT) return simpleFFT->fft(input, output);
+		std::memcpy(tmpTime.data(), input, sizeof(float)*tmpTime.size());
+		arm_rfft_fast_f32(&instance, tmpTime.data(), reinterpret_cast<float *>(output), 0);
+	}
+	void fft(const float *input, float *outR, float *outI) {
+		if (simpleFFT) return simpleFFT->fft(input, outR, outI);
+		std::memcpy(tmpTime.data(), input, sizeof(float)*tmpTime.size());
+		arm_rfft_fast_f32(&instance, tmpTime.data(), reinterpret_cast<float *>(tmpFreq.data()), 0);
+		for (size_t i = 0; i < tmpFreq.size(); ++i) {
+			auto v = tmpFreq[i];
+			outR[i] = v.real();
+			outI[i] = v.imag();
+		}
+	}
+
+	void ifft(const Complex *freq, float *time) {
+		if (simpleFFT) return simpleFFT->ifft(freq, time);
+		std::memcpy(tmpFreq.data(), freq, sizeof(Complex)*tmpFreq.size());
+		arm_rfft_fast_f32(&instance, reinterpret_cast<float *>(tmpFreq.data()), time, 1);
+		arm_scale_f32(time, float(tmpTime.size()), time, uint32_t(tmpTime.size()));
+	}
+	void ifft(const float *inR, const float *inI, float *outR) {
+		if (simpleFFT) return simpleFFT->ifft(inR, inI, outR);
+
+		for (size_t i = 0; i < tmpFreq.size(); ++i) {
+			tmpFreq[i] = {inR[i], inI[i]}; // for some reason this ends up flipped
+		}
+		arm_rfft_fast_f32(&instance, reinterpret_cast<float *>(tmpFreq.data()), outR, 1);
+		arm_scale_f32(outR, float(tmpTime.size()), outR, uint32_t(tmpTime.size()));
+	}
+
+private:
+	static constexpr size_t minSize = 32;
+	static constexpr size_t maxSize = 4096;
+	arm_rfft_fast_instance_f32 instance;
+	SimpleRealFFT<float> *simpleFFT = nullptr;
+	std::vector<float> tmpTime;
+	std::vector<Complex> tmpFreq;
+};
+
+/*
+template<>
+struct Pow2FFT<double> {
+	static constexpr bool prefersSplit = true;
+
+	using Complex = std::complex<double>;
+
+	Pow2FFT(size_t size=0) {
+		resize(size);
+	}
+	~Pow2FFT() {
+		if (hasSetup) vDSP_destroy_fftsetupD(fftSetup);
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		if (hasSetup) vDSP_destroy_fftsetupD(fftSetup);
+		if (!size) {
+			hasSetup = false;
+			return;
+		}
+
+		log2 = std::round(std::log2(size));
+		fftSetup = vDSP_create_fftsetupD(log2, FFT_RADIX2);
+		hasSetup = fftSetup;
+
+		splitReal.resize(size);
+		splitImag.resize(size);
+	}
+
+	void fft(const Complex* input, Complex* output) {
+		DSPDoubleSplitComplex splitComplex{ splitReal.data(), splitImag.data() };
+		vDSP_ctozD((DSPDoubleComplex*)input, 2, &splitComplex, 1, _size);
+		vDSP_fft_zipD(fftSetup, &splitComplex, 1, log2, kFFTDirection_Forward);
+		vDSP_ztocD(&splitComplex, 1, (DSPDoubleComplex*)output, 2, _size);
+	}
+	void fft(const double *inR, const double *inI, double *outR, double *outI) {
+		DSPDoubleSplitComplex inSplit{(double *)inR, (double *)inI};
+		DSPDoubleSplitComplex outSplit{outR, outI};
+		vDSP_fft_zopD(fftSetup, &inSplit, 1, &outSplit, 1, log2, kFFTDirection_Forward);
+	}
+
+	void ifft(const Complex* input, Complex* output) {
+		DSPDoubleSplitComplex splitComplex{ splitReal.data(), splitImag.data() };
+		vDSP_ctozD((DSPDoubleComplex*)input, 2, &splitComplex, 1, _size);
+		vDSP_fft_zipD(fftSetup, &splitComplex, 1, log2, kFFTDirection_Inverse);
+		vDSP_ztocD(&splitComplex, 1, (DSPDoubleComplex*)output, 2, _size);
+	}
+	void ifft(const double *inR, const double *inI, double *outR, double *outI) {
+		DSPDoubleSplitComplex inSplit{(double *)inR, (double *)inI};
+		DSPDoubleSplitComplex outSplit{outR, outI};
+		vDSP_fft_zopD(fftSetup, &inSplit, 1, &outSplit, 1, log2, kFFTDirection_Inverse);
+	}
+
+private:
+	size_t _size = 0;
+	bool hasSetup = false;
+	FFTSetupD fftSetup;
+	int log2 = 0;
+	std::vector<double> splitReal, splitImag;
+};
+
+template<>
+struct Pow2RealFFT<double> {
+	static constexpr bool prefersSplit = true;
+
+	using Complex = std::complex<double>;
+
+	Pow2RealFFT(size_t size = 0) {
+		resize(size);
+	}
+	~Pow2RealFFT() {
+		if (hasSetup) vDSP_destroy_fftsetupD(fftSetup);
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		if (hasSetup) vDSP_destroy_fftsetupD(fftSetup);
+		if (!size) {
+			hasSetup = false;
+			return;
+		}
+
+		splitReal.resize(size);
+		splitImag.resize(size);
+		log2 = std::log2(size);
+		fftSetup = vDSP_create_fftsetupD(log2, FFT_RADIX2);
+		hasSetup = fftSetup;
+	}
+
+	void fft(const double* input, Complex* output) {
+		double mul = 0.5f;
+		vDSP_vsmulD(input, 2, &mul, splitReal.data(), 1, _size/2);
+		vDSP_vsmulD(input + 1, 2, &mul, splitImag.data(), 1, _size/2);
+		DSPDoubleSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_fft_zripD(fftSetup, &tmpSplit, 1, log2, kFFTDirection_Forward);
+		vDSP_ztocD(&tmpSplit, 1, (DSPDoubleComplex *)output, 2, _size/2);
+	}
+	void fft(const double *inR, double *outR, double *outI) {
+		DSPDoubleSplitComplex outputSplit{outR, outI};
+		double mul = 0.5f;
+		vDSP_vsmulD(inR, 2, &mul, outR, 1, _size/2);
+		vDSP_vsmulD(inR + 1, 2, &mul, outI, 1, _size/2);
+		vDSP_fft_zripD(fftSetup, &outputSplit, 1, log2, kFFTDirection_Forward);
+	}
+
+	void ifft(const Complex * input, double * output) {
+		DSPDoubleSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_ctozD((DSPDoubleComplex*)input, 2, &tmpSplit, 1, _size/2);
+		vDSP_fft_zripD(fftSetup, &tmpSplit, 1, log2, kFFTDirection_Inverse);
+		DSPDoubleSplitComplex outputSplit{output, output + 1};
+		vDSP_zvmovD(&tmpSplit, 1, &outputSplit, 2, _size/2);
+	}
+	void ifft(const double *inR, const double *inI, double *outR) {
+		DSPDoubleSplitComplex inputSplit{(double *)inR, (double *)inI};
+		DSPDoubleSplitComplex tmpSplit{splitReal.data(), splitImag.data()};
+		vDSP_fft_zropD(fftSetup, &inputSplit, 1, &tmpSplit, 1, log2, kFFTDirection_Inverse);
+		DSPDoubleSplitComplex outputSplit{outR, outR + 1};
+		// We can't use vDSP_ztoc without knowing the alignment
+		vDSP_zvmovD(&tmpSplit, 1, &outputSplit, 2, _size/2);
+	}
+
+private:
+	size_t _size = 0;
+	bool hasSetup = false;
+	FFTSetupD fftSetup;
+	int log2 = 0;
+	std::vector<double> splitReal, splitImag;
+};
+*/
+
+}} // namespace

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-ipp.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-ipp.h
@@ -1,0 +1,532 @@
+#ifndef FFT2_FFT2_IPP_H
+#define FFT2_FFT2_IPP_H
+
+#include <ipp/ippcore.h>
+#include <ipp/ipps.h>
+
+#include <memory>
+#include <cmath>
+#include <complex>
+#include <cassert>
+
+namespace signalsmith { namespace linear {
+
+namespace {
+
+void checkStatus(IppStatus status) {
+  assert(status == ippStsNoErr);
+}
+
+template<typename T, bool complex>
+struct State{};
+
+template<>
+struct State<float, true> {
+public:
+    explicit State(size_t size) {
+        IppStatus status;
+        const auto order = static_cast<int>(std::log2(size));
+        Ipp8u* initBuffer{ nullptr };
+
+        int maxWorkingSize = 0;
+
+        {
+              int fftSpecSize, fftInitBuffSize, fftWorkBuffSize;
+              status = ippsFFTGetSize_C_32fc(order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, &fftSpecSize, &fftInitBuffSize, &fftWorkBuffSize);
+              checkStatus(status);
+              maxWorkingSize = std::max(maxWorkingSize, fftWorkBuffSize);
+              specBuffer = ippsMalloc_8u(fftSpecSize);
+              spec = (IppsFFTSpec_C_32fc*)specBuffer;
+              if (fftInitBuffSize != 0) {
+                    initBuffer = ippsMalloc_8u(fftInitBuffSize);
+              }
+              status = ippsFFTInit_C_32fc(&spec, order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, specBuffer, initBuffer);
+
+              checkStatus(status);
+              if (initBuffer) {
+                    ippsFree(initBuffer);
+              }
+        }
+
+        {
+              int fftSpecSize, fftInitBuffSize, fftWorkBuffSize;
+              status = ippsFFTGetSize_C_32f(order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, &fftSpecSize, &fftInitBuffSize, &fftWorkBuffSize);
+              checkStatus(status);
+              maxWorkingSize = std::max(maxWorkingSize, fftWorkBuffSize);
+              specSplitBuffer = ippsMalloc_8u(fftSpecSize);
+              specSplit = (IppsFFTSpec_C_32f*)specSplitBuffer;
+              if (fftInitBuffSize != 0) {
+                    initBuffer = ippsMalloc_8u(fftInitBuffSize);
+              }
+              status = ippsFFTInit_C_32f(&specSplit, order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, specSplitBuffer, initBuffer);
+
+              checkStatus(status);
+              if (initBuffer) {
+                    ippsFree(initBuffer);
+              }
+        }
+
+        if(maxWorkingSize != 0) {
+              workBuffer = ippsMalloc_8u(maxWorkingSize);
+              workSize = maxWorkingSize;
+        }
+    }
+
+    ~State() noexcept {
+          if(specBuffer) {
+                ippsFree(specBuffer);
+          }
+          if(specSplitBuffer) {
+                ippsFree(specSplitBuffer);
+          }
+          if(workBuffer) {
+            ippsFree(workBuffer);
+        }
+    }
+
+    IppsFFTSpec_C_32fc *spec{nullptr};
+    IppsFFTSpec_C_32f *specSplit{nullptr};
+    Ipp8u *specBuffer{nullptr};
+    Ipp8u *specSplitBuffer{nullptr};
+    Ipp8u *workBuffer{nullptr};
+    size_t workSize = 0;
+};
+
+template<>
+struct State<float, false> {
+public:
+      explicit State(size_t size) {
+            IppStatus status;
+            const auto order = static_cast<int>(std::log2(size));
+            Ipp8u* initBuffer{ nullptr };
+
+            int maxWorkingSize = 0;
+
+            int fftSpecSize, fftInitBuffSize, fftWorkBuffSize;
+            status = ippsFFTGetSize_R_32f(order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, &fftSpecSize, &fftInitBuffSize, &fftWorkBuffSize);
+            checkStatus(status);
+            maxWorkingSize = std::max(maxWorkingSize, fftWorkBuffSize);
+            specBuffer = ippsMalloc_8u(fftSpecSize);
+            spec = (IppsFFTSpec_R_32f*)specBuffer;
+            if (fftInitBuffSize != 0) {
+                  initBuffer = ippsMalloc_8u(fftInitBuffSize);
+            }
+            status = ippsFFTInit_R_32f(&spec, order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, specBuffer, initBuffer);
+
+            checkStatus(status);
+            if (initBuffer) {
+                  ippsFree(initBuffer);
+            }
+
+            if(maxWorkingSize != 0) {
+                  workBuffer = ippsMalloc_8u(maxWorkingSize);
+                  workSize = maxWorkingSize;
+            }
+      }
+
+      ~State() noexcept {
+            if(specBuffer) {
+                  ippsFree(specBuffer);
+            }
+            if(workBuffer) {
+                  ippsFree(workBuffer);
+            }
+      }
+
+      IppsFFTSpec_R_32f *spec{nullptr};
+      Ipp8u *specBuffer{nullptr};
+      Ipp8u *workBuffer{nullptr};
+      size_t workSize = 0;
+};
+
+template<>
+struct State<double, true> {
+      explicit State(size_t size) {
+            IppStatus status;
+            const auto order = static_cast<int>(std::log2(size));
+            Ipp8u* initBuffer{ nullptr };
+
+            int maxWorkingSize = 0;
+
+            {
+                  int fftSpecSize, fftInitBuffSize, fftWorkBuffSize;
+                  status = ippsFFTGetSize_C_64fc(order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, &fftSpecSize, &fftInitBuffSize, &fftWorkBuffSize);
+                  checkStatus(status);
+                  maxWorkingSize = std::max(maxWorkingSize, fftWorkBuffSize);
+                  specBuffer = ippsMalloc_8u(fftSpecSize);
+                  spec = (IppsFFTSpec_C_64fc*)specBuffer;
+                  if (fftInitBuffSize != 0) {
+                        initBuffer = ippsMalloc_8u(fftInitBuffSize);
+                  }
+                  status = ippsFFTInit_C_64fc(&spec, order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, specBuffer, initBuffer);
+
+                  checkStatus(status);
+                  if (initBuffer) {
+                        ippsFree(initBuffer);
+                  }
+            }
+
+            {
+                  int fftSpecSize, fftInitBuffSize, fftWorkBuffSize;
+                  status = ippsFFTGetSize_C_64f(order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, &fftSpecSize, &fftInitBuffSize, &fftWorkBuffSize);
+                  checkStatus(status);
+                  maxWorkingSize = std::max(maxWorkingSize, fftWorkBuffSize);
+                  specSplitBuffer = ippsMalloc_8u(fftSpecSize);
+                  specSplit = (IppsFFTSpec_C_64f*)specSplitBuffer;
+                  if (fftInitBuffSize != 0) {
+                        initBuffer = ippsMalloc_8u(fftInitBuffSize);
+                  }
+                  status = ippsFFTInit_C_64f(&specSplit, order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, specSplitBuffer, initBuffer);
+
+                  checkStatus(status);
+                  if (initBuffer) {
+                        ippsFree(initBuffer);
+                  }
+            }
+
+            if(maxWorkingSize != 0) {
+                  workBuffer = ippsMalloc_8u(maxWorkingSize);
+                  workSize = maxWorkingSize;
+            }
+      }
+
+      ~State() noexcept {
+            if(specBuffer) {
+                  ippsFree(specBuffer);
+            }
+            if(specSplitBuffer) {
+                  ippsFree(specSplitBuffer);
+            }
+            if(workBuffer) {
+                  ippsFree(workBuffer);
+            }
+      }
+
+      IppsFFTSpec_C_64fc *spec{nullptr};
+      IppsFFTSpec_C_64f *specSplit{nullptr};
+      Ipp8u *specBuffer{nullptr};
+      Ipp8u *specSplitBuffer{nullptr};
+      Ipp8u *workBuffer{nullptr};
+      size_t workSize = 0;
+};
+
+template<>
+struct State<double, false> {
+    explicit State(size_t size) {
+        IppStatus status;
+        const auto order = static_cast<int>(std::log2(size));
+        Ipp8u* initBuffer{ nullptr };
+
+        int maxWorkingSize = 0;
+
+            int fftSpecSize, fftInitBuffSize, fftWorkBuffSize;
+            status = ippsFFTGetSize_R_64f(order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, &fftSpecSize, &fftInitBuffSize, &fftWorkBuffSize);
+            checkStatus(status);
+            maxWorkingSize = std::max(maxWorkingSize, fftWorkBuffSize);
+            specBuffer = ippsMalloc_8u(fftSpecSize);
+            spec = (IppsFFTSpec_R_64f*)specBuffer;
+            if (fftInitBuffSize != 0) {
+                  initBuffer = ippsMalloc_8u(fftInitBuffSize);
+            }
+            status = ippsFFTInit_R_64f(&spec, order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast, specBuffer, initBuffer);
+
+            checkStatus(status);
+            if (initBuffer) {
+                  ippsFree(initBuffer);
+            }
+
+
+        if(maxWorkingSize != 0) {
+              workBuffer = ippsMalloc_8u(maxWorkingSize);
+              workSize = maxWorkingSize;
+        }
+    }
+
+    ~State() noexcept {
+          if(specBuffer) {
+                ippsFree(specBuffer);
+          }
+          if(workBuffer) {
+            ippsFree(workBuffer);
+        }
+    }
+
+    IppsFFTSpec_R_64f *spec{nullptr};
+    Ipp8u *specBuffer{nullptr};
+    Ipp8u *workBuffer{nullptr};
+    size_t workSize = 0;
+
+};
+} // namespace
+
+
+namespace _impl {
+      template<>
+      void complexMul<float>(std::complex<float> *a, const std::complex<float> *b, const std::complex<float> *c, size_t size) {
+            auto status = ippsMul_32fc((const Ipp32fc*)b, (const Ipp32fc*)c, (Ipp32fc*)a, int(size));
+            checkStatus(status);
+      }
+      //template<>
+      //void complexMulConj<float>(std::complex<float> *a, const std::complex<float> *b, const std::complex<float> *c, size_t size) {
+      //      DSPSplitComplex aSplit = {(float *)a, (float *)a + 1};
+      //      DSPSplitComplex bSplit = {(float *)b, (float *)b + 1};
+      //      DSPSplitComplex cSplit = {(float *)c, (float *)c + 1};
+      //      vDSP_zvmul(&cSplit, 2, &bSplit, 2, &aSplit, 2, size, -1);
+      //}
+      //template<>
+      //void complexMul<float>(float *ar, float *ai, const float *br, const float *bi, const float *cr, const float *ci, size_t size) {
+      //      DSPSplitComplex aSplit = {ar, ai};
+      //      DSPSplitComplex bSplit = {(float *)br, (float *)bi};
+      //      DSPSplitComplex cSplit = {(float *)cr, (float *)ci};
+      //      vDSP_zvmul(&cSplit, 1, &bSplit, 1, &aSplit, 1, size, 1);
+      //}
+      //template<>
+      //void complexMulConj<float>(float *ar, float *ai, const float *br, const float *bi, const float *cr, const float *ci, size_t size) {
+      //      DSPSplitComplex aSplit = {ar, ai};
+      //      DSPSplitComplex bSplit = {(float *)br, (float *)bi};
+      //      DSPSplitComplex cSplit = {(float *)cr, (float *)ci};
+      //      vDSP_zvmul(&cSplit, 1, &bSplit, 1, &aSplit, 1, size, -1);
+      //}
+
+      // doubles
+      template<>
+      void complexMul<double>(std::complex<double> *a, const std::complex<double> *b, const std::complex<double> *c, size_t size) {
+            auto status = ippsMul_64fc((const Ipp64fc*)b, (const Ipp64fc*)c, (Ipp64fc*)a, int(size));
+            checkStatus(status);
+      }
+      //template<>
+      //void complexMulConj<double>(std::complex<double> *a, const std::complex<double> *b, const std::complex<double> *c, size_t size) {
+      //      DSPDoubleSplitComplex aSplit = {(double *)a, (double *)a + 1};
+      //      DSPDoubleSplitComplex bSplit = {(double *)b, (double *)b + 1};
+      //      DSPDoubleSplitComplex cSplit = {(double *)c, (double *)c + 1};
+      //      vDSP_zvmulD(&cSplit, 2, &bSplit, 2, &aSplit, 2, size, -1);
+      //}
+      //template<>
+      //void complexMul<double>(double *ar, double *ai, const double *br, const double *bi, const double *cr, const double *ci, size_t size) {
+      //      DSPDoubleSplitComplex aSplit = {ar, ai};
+      //      DSPDoubleSplitComplex bSplit = {(double *)br, (double *)bi};
+      //      DSPDoubleSplitComplex cSplit = {(double *)cr, (double *)ci};
+      //      vDSP_zvmulD(&cSplit, 1, &bSplit, 1, &aSplit, 1, size, 1);
+      //}
+      //template<>
+      //void complexMulConj<double>(double *ar, double *ai, const double *br, const double *bi, const double *cr, const double *ci, size_t size) {
+      //      DSPDoubleSplitComplex aSplit = {ar, ai};
+      //      DSPDoubleSplitComplex bSplit = {(double *)br, (double *)bi};
+      //      DSPDoubleSplitComplex cSplit = {(double *)cr, (double *)ci};
+      //      vDSP_zvmulD(&cSplit, 1, &bSplit, 1, &aSplit, 1, size, -1);
+      //}
+}
+
+template<>
+struct Pow2FFT<float> {
+      static constexpr bool prefersSplit = true; // whether this FFT implementation is faster when given split-complex inputs
+
+      Pow2FFT(size_t size = 0) {
+        if(size > 0) {
+            resize(size);
+        }
+    }
+
+    void resize(size_t size) {
+        m_state = std::make_unique<State<float, true>>(size);
+    }
+
+    void fft(const std::complex<float>* input, std::complex<float>* output) {
+          auto* ippComplexIn = reinterpret_cast<const Ipp32fc*>(input);
+          auto* ippComplexOut = reinterpret_cast<Ipp32fc*>(output);
+          const auto status = ippsFFTFwd_CToC_32fc(ippComplexIn, ippComplexOut, m_state->spec, m_state->workBuffer);
+          checkStatus(status);
+    }
+
+    void fft(const float *inR, const float *inI, float *outR, float *outI) {
+          const auto status = ippsFFTFwd_CToC_32f((const Ipp32f*)inR, (const Ipp32f*)inI, (Ipp32f*)outR, (Ipp32f*)outI, m_state->specSplit, m_state->workBuffer);
+          checkStatus(status);
+    }
+
+    void ifft(const std::complex<float>* input, std::complex<float>* output) {
+          auto* ippComplexIn = reinterpret_cast<const Ipp32fc*>(input);
+          auto* ippComplexOut = reinterpret_cast<Ipp32fc*>(output);
+          const auto status = ippsFFTInv_CToC_32fc(ippComplexIn, ippComplexOut, m_state->spec, m_state->workBuffer);
+          checkStatus(status);
+    }
+
+    void ifft(const float *inR, const float *inI, float *outR, float *outI) {
+          const auto status = ippsFFTInv_CToC_32f((const Ipp32f*)inR, (const Ipp32f*)inI, (Ipp32f*)outR, (Ipp32f*)outI, m_state->specSplit, m_state->workBuffer);
+          checkStatus(status);
+    }
+
+private:
+  std::unique_ptr<State<float, true>> m_state{ nullptr };
+};
+
+template<>
+struct Pow2RealFFT<float> {
+      static constexpr bool prefersSplit = false; // whether this FFT implementation is faster when given split-complex inputs
+
+      Pow2RealFFT(size_t size = 0) {
+            if(size > 0) {
+                  resize(size);
+            }
+      }
+
+      void resize(size_t size) {
+            hSize = size/2;
+            size = hSize * 2;
+            m_state = std::make_unique<State<float, false>>(size);
+
+            // Either use the existing working buffer (if it's big enough), or allocate a new one using std::vector<>
+            size_t complexAlign = alignof(std::complex<float>);
+            size_t work = size_t(m_state->workBuffer);
+            size_t aligned = (work + (complexAlign - 1)) & ~(complexAlign - 1);
+
+            if (work + m_state->workSize - aligned >= size * sizeof(std::complex<float>)) {
+                  tmp = (std::complex<float> *) aligned;
+                  tmpVector.resize(0);
+            } else {
+                  tmpVector.resize(size);
+                  tmp = tmpVector.data();
+            }
+      }
+
+      void fft(const float *input, std::complex<float>* output) {
+            const auto status = ippsFFTFwd_RToPerm_32f((const Ipp32f*)input, (Ipp32f*)output, m_state->spec, m_state->workBuffer);
+            checkStatus(status);
+      }
+
+      void fft(const float *inR, float *outR, float *outI) {
+            const auto status = ippsFFTFwd_RToPerm_32f((const Ipp32f*)inR, (Ipp32f*)tmp, m_state->spec, m_state->workBuffer);
+            checkStatus(status);
+            for (size_t i = 0; i < hSize; ++i) {
+                  outR[i] = tmp[i].real();
+                  outI[i] = tmp[i].imag();
+            }
+      }
+
+      void ifft(const std::complex<float>* input, float *output) {
+            const auto status = ippsFFTInv_PermToR_32f((const Ipp32f*)input, (Ipp32f*)output, m_state->spec, m_state->workBuffer);
+            checkStatus(status);
+      }
+
+      void ifft(const float *inR, const float *inI, float *outR) {
+            for (size_t i = 0; i < hSize; ++i) {
+                  tmp[i] = { inR[i], inI[i] };
+            }
+            const auto status = ippsFFTInv_PermToR_32f((const Ipp32f*)tmp, (Ipp32f*)outR, m_state->spec, m_state->workBuffer);
+            checkStatus(status);
+      }
+
+private:
+      std::unique_ptr<State<float, false>> m_state{ nullptr };
+      std::complex<float>* tmp = nullptr;
+      std::vector<std::complex<float>> tmpVector;
+      size_t hSize;
+};
+
+template<>
+struct Pow2FFT<double> {
+      static constexpr bool prefersSplit = true; // whether this FFT implementation is faster when given split-complex inputs
+      
+      Pow2FFT(size_t size = 0) {
+        if(size > 0) {
+            resize(size);
+        }
+    }
+
+    void resize(size_t size) {
+        m_state = std::make_unique<State<double, true>>(size);
+    }
+
+    void fft(const std::complex<double>* input, std::complex<double>* output) {
+        auto* ippComplexIn = reinterpret_cast<const Ipp64fc*>(input);
+        auto* ippComplexOut = reinterpret_cast<Ipp64fc*>(output);
+        const auto status = ippsFFTFwd_CToC_64fc(ippComplexIn, ippComplexOut, m_state->spec, m_state->workBuffer);
+        checkStatus(status);
+    }
+
+    void fft(const double *inR, const double *inI, double *outR, double *outI) {
+          const auto status = ippsFFTFwd_CToC_64f((const Ipp64f*)inR, (const Ipp64f*)inI, (Ipp64f*)outR, (Ipp64f*)outI, m_state->specSplit, m_state->workBuffer);
+          checkStatus(status);
+    }
+
+    void ifft(const std::complex<double>* input, std::complex<double>* output) {
+        auto* ippComplexIn = reinterpret_cast<const Ipp64fc*>(input);
+        auto* ippComplexOut = reinterpret_cast<Ipp64fc*>(output);
+        const auto status = ippsFFTInv_CToC_64fc(ippComplexIn, ippComplexOut, m_state->spec, m_state->workBuffer);
+        checkStatus(status);
+    }
+
+    void ifft(const double *inR, const double *inI, double *outR, double *outI) {
+          const auto status = ippsFFTInv_CToC_64f((const Ipp64f*)inR, (const Ipp64f*)inI, (Ipp64f*)outR, (Ipp64f*)outI, m_state->specSplit, m_state->workBuffer);
+          checkStatus(status);
+    }
+
+private:
+  std::unique_ptr<State<double, true>> m_state{ nullptr };
+};
+
+template<>
+struct Pow2RealFFT<double> {
+      static constexpr bool prefersSplit = false; // whether this FFT implementation is faster when given split-complex inputs
+
+      Pow2RealFFT(size_t size = 0) {
+            if(size > 0) {
+                  resize(size);
+            }
+      }
+
+      void resize(size_t size) {
+            hSize = size/2;
+            size = hSize * 2;
+            m_state = std::make_unique<State<double, false>>(size);
+
+            // Either use the existing working buffer (if it's big enough), or allocate a new one using std::vector<>
+            size_t complexAlign = alignof(std::complex<double>);
+            size_t work = size_t(m_state->workBuffer);
+            size_t aligned = (work + (complexAlign - 1)) & ~(complexAlign - 1);
+
+            if (work + m_state->workSize - aligned >= size * sizeof(std::complex<double>)) {
+                  tmp = (std::complex<double> *) aligned;
+                  tmpVector.resize(0);
+            } else {
+                  tmpVector.resize(size);
+                  tmp = tmpVector.data();
+            }
+      }
+
+      void fft(const double *input, std::complex<double>* output) {
+            const auto status = ippsFFTFwd_RToPerm_64f((const Ipp64f*)input, (Ipp64f*)output, m_state->spec, m_state->workBuffer);
+            checkStatus(status);
+      }
+
+      void fft(const double *inR, double *outR, double *outI) {
+            const auto status = ippsFFTFwd_RToPerm_64f((const Ipp64f*)inR, (Ipp64f*)tmp, m_state->spec, m_state->workBuffer);
+            checkStatus(status);
+            for (size_t i = 0; i < hSize; ++i) {
+                  outR[i] = tmp[i].real();
+                  outI[i] = tmp[i].imag();
+            }
+      }
+
+      void ifft(const std::complex<double>* input, double *output) {
+            const auto status = ippsFFTInv_PermToR_64f((const Ipp64f*)input, (Ipp64f*)output, m_state->spec, m_state->workBuffer);
+            checkStatus(status);
+      }
+
+      void ifft(const double *inR, const double *inI, double *outR) {
+            for (size_t i = 0; i < hSize; ++i) {
+                  tmp[i] = { inR[i], inI[i] };
+            }
+            const auto status = ippsFFTInv_PermToR_64f((const Ipp64f*)tmp, (Ipp64f*)outR, m_state->spec, m_state->workBuffer);
+            checkStatus(status);
+      }
+
+private:
+      std::unique_ptr<State<double, false>> m_state{ nullptr };
+      std::complex<double>* tmp = nullptr;
+      std::vector<std::complex<double>> tmpVector;
+      size_t hSize;
+};
+
+}}
+
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-linear.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-linear.h
@@ -1,0 +1,213 @@
+#ifndef SIGNALSMITH_LINEAR_PLATFORM_FFT_LINEAR_H
+#define SIGNALSMITH_LINEAR_PLATFORM_FFT_LINEAR_H
+
+#include "../linear.h"
+
+namespace signalsmith { namespace linear {
+
+namespace _impl_linear_fft {
+
+/// SimpleFFT, but rewritten to use some Linear functions
+template<typename Sample>
+struct LinearFFT {
+	static constexpr bool prefersSplit = true;
+
+	using Complex = std::complex<Sample>;
+	
+	LinearFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		twiddles.resize(size*3/4);
+		for (size_t i = 0; i < size*3/4; ++i) {
+			Sample twiddlePhase = -2*M_PI*i/size;
+			twiddles[i] = std::polar(Sample(1), twiddlePhase);
+		}
+		working.resize(size);
+	}
+	
+	void fft(const Complex *time, Complex *freq) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*freq = *time;
+			return;
+		}
+		fftPass<false>(size, 1, time, freq, working.data());
+	}
+
+	void ifft(const Complex *freq, Complex *time) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*time = *freq;
+			return;
+		}
+		fftPass<true>(size, 1, freq, time, working.data());
+	}
+
+	void fft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*outR = *inR;
+			*outI = *inI;
+			return;
+		}
+		Sample *workingR = (Sample *)working.data(), *workingI = workingR + size;
+		fftPass<false>(size, 1, inR, inI, outR, outI, workingR, workingI);
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*outR = *inR;
+			*outI = *inI;
+			return;
+		}
+		Sample *workingR = (Sample *)working.data(), *workingI = workingR + size;
+		fftPass<true>(size, 1, inR, inI, outR, outI, workingR, workingI);
+	}
+private:
+	std::vector<Complex> twiddles;
+	std::vector<Complex> working;
+	
+	template<bool conjB>
+	static Complex mul(const Complex &a, const Complex &b) {
+		return conjB ? Complex{
+			a.real()*b.real() + a.imag()*b.imag(),
+			a.imag()*b.real() - a.real()*b.imag()
+		} : Complex{
+			a.real()*b.real() - a.imag()*b.imag(),
+			a.imag()*b.real() + a.real()*b.imag()
+		};
+	}
+
+	// Calculate a [size]-point FFT, where each element is a block of [stride] values
+	template<bool inverse>
+	void fftPass(size_t size, size_t stride, const Complex *input, Complex *output, Complex *working) {
+		if (size/4 > 1) {
+			// Calculate four quarter-size FFTs
+			fftPass<inverse>(size/4, stride*4, input, working, output);
+			combine4<inverse>(size, stride, working, output);
+		} else if (size == 4) {
+			combine4<inverse>(4, stride, input, output);
+		} else {
+			// 2-point FFT
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = input[s];
+				Complex b = input[s + stride];
+				output[s] = a + b;
+				output[s + stride] = a - b;
+			}
+		}
+	}
+
+	// Combine interleaved results into a single spectrum
+	template<bool inverse>
+	void combine4(size_t size, size_t stride, const Complex *input, Complex *output) const {
+		auto twiddleStep = working.size()/size;
+		for (size_t i = 0; i < size/4; ++i) {
+			Complex twiddleB = twiddles[i*twiddleStep];
+			Complex twiddleC = twiddles[i*2*twiddleStep];
+			Complex twiddleD = twiddles[i*3*twiddleStep];
+			
+			const Complex *inputA = input + 4*i*stride;
+			const Complex *inputB = input + (4*i + 1)*stride;
+			const Complex *inputC = input + (4*i + 2)*stride;
+			const Complex *inputD = input + (4*i + 3)*stride;
+			Complex *outputA = output + i*stride;
+			Complex *outputB = output + (i + size/4)*stride;
+			Complex *outputC = output + (i + size/4*2)*stride;
+			Complex *outputD = output + (i + size/4*3)*stride;
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = inputA[s];
+				Complex b = mul<inverse>(inputB[s], twiddleB);
+				Complex c = mul<inverse>(inputC[s], twiddleC);
+				Complex d = mul<inverse>(inputD[s], twiddleD);
+				Complex ac0 = a + c, ac1 = a - c;
+				Complex bd0 = b + d, bd1 = inverse ? (b - d) : (d - b);
+				Complex bd1i = {-bd1.imag(), bd1.real()};
+				outputA[s] = ac0 + bd0;
+				outputB[s] = ac1 + bd1i;
+				outputC[s] = ac0 - bd0;
+				outputD[s] = ac1 - bd1i;
+			}
+		}
+	}
+
+	// The same thing, but translated for split-complex input/output
+	template<bool inverse>
+	void fftPass(size_t size, size_t stride, const Sample *inputR, const Sample *inputI, Sample *outputR, Sample *outputI, Sample *workingR, Sample *workingI) const {
+		if (size/4 > 1) {
+			// Calculate four quarter-size FFTs
+			fftPass<inverse>(size/4, stride*4, inputR, inputI, workingR, workingI, outputR, outputI);
+			combine4<inverse>(size, stride, workingR, workingI, outputR, outputI);
+		} else if (size == 4) {
+			combine4<inverse>(4, stride, inputR, inputI, outputR, outputI);
+		} else {
+			// 2-point FFT
+			for (size_t s = 0; s < stride; ++s) {
+				Sample ar = inputR[s], ai = inputI[s];
+				Sample br = inputR[s + stride], bi = inputI[s + stride];
+				outputR[s] = ar + br;
+				outputI[s] = ai + bi;
+				outputR[s + stride] = ar - br;
+				outputI[s + stride] = ai - bi;
+			}
+		}
+	}
+
+	// Combine interleaved results into a single spectrum
+	template<bool inverse>
+	void combine4(size_t size, size_t stride, const Sample *inputR, const Sample *inputI, Sample *outputR, Sample *outputI) const {
+		auto twiddleStep = working.size()/size;
+		for (size_t i = 0; i < size/4; ++i) {
+			Complex twiddleB = twiddles[i*twiddleStep];
+			Complex twiddleC = twiddles[i*2*twiddleStep];
+			Complex twiddleD = twiddles[i*3*twiddleStep];
+			
+			const Sample *inputAr = inputR + 4*i*stride, *inputAi = inputI + 4*i*stride;
+			const Sample *inputBr = inputR + (4*i + 1)*stride, *inputBi = inputI + (4*i + 1)*stride;
+			const Sample *inputCr = inputR + (4*i + 2)*stride, *inputCi = inputI + (4*i + 2)*stride;
+			const Sample *inputDr = inputR + (4*i + 3)*stride, *inputDi = inputI + (4*i + 3)*stride;
+			Sample *outputAr = outputR + i*stride, *outputAi = outputI + i*stride;
+			Sample *outputBr = outputR + (i + size/4)*stride, *outputBi = outputI + (i + size/4)*stride;
+			Sample *outputCr = outputR + (i + size/4*2)*stride, *outputCi = outputI + (i + size/4*2)*stride;
+			Sample *outputDr = outputR + (i + size/4*3)*stride, *outputDi = outputI + (i + size/4*3)*stride;
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = {inputAr[s], inputAi[s]};
+				Complex b = mul<inverse>({inputBr[s], inputBi[s]}, twiddleB);
+				Complex c = mul<inverse>({inputCr[s], inputCi[s]}, twiddleC);
+				Complex d = mul<inverse>({inputDr[s], inputDi[s]}, twiddleD);
+				Complex ac0 = a + c, ac1 = a - c;
+				Complex bd0 = b + d, bd1 = inverse ? (b - d) : (d - b);
+				Complex bd1i = {-bd1.imag(), bd1.real()};
+				outputAr[s] = ac0.real() + bd0.real();
+				outputAi[s] = ac0.imag() + bd0.imag();
+				outputBr[s] = ac1.real() + bd1i.real();
+				outputBi[s] = ac1.imag() + bd1i.imag();
+				outputCr[s] = ac0.real() - bd0.real();
+				outputCi[s] = ac0.imag() - bd0.imag();
+				outputDr[s] = ac1.real() - bd1i.real();
+				outputDi[s] = ac1.imag() - bd1i.imag();
+			}
+		}
+	}
+};
+
+} // namespace
+
+template<>
+struct Pow2FFT<float> : public _impl_linear_fft::LinearFFT<float> {
+private:
+	using Super = _impl_linear_fft::LinearFFT<float>;
+public:
+	using Complex = std::complex<float>;
+
+	Pow2FFT(size_t size=0) : Super(size) {}
+
+	// Allow move, but not copy
+	Pow2FFT(const Pow2FFT &other) = delete;
+	Pow2FFT(Pow2FFT &&other) : Super(std::move(other)) {}
+};
+
+}} // namespace
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-pffft-double.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-pffft-double.h
@@ -1,0 +1,221 @@
+#ifndef SIGNALSMITH_LINEAR_PLATFORM_FFT_PFFFTDOUBLE_H
+#define SIGNALSMITH_LINEAR_PLATFORM_FFT_PFFFTDOUBLE_H
+
+#if defined(__has_include) && !__has_include("pffft/pffft_double.h")
+#	include "pffft_double.h"
+#else
+#	include "pffft/pffft_double.h"
+#endif
+
+#include <memory>
+#include <cmath>
+#include <complex>
+#include <cassert>
+
+namespace signalsmith { namespace linear {
+
+template<>
+struct Pow2FFT<double> {
+	static constexpr bool prefersSplit = false;
+
+	using Complex = std::complex<double>;
+
+	Pow2FFT(size_t size=0) {
+		resize(size);
+	}
+	~Pow2FFT() {
+		resize(0); // frees everything
+	}
+	// Allow move, but not copy
+	Pow2FFT(const Pow2FFT &other) = delete;
+	Pow2FFT(Pow2FFT &&other) : _size(other._size), hasSetup(other.hasSetup), fftSetup(other.fftSetup), fallback(std::move(other.fallback)), work(other.work), tmpAligned(other.tmpAligned) {
+		// Avoid double-free
+		other.hasSetup = false;
+		other.work = nullptr;
+		other.tmpAligned = nullptr;
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		fallback = nullptr;
+		if (hasSetup) pffftd_destroy_setup(fftSetup);
+		if (work) pffftd_aligned_free(work);
+		work = nullptr;
+		if (tmpAligned) pffftd_aligned_free(tmpAligned);
+		tmpAligned = nullptr;
+
+		// We use this for split-real, even if there's no PFFFT setup
+		tmpAligned = (double *)pffftd_aligned_malloc(sizeof(double)*size*2);
+
+		if (size < 16) {
+			// PFFFT doesn't support smaller sizes
+			hasSetup = false;
+			fallback = std::unique_ptr<SimpleFFT<double>>{
+				new SimpleFFT<double>(size)
+			};
+			return;
+		}
+		
+		work = (double *)pffftd_aligned_malloc(sizeof(double)*size*2);
+		fftSetup = pffftd_new_setup(int(size), PFFFT_COMPLEX);
+		hasSetup = fftSetup;
+	}
+
+	void fft(const Complex* input, Complex* output) {
+		if (fallback) return fallback->fft(input, output);
+		fftInner(input, output, PFFFT_FORWARD);
+	}
+	void fft(const double *inR, const double *inI, double *outR, double *outI) {
+		if (fallback) return fallback->fft(inR, inI, outR, outI);
+		fftInner(inR, inI, outR, outI, PFFFT_FORWARD);
+	}
+
+	void ifft(const Complex* input, Complex* output) {
+		if (fallback) return fallback->ifft(input, output);
+		fftInner(input, output, PFFFT_BACKWARD);
+	}
+	void ifft(const double *inR, const double *inI, double *outR, double *outI) {
+		if (fallback) return fallback->ifft(inR, inI, outR, outI);
+		fftInner(inR, inI, outR, outI, PFFFT_BACKWARD);
+	}
+
+private:
+	void fftInner(const Complex *input, Complex *output, pffft_direction_t direction) {
+		// 32-byte alignment
+		if (size_t(input)&0x1F) {
+			// `tmpAligned` is always aligned, so copy into that
+			std::memcpy(static_cast<void *>(tmpAligned), static_cast<const void *>(input), sizeof(Complex)*_size);
+			input = (const Complex *)tmpAligned;
+		}
+		if (size_t(output)&0x1F) {
+			// Output to `tmpAligned` - might be in-place if input is unaligned, but that's fine
+			pffftd_transform_ordered(fftSetup, (const double *)input, tmpAligned, work, direction);
+			std::memcpy(static_cast<void *>(output), static_cast<const void *>(tmpAligned), sizeof(Complex)*_size);
+		} else {
+			pffftd_transform_ordered(fftSetup, (const double *)input, (double *)output, work, direction);
+		}
+	}
+	void fftInner(const double *inR, const double *inI, double *outR, double *outI, pffft_direction_t direction) {
+		for (size_t i = 0; i < _size; ++i) {
+			tmpAligned[2*i] = inR[i];
+			tmpAligned[2*i + 1] = inI[i];
+		}
+		// PFFFT supports in-place transforms
+		fftInner((const Complex *)tmpAligned, (Complex *)tmpAligned, direction);
+		// Un-interleave
+		for (size_t i = 0; i < _size; ++i) {
+			outR[i] = tmpAligned[2*i];
+			outI[i] = tmpAligned[2*i + 1];
+		}
+	}
+
+	size_t _size = 0;
+	bool hasSetup = false;
+	PFFFTD_Setup *fftSetup = nullptr;
+	std::unique_ptr<SimpleFFT<double>> fallback;
+	double *work = nullptr, *tmpAligned = nullptr;
+};
+
+template<>
+struct Pow2RealFFT<double> {
+private:
+	using FallbackFFT = SimpleRealFFT<double>; // this wraps the complex one
+public:
+	static constexpr bool prefersSplit = false;
+
+	using Complex = std::complex<double>;
+
+	Pow2RealFFT(size_t size=0) {
+		resize(size);
+	}
+	~Pow2RealFFT() {
+		resize(0);
+	}
+	// Allow move, but not copy
+	Pow2RealFFT(const Pow2RealFFT &other) = delete;
+	Pow2RealFFT(Pow2RealFFT &&other) : _size(other._size), hasSetup(other.hasSetup), fftSetup(other.fftSetup), fallback(std::move(other.fallback)), work(other.work), tmpAligned(other.tmpAligned) {
+		// Avoid double-free
+		other.hasSetup = false;
+		other.work = nullptr;
+		other.tmpAligned = nullptr;
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		fallback = nullptr;
+		if (hasSetup) pffftd_destroy_setup(fftSetup);
+		if (work) pffftd_aligned_free(work);
+		work = nullptr;
+		if (tmpAligned) pffftd_aligned_free(tmpAligned);
+		tmpAligned = nullptr;
+
+		// We use this for split-real, even if there's no PFFFT setup
+		tmpAligned = (double *)pffftd_aligned_malloc(sizeof(double)*size*2);
+
+		// TODO: just go for it, and check for success before allocating `work`
+		if (size < 32) {
+			// PFFFT doesn't support smaller sizes
+			hasSetup = false;
+			fallback = std::unique_ptr<FallbackFFT>{
+				new FallbackFFT(size)
+			};
+			return;
+		}
+		
+		work = (double *)pffftd_aligned_malloc(sizeof(double)*size);
+		fftSetup = pffftd_new_setup(int(size), PFFFT_REAL);
+		hasSetup = fftSetup;
+	}
+
+	void fft(const double *input, Complex *output) {
+		if (fallback) return fallback->fft(input, output);
+		fftInner(input, (double *)output, PFFFT_FORWARD);
+	}
+	void fft(const double *inR, double *outR, double *outI) {
+		if (fallback) return fallback->fft(inR, outR, outI);
+		fftInner(inR, tmpAligned, PFFFT_FORWARD);
+		for (size_t i = 0; i < _size/2; ++i) {
+			outR[i] = tmpAligned[2*i];
+			outI[i] = tmpAligned[2*i + 1];
+		}
+	}
+
+	void ifft(const Complex *input, double *output) {
+		if (fallback) return fallback->ifft(input, output);
+		fftInner((const double *)input, output, PFFFT_BACKWARD);
+	}
+	void ifft(const double *inR, const double *inI, double *outR) {
+		if (fallback) return fallback->ifft(inR, inI, outR);
+		for (size_t i = 0; i < _size/2; ++i) {
+			tmpAligned[2*i] = inR[i];
+			tmpAligned[2*i + 1] = inI[i];
+		}
+		fftInner(tmpAligned, outR, PFFFT_BACKWARD);
+	}
+
+private:
+	void fftInner(const double *input, double *output, pffft_direction_t direction) {
+		// 32-byte alignment
+		if (size_t(input)&0x1F) {
+			// `tmpAligned` is always aligned, so copy into that
+			std::memcpy(static_cast<void *>(tmpAligned), static_cast<const void *>(input), sizeof(double)*_size);
+			input = tmpAligned;
+		}
+		if (size_t(output)&0x1F) {
+			// Output to `tmpAligned` - might be in-place if input is unaligned, but that's fine
+			pffftd_transform_ordered(fftSetup, input, tmpAligned, work, direction);
+			std::memcpy(static_cast<void *>(output), static_cast<const void *>(tmpAligned), sizeof(double)*_size);
+		} else {
+			pffftd_transform_ordered(fftSetup, input, output, work, direction);
+		}
+	}
+
+	size_t _size = 0;
+	bool hasSetup = false;
+	PFFFTD_Setup *fftSetup = nullptr;
+	std::unique_ptr<FallbackFFT> fallback;
+	double *work = nullptr, *tmpAligned = nullptr;
+};
+
+}} // namespace
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-pffft.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/fft-pffft.h
@@ -1,0 +1,221 @@
+#ifndef SIGNALSMITH_LINEAR_PLATFORM_FFT_PFFFT_H
+#define SIGNALSMITH_LINEAR_PLATFORM_FFT_PFFFT_H
+
+#if defined(__has_include) && !__has_include("pffft/pffft.h")
+#	include "pffft.h"
+#else
+#	include "pffft/pffft.h"
+#endif
+
+#include <memory>
+#include <cmath>
+#include <complex>
+#include <cassert>
+
+namespace signalsmith { namespace linear {
+
+template<>
+struct Pow2FFT<float> {
+	static constexpr bool prefersSplit = false;
+
+	using Complex = std::complex<float>;
+
+	Pow2FFT(size_t size=0) {
+		resize(size);
+	}
+	~Pow2FFT() {
+		resize(0); // frees everything
+	}
+	// Allow move, but not copy
+	Pow2FFT(const Pow2FFT &other) = delete;
+	Pow2FFT(Pow2FFT &&other) : _size(other._size), hasSetup(other.hasSetup), fftSetup(other.fftSetup), fallback(std::move(other.fallback)), work(other.work), tmpAligned(other.tmpAligned) {
+		// Avoid double-free
+		other.hasSetup = false;
+		other.work = nullptr;
+		other.tmpAligned = nullptr;
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		fallback = nullptr;
+		if (hasSetup) pffft_destroy_setup(fftSetup);
+		if (work) pffft_aligned_free(work);
+		work = nullptr;
+		if (tmpAligned) pffft_aligned_free(tmpAligned);
+		tmpAligned = nullptr;
+
+		// We use this for split-real, even if there's no PFFFT setup
+		tmpAligned = (float *)pffft_aligned_malloc(sizeof(float)*size*2);
+
+		if (size < 16) {
+			// PFFFT doesn't support smaller sizes
+			hasSetup = false;
+			fallback = std::unique_ptr<SimpleFFT<float>>{
+				new SimpleFFT<float>(size)
+			};
+			return;
+		}
+		
+		work = (float *)pffft_aligned_malloc(sizeof(float)*size*2);
+		fftSetup = pffft_new_setup(int(size), PFFFT_COMPLEX);
+		hasSetup = fftSetup;
+	}
+
+	void fft(const Complex* input, Complex* output) {
+		if (fallback) return fallback->fft(input, output);
+		fftInner(input, output, PFFFT_FORWARD);
+	}
+	void fft(const float *inR, const float *inI, float *outR, float *outI) {
+		if (fallback) return fallback->fft(inR, inI, outR, outI);
+		fftInner(inR, inI, outR, outI, PFFFT_FORWARD);
+	}
+
+	void ifft(const Complex* input, Complex* output) {
+		if (fallback) return fallback->ifft(input, output);
+		fftInner(input, output, PFFFT_BACKWARD);
+	}
+	void ifft(const float *inR, const float *inI, float *outR, float *outI) {
+		if (fallback) return fallback->ifft(inR, inI, outR, outI);
+		fftInner(inR, inI, outR, outI, PFFFT_BACKWARD);
+	}
+
+private:
+	void fftInner(const Complex *input, Complex *output, pffft_direction_t direction) {
+		// 16-byte alignment
+		if (size_t(input)&0x0F) {
+			// `tmpAligned` is always aligned, so copy into that
+			std::memcpy(static_cast<void *>(tmpAligned), static_cast<const void *>(input), sizeof(Complex)*_size);
+			input = (const Complex *)tmpAligned;
+		}
+		if (size_t(output)&0x0F) {
+			// Output to `tmpAligned` - might be in-place if input is unaligned, but that's fine
+			pffft_transform_ordered(fftSetup, (const float *)input, tmpAligned, work, direction);
+			std::memcpy(static_cast<void *>(output), static_cast<const void *>(tmpAligned), sizeof(Complex)*_size);
+		} else {
+			pffft_transform_ordered(fftSetup, (const float *)input, (float *)output, work, direction);
+		}
+	}
+	void fftInner(const float *inR, const float *inI, float *outR, float *outI, pffft_direction_t direction) {
+		for (size_t i = 0; i < _size; ++i) {
+			tmpAligned[2*i] = inR[i];
+			tmpAligned[2*i + 1] = inI[i];
+		}
+		// PFFFT supports in-place transforms
+		fftInner((const Complex *)tmpAligned, (Complex *)tmpAligned, direction);
+		// Un-interleave
+		for (size_t i = 0; i < _size; ++i) {
+			outR[i] = tmpAligned[2*i];
+			outI[i] = tmpAligned[2*i + 1];
+		}
+	}
+
+	size_t _size = 0;
+	bool hasSetup = false;
+	PFFFT_Setup *fftSetup = nullptr;
+	std::unique_ptr<SimpleFFT<float>> fallback;
+	float *work = nullptr, *tmpAligned = nullptr;
+};
+
+template<>
+struct Pow2RealFFT<float> {
+private:
+	using FallbackFFT = SimpleRealFFT<float>; // this wraps the complex one
+public:
+	static constexpr bool prefersSplit = false;
+
+	using Complex = std::complex<float>;
+
+	Pow2RealFFT(size_t size=0) {
+		resize(size);
+	}
+	~Pow2RealFFT() {
+		resize(0);
+	}
+	// Allow move, but not copy
+	Pow2RealFFT(const Pow2RealFFT &other) = delete;
+	Pow2RealFFT(Pow2RealFFT &&other) : _size(other._size), hasSetup(other.hasSetup), fftSetup(other.fftSetup), fallback(std::move(other.fallback)), work(other.work), tmpAligned(other.tmpAligned) {
+		// Avoid double-free
+		other.hasSetup = false;
+		other.work = nullptr;
+		other.tmpAligned = nullptr;
+	}
+
+	void resize(size_t size) {
+		_size = size;
+		fallback = nullptr;
+		if (hasSetup) pffft_destroy_setup(fftSetup);
+		if (work) pffft_aligned_free(work);
+		work = nullptr;
+		if (tmpAligned) pffft_aligned_free(tmpAligned);
+		tmpAligned = nullptr;
+
+		// We use this for split-real, even if there's no PFFFT setup
+		tmpAligned = (float *)pffft_aligned_malloc(sizeof(float)*size*2);
+
+		// TODO: just go for it, and check for success before allocating `work`
+		if (size < 32) {
+			// PFFFT doesn't support smaller sizes
+			hasSetup = false;
+			fallback = std::unique_ptr<FallbackFFT>{
+				new FallbackFFT(size)
+			};
+			return;
+		}
+		
+		work = (float *)pffft_aligned_malloc(sizeof(float)*size);
+		fftSetup = pffft_new_setup(int(size), PFFFT_REAL);
+		hasSetup = fftSetup;
+	}
+
+	void fft(const float *input, Complex *output) {
+		if (fallback) return fallback->fft(input, output);
+		fftInner(input, (float *)output, PFFFT_FORWARD);
+	}
+	void fft(const float *inR, float *outR, float *outI) {
+		if (fallback) return fallback->fft(inR, outR, outI);
+		fftInner(inR, tmpAligned, PFFFT_FORWARD);
+		for (size_t i = 0; i < _size/2; ++i) {
+			outR[i] = tmpAligned[2*i];
+			outI[i] = tmpAligned[2*i + 1];
+		}
+	}
+
+	void ifft(const Complex *input, float *output) {
+		if (fallback) return fallback->ifft(input, output);
+		fftInner((const float *)input, output, PFFFT_BACKWARD);
+	}
+	void ifft(const float *inR, const float *inI, float *outR) {
+		if (fallback) return fallback->ifft(inR, inI, outR);
+		for (size_t i = 0; i < _size/2; ++i) {
+			tmpAligned[2*i] = inR[i];
+			tmpAligned[2*i + 1] = inI[i];
+		}
+		fftInner(tmpAligned, outR, PFFFT_BACKWARD);
+	}
+
+private:
+	void fftInner(const float *input, float *output, pffft_direction_t direction) {
+		// 16-byte alignment
+		if (size_t(input)&0x0F) {
+			// `tmpAligned` is always aligned, so copy into that
+			std::memcpy(tmpAligned, input, sizeof(float)*_size);
+			input = tmpAligned;
+		}
+		if (size_t(output)&0x0F) {
+			// Output to `tmpAligned` - might be in-place if input is unaligned, but that's fine
+			pffft_transform_ordered(fftSetup, input, tmpAligned, work, direction);
+			std::memcpy(output, tmpAligned, sizeof(float)*_size);
+		} else {
+			pffft_transform_ordered(fftSetup, input, output, work, direction);
+		}
+	}
+
+	size_t _size = 0;
+	bool hasSetup = false;
+	PFFFT_Setup *fftSetup = nullptr;
+	std::unique_ptr<FallbackFFT> fallback;
+	float *work = nullptr, *tmpAligned = nullptr;
+};
+
+}} // namespace
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/linear-accelerate.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/linear-accelerate.h
@@ -1,0 +1,576 @@
+//#define ACCELERATE_NEW_LAPACK
+
+// If possible, only include vecLib, since JUCE has conflicts with vImage
+#if defined(__has_include) && __has_include(<vecLib/vecLib.h>)
+#	include <vecLib/vecLib.h>
+#else
+#	include <Accelerate/Accelerate.h>
+#endif
+
+#include <cstring> // std::memcpy
+
+#include "./basic-fill-warnings.h"
+
+namespace signalsmith { namespace linear {
+
+template<>
+struct LinearImpl<true> : public LinearImplBase<true> {
+	using Base = LinearImplBase<true>;
+
+	LinearImpl() : Base(this), cached(*this) {
+		basicFillWarningReset();
+	}
+
+	template<class V>
+	void reserve(size_t size) {
+		// assume float/doubles if the right size
+		if (sizeof(V) == sizeof(float)) {
+			cached.reserveFloats(size*4);
+		} else if (sizeof(V) == sizeof(double)) {
+			cached.reserveDoubles(size*4);
+		}
+	}
+
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, Expr expr, size_t size) {
+		fillExpr(pointer, expr, size);
+	}
+
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, Expression<Expr> expr, size_t size) {
+		return fillExpr(pointer, (Expr &)expr, size);
+	};
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, WritableExpression<Expr> expr, size_t size) {
+		return fillExpr(pointer, (Expr &)expr, size);
+	};
+
+private:
+	// Most generic fill
+	template<class Pointer, class Expr>
+	void fillExpr(Pointer pointer, Expr expr, size_t size) {
+		fillBasic(pointer, expr, size);
+	}
+
+	template<class Pointer, class Expr>
+	void fillBasic(Pointer pointer, Expr expr, size_t size) {
+		basicFillWarning<Expr>();
+		for (size_t i = 0; i < size; ++i) {
+			pointer[i] = expr.get(i);
+		}
+	}
+	template<class V, class Expr>
+	void fillBasic(SplitPointer<V> pointer, Expr expr, size_t size) {
+		basicFillWarning<Expr>();
+		using Complex = typename SplitPointer<V>::Complex;
+		for (size_t i = 0; i < size; ++i) {
+			Complex c = expr.get(i);
+			pointer.real[i] = c.real();
+			pointer.imag[i] = c.imag();
+		}
+	}
+	
+	template<typename V>
+	void clear(V *v, size_t size) {
+		for (size_t i = 0; i < size; ++i) v[i] = 0;
+	}
+	void clear(float *v, size_t size) {
+		vDSP_vclr(v, 1, size);
+	}
+	void clear(double *v, size_t size) {
+		vDSP_vclrD(v, 1, size);
+	}
+	// Filling a split-complex vector with real values won't hit the specialisations below, so we handle it here
+	template<class Expr>
+	ItemType<Expr, float, void> fillBasic(SplitPointer<float> pointer, Expr expr, size_t size) {
+		fillExpr(pointer.real, expr, size);
+		clear(pointer.imag, size);
+	}
+	template<class Expr>
+	ItemType<Expr, double, void> fillBasic(SplitPointer<double> pointer, Expr expr, size_t size) {
+		fillExpr(pointer.real, expr, size);
+		clear(pointer.imag, size);
+	}
+	
+	// Copying from existing pointer
+	void fillExpr(RealPointer<float> pointer, expression::ReadableReal<float> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(float));
+	}
+	void fillExpr(RealPointer<float> pointer, WritableReal<float> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(float));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::ReadableReal<double> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(double));
+	}
+	void fillExpr(RealPointer<double> pointer, WritableReal<double> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(double));
+	}
+	void fillExpr(ComplexPointer<float> pointer, expression::ReadableComplex<float> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(std::complex<float>));
+	}
+	void fillExpr(ComplexPointer<float> pointer, WritableComplex<float> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(std::complex<float>));
+	}
+	void fillExpr(ComplexPointer<double> pointer, expression::ReadableComplex<double> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(std::complex<double>));
+	}
+	void fillExpr(ComplexPointer<double> pointer, WritableComplex<double> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(std::complex<double>));
+	}
+
+	// Real part of a split pointer
+	void fillExpr(RealPointer<float> pointer, expression::Real<expression::ReadableSplit<float>> expr, size_t size) {
+		std::memcpy(pointer, expr.a.pointer.real, size*sizeof(float));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::Real<expression::ReadableSplit<double>> expr, size_t size) {
+		std::memcpy(pointer, expr.a.pointer.real, size*sizeof(double));
+	}
+	void fillExpr(RealPointer<float> pointer, expression::Real<WritableSplit<float>> expr, size_t size) {
+		std::memcpy(pointer, expr.a.pointer.real, size*sizeof(float));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::Real<WritableSplit<double>> expr, size_t size) {
+		std::memcpy(pointer, expr.a.pointer.real, size*sizeof(double));
+	}
+	// Imaginary part
+	void fillExpr(RealPointer<float> pointer, expression::Imag<expression::ReadableSplit<float>> expr, size_t size) {
+		std::memcpy(pointer, expr.a.pointer.imag, size*sizeof(float));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::Imag<expression::ReadableSplit<double>> expr, size_t size) {
+		std::memcpy(pointer, expr.a.pointer.imag, size*sizeof(double));
+	}
+	void fillExpr(RealPointer<float> pointer, expression::Imag<WritableSplit<float>> expr, size_t size) {
+		std::memcpy(pointer, expr.a.pointer.imag, size*sizeof(float));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::Imag<WritableSplit<double>> expr, size_t size) {
+		std::memcpy(pointer, expr.a.pointer.imag, size*sizeof(double));
+	}
+
+	// Complex norm of a split pointer - rephrased as (r*r + i*i)
+	template<class V>
+	void fillExpr(RealPointer<V> pointer, expression::Norm<expression::ReadableSplit<V>> expr, size_t size) {
+		auto real = expression::ReadableReal<V>(expr.a.pointer.real);
+		auto imag = expression::ReadableReal<V>(expr.a.pointer.imag);
+		auto newExpr = expression::makeAdd(expression::makeMul(real, real), expression::makeMul(imag, imag));
+		return fillExpr(pointer, newExpr, size);
+	}
+	template<class V>
+	void fillExpr(RealPointer<V> pointer, expression::Norm<WritableSplit<V>> expr, size_t size) {
+		auto real = expression::ReadableReal<V>(expr.a.pointer.real);
+		auto imag = expression::ReadableReal<V>(expr.a.pointer.imag);
+		auto newExpr = expression::makeAdd(expression::makeMul(real, real), expression::makeMul(imag, imag));
+		return fillExpr(pointer, newExpr, size);
+	}
+	
+	// Filling with a constant
+	template<class V>
+	void fillExpr(RealPointer<float> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		float v = expr.value;
+		vDSP_vfill(&v, pointer, 1, size);
+	}
+	template<class V>
+	void fillExpr(RealPointer<double> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		double v = expr.value;
+		vDSP_vfillD(&v, pointer, 1, size);
+	}
+	template<class V>
+	void fillExpr(ComplexPointer<float> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		std::complex<float> v = expr.value;
+		auto vSplit = dspSplit(&v);
+		auto pSplit = dspSplit(pointer);
+		vDSP_zvfill(&vSplit, &pSplit, 2, size);
+	}
+	template<class V>
+	void fillExpr(ComplexPointer<double> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		std::complex<double> v = expr.value;
+		auto vSplit = dspSplit(&v);
+		auto pSplit = dspSplit(pointer);
+		vDSP_zvfillD(&vSplit, &pSplit, 2, size);
+	}
+	template<class V>
+	void fillExpr(SplitPointer<float> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		std::complex<float> v = expr.value;
+		float vr = v.real(), vi = v.imag();
+		auto vSplit = dspSplit({&vr, &vi});
+		auto pSplit = dspSplit(pointer);
+		vDSP_zvfill(&vSplit, &pSplit, 1, size);
+	}
+	template<class V>
+	void fillExpr(SplitPointer<double> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		std::complex<double> v = expr.value;
+		double vr = v.real(), vi = v.imag();
+		auto vSplit = dspSplit({&vr, &vi});
+		auto pSplit = dspSplit(pointer);
+		vDSP_zvfillD(&vSplit, &pSplit, 1, size);
+	}
+
+// Forwards .fillExpr() to .fillName(), but doesn't define that
+#define SIGNALSMITH_AUDIO_LINEAR_OP1_R(Name) \
+	template<class A> \
+	void fillExpr(RealPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A> \
+	void fillExpr(RealPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(RealPointer<float> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(RealPointer<double> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	}
+#define SIGNALSMITH_AUDIO_LINEAR_OP1_C(Name) \
+	template<class A> \
+	void fillExpr(ComplexPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A> \
+	void fillExpr(ComplexPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(ComplexPointer<float> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(ComplexPointer<double> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	} \
+	template<class A> \
+	void fillExpr(SplitPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A> \
+	void fillExpr(SplitPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(SplitPointer<float> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(SplitPointer<double> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	}
+// R -> R operators
+#define SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Name, vDSP_func) \
+	template<class A> \
+	ItemType<A, float, void> fill##Name(RealPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a, size); \
+		vDSP_func(a, 1, pointer, 1, size); \
+	} \
+	template<class A> \
+	ItemType<A, double, void> fill##Name(RealPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a, size); \
+		vDSP_func##D(a, 1, pointer, 1, size); \
+	}
+// C -> R operators
+#define SIGNALSMITH_AUDIO_LINEAR_TREE1_RC(Name, vDSP_func) \
+	template<class A> \
+	ItemType<A, std::complex<float>, void> fill##Name(RealPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto a = dspSplit(floats.split(expr.a, size)); \
+		vDSP_func(&a, 1, pointer, 1, size); \
+	} \
+	template<class A> \
+	ItemType<A, std::complex<double>, void> fill##Name(RealPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto a = dspSplit(doubles.split(expr.a, size)); \
+		vDSP_func##D(&a, 1, pointer, 1, size); \
+	}
+// C -> C operators
+#define SIGNALSMITH_AUDIO_LINEAR_TREE1_CC(Name, vDSP_func) \
+	template<class A> \
+	ItemType<A, std::complex<float>, void> fill##Name(ComplexPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto a = dspSplit(floats.complex(expr.a, size)); \
+		auto p = dspSplit(pointer); \
+		vDSP_func(&a, 2, &p, 2, size); \
+	} \
+	template<class A> \
+	ItemType<A, std::complex<double>, void> fill##Name(ComplexPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto a = dspSplit(doubles.complex(expr.a, size)); \
+		auto p = dspSplit(pointer); \
+		vDSP_func##D(&a, 2, &p, 2, size); \
+	}\
+	template<class A> \
+	ItemType<A, std::complex<float>, void> fill##Name(SplitPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto a = dspSplit(floats.split(expr.a, size)); \
+		auto p = dspSplit(pointer); \
+		vDSP_func(&a, 1, &p, 1, size); \
+	} \
+	template<class A> \
+	ItemType<A, std::complex<double>, void> fill##Name(SplitPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto a = dspSplit(doubles.split(expr.a, size)); \
+		auto p = dspSplit(pointer); \
+		vDSP_func##D(&a, 1, &p, 1, size); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Abs)
+	//SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Abs, vDSP_zabs); - why is this commented out?
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RC(Abs, vDSP_zvabs);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Neg)
+	SIGNALSMITH_AUDIO_LINEAR_OP1_C(Neg)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Neg, vDSP_vneg);
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_CC(Neg, vDSP_zvneg);
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE1_RR
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE1_RC
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE1_CC
+
+// vForce stuff
+// R -> R operators
+#define SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Name, vForce_float, vForce_double) \
+	template<class A> \
+	ItemType<A, float, void> fill##Name(RealPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a, size, pointer); \
+		int intSize = int(size); \
+		vForce_float(pointer, a, &intSize); \
+	} \
+	template<class A> \
+	ItemType<A, double, void> fill##Name(RealPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a, size, pointer); \
+		int intSize = int(size); \
+		vForce_double(pointer, a, &intSize); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Abs, vvfabsf, vvfabs);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Exp)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Exp, vvexpf, vvexp);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Exp2)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Exp2, vvexp2f, vvexp2);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Log)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Log, vvlogf, vvlog);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Log2)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Log2, vvlog2f, vvlog2);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Log10)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Log10, vvlog10f, vvlog10);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Sqrt)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Sqrt, vvsqrtf, vvsqrt);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Ceil)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Ceil, vvceilf, vvceil);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Floor)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Floor, vvfloorf, vvfloor);
+#undef SIGNALSMITH_AUDIO_LINEAR_OP1_R
+
+// Forwards .fillExpr() to .fillName(), but doesn't define that
+#define SIGNALSMITH_AUDIO_LINEAR_OP2_R(Name) \
+public: \
+	template<class A, class B> \
+	void fillExpr(RealPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A, class B> \
+	void fillExpr(RealPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+private:
+// R x R -> R operators where the vDSP function arguments are the other way around for some reason
+#define SIGNALSMITH_AUDIO_LINEAR_TREE2FLIP_RRR(Name, vDSP_func) \
+	template<class A, class B> \
+	void fill##Name(RealPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a, size); \
+		auto *b = floats.real(expr.b, size); \
+		vDSP_func(b, 1, a, 1, pointer, 1, size); \
+	} \
+	template<class A, class B> \
+	void fill##Name(RealPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a, size); \
+		auto *b = doubles.real(expr.b, size); \
+		vDSP_func##D(b, 1, a, 1, pointer, 1, size); \
+	}
+#define SIGNALSMITH_AUDIO_LINEAR_TREE2COMM_RRkR(Name, vDSP_func) \
+	template<class A, class V> \
+	void fill##Name(RealPointer<float> pointer, expression::Name<A, expression::ConstantExpr<V>> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a, size, pointer); \
+		float b = expr.b.value; \
+		vDSP_func(a, 1, &b, pointer, 1, size); \
+	} \
+	template<class A, class V> \
+	void fill##Name(RealPointer<double> pointer, expression::Name<A, expression::ConstantExpr<V>> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a, size, pointer); \
+		double b = expr.b.value; \
+		vDSP_func##D(a, 1, &b, pointer, 1, size); \
+	} \
+	template<class V, class B> \
+	void fill##Name(RealPointer<float> pointer, expression::Name<expression::ConstantExpr<V>, B> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		float a = expr.a.value; \
+		auto *b = floats.real(expr.b, size, pointer); \
+		vDSP_func(b, 1, &a, pointer, 1, size); \
+	} \
+	template<class V, class B> \
+	void fill##Name(RealPointer<double> pointer, expression::Name<expression::ConstantExpr<V>, B> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		double a = expr.a.value; \
+		auto *b = doubles.real(expr.b, size, pointer); \
+		vDSP_func##D(b, 1, &a, pointer, 1, size); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP2_R(Add)
+	SIGNALSMITH_AUDIO_LINEAR_TREE2FLIP_RRR(Add, vDSP_vadd);
+	SIGNALSMITH_AUDIO_LINEAR_TREE2COMM_RRkR(Add, vDSP_vsadd);
+	SIGNALSMITH_AUDIO_LINEAR_OP2_R(Sub)
+	SIGNALSMITH_AUDIO_LINEAR_TREE2FLIP_RRR(Sub, vDSP_vsub);
+	template<class A, class V>
+	void fillSub(RealPointer<float> pointer, expression::Sub<A, expression::ConstantExpr<V>> expr, size_t size) {
+		expression::ConstantExpr<V> negB{-expr.b.value};
+		fillAdd(pointer, expression::makeAdd(expr.a, negB), size);
+	}
+	template<class A, class V>
+	void fillSub(RealPointer<double> pointer, expression::Sub<A, expression::ConstantExpr<V>> expr, size_t size) {
+		expression::ConstantExpr<V> negB{-expr.b.value};
+		fillAdd(pointer, expression::makeAdd(expr.a, negB), size);
+	}
+	template<class A, class V>
+	void fillSub(RealPointer<float> pointer, expression::Sub<expression::ConstantExpr<V>, A> expr, size_t size) {
+		expression::ConstantExpr<V> negA{-expr.a.value};
+		fillNeg(pointer, expression::makeNeg(expression::makeAdd(expr.b, negA)), size);
+	}
+	template<class A, class V>
+	void fillSub(RealPointer<double> pointer, expression::Sub<expression::ConstantExpr<V>, A> expr, size_t size) {
+		expression::ConstantExpr<V> negA{-expr.a.value};
+		fillNeg(pointer, expression::makeNeg(expression::makeAdd(expr.b, negA)), size);
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP2_R(Mul)
+	SIGNALSMITH_AUDIO_LINEAR_TREE2FLIP_RRR(Mul, vDSP_vmul);
+	SIGNALSMITH_AUDIO_LINEAR_TREE2COMM_RRkR(Mul, vDSP_vsmul);
+	SIGNALSMITH_AUDIO_LINEAR_OP2_R(Div)
+	template<class A, class V>
+	void fillDiv(RealPointer<float> pointer, expression::Div<A, expression::ConstantExpr<V>> expr, size_t size) {
+		expression::ConstantExpr<V> recipB{1.0f/expr.b.value};
+		fillMul(pointer, expression::makeMul(expr.a, recipB), size);
+	}
+	template<class A, class V>
+	void fillDiv(RealPointer<double> pointer, expression::Sub<A, expression::ConstantExpr<V>> expr, size_t size) {
+		expression::ConstantExpr<V> recipB{1.0/expr.b.value};
+		fillMul(pointer, expression::makeMul(expr.a, recipB), size);
+	}
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE2FLIP_RRR
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE2COMM_RRkR
+
+// R x R -> R operators in vForce
+#define SIGNALSMITH_AUDIO_LINEAR_TREE2_RRR(Name, vForce_float, vForce_double) \
+	template<class A, class B> \
+	void fill##Name(RealPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a, size); \
+		auto *b = floats.real(expr.b, size); \
+		int intSize = int(size); \
+		vForce_float(pointer, a, b, &intSize); \
+	} \
+	template<class A, class B> \
+	void fill##Name(RealPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a, size); \
+		auto *b = doubles.real(expr.b, size); \
+		int intSize = int(size); \
+		vForce_double(pointer, a, b, &intSize); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_TREE2_RRR(Div, vvdivf, vvdiv);
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE2_RRR
+#undef SIGNALSMITH_AUDIO_LINEAR_OP2_R
+
+// Forwards .fillName() to .fillNameName2(), but doesn't define that
+#define SIGNALSMITH_AUDIO_LINEAR_Op3L_R(Name, NameL) \
+	template<class A, class B, class C> \
+	void fill##Name(RealPointer<float> pointer, expression::Name<expression::NameL<A, B>, C> expr, size_t size) { \
+		fill##Name##NameL(pointer, expr, size); \
+	} \
+	template<class A, class B, class C> \
+	void fill##Name(RealPointer<double> pointer, expression::Name<expression::NameL<A, B>, C> expr, size_t size) { \
+		fill##Name##NameL(pointer, expr, size); \
+	}
+// (A $ B) $ C
+#define SIGNALSMITH_AUDIO_LINEAR_TREE3L_RRR(Name, NameL, vDSP_func) \
+	template<class A, class B, class C> \
+	void fill##Name##NameL(RealPointer<float> pointer, expression::Name<expression::NameL<A, B>, C> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a.a, size); \
+		auto *b = floats.real(expr.a.b, size); \
+		auto *c = floats.real(expr.b, size); \
+		vDSP_func(a, 1, b, 1, c, 1, pointer, 1, size); \
+	} \
+	template<class A, class B, class C> \
+	void fill##Name##NameL(RealPointer<double> pointer, expression::Name<expression::NameL<A, B>, C> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a.a, size); \
+		auto *b = doubles.real(expr.a.b, size); \
+		auto *c = doubles.real(expr.b, size); \
+		vDSP_func##D(a, 1, b, 1, c, 1, pointer, 1, size); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_Op3L_R(Mul, Add)
+	SIGNALSMITH_AUDIO_LINEAR_TREE3L_RRR(Mul, Add, vDSP_vam)
+
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE3L_RRR
+#undef SIGNALSMITH_AUDIO_LINEAR_Op3L_R
+
+//	SIGNALSMITH_AUDIO_LINEAR_TREE3COMMUTATIVE_RRR(Add, Mul, vDSP_vam, 0)
+//	SIGNALSMITH_AUDIO_LINEAR_TREE3COMMUTATIVE_RRR(Mul, Add, vDSP_vma, 1)
+//	SIGNALSMITH_AUDIO_LINEAR_TREE3COMMUTATIVE_RRR(Sub, Mul, vDSP_vsbm, 2)
+//	SIGNALSMITH_AUDIO_LINEAR_TREE3L_RRR(Mul, Sub, vDSP_vmsb, 3)
+
+// Forwards .fillExpr() to .fillName(), but doesn't define that
+#define SIGNALSMITH_AUDIO_LINEAR_OP2_C(Name) \
+public: \
+	template<class A, class B> \
+	void fillExpr(ComplexPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A, class B> \
+	void fillExpr(ComplexPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A, class B> \
+	void fillExpr(SplitPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A, class B> \
+	void fillExpr(SplitPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+private:
+//	SIGNALSMITH_AUDIO_LINEAR_OP2_C(Add)
+//	SIGNALSMITH_AUDIO_LINEAR_OP2_C(Sub)
+//	SIGNALSMITH_AUDIO_LINEAR_OP2_C(Mul)
+//	SIGNALSMITH_AUDIO_LINEAR_OP2_C(Div)
+
+protected:
+	CachedResults<LinearImpl> cached;
+
+	static DSPSplitComplex dspSplit(ConstSplitPointer<float> x) {
+		DSPSplitComplex dsp;
+		dsp.realp = (float *)x.real;
+		dsp.imagp = (float *)x.imag;
+		return dsp;
+	}
+	static DSPSplitComplex dspSplit(ConstComplexPointer<float> x) {
+		DSPSplitComplex dsp;
+		dsp.realp = (float *)x;
+		dsp.imagp = (float *)x + 1;
+		return dsp;
+	}
+	static DSPDoubleSplitComplex dspSplit(ConstSplitPointer<double> x) {
+		DSPDoubleSplitComplex dsp;
+		dsp.realp = (double *)x.real;
+		dsp.imagp = (double *)x.imag;
+		return dsp;
+	}
+	static DSPDoubleSplitComplex dspSplit(ConstComplexPointer<double> x) {
+		DSPDoubleSplitComplex dsp;
+		dsp.realp = (double *)x;
+		dsp.imagp = (double *)x + 1;
+		return dsp;
+	}
+};
+
+}}; // namespace

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/linear-cmsisdsp.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/linear-cmsisdsp.h
@@ -1,0 +1,713 @@
+#include "arm_math.h"
+
+namespace signalsmith { namespace linear {
+
+template<>
+struct LinearImpl<true> : public LinearImplBase<true> {
+	using Base = LinearImplBase<true>;
+
+	LinearImpl() : Base(this), cached(*this) {}
+
+	template<class V>
+	void reserve(size_t size) {
+		// assume float/doubles if the right size
+		if (sizeof(V) == sizeof(float)) {
+			cached.reserveFloats(size*4);
+		} else if (sizeof(V) == sizeof(double)) {
+			cached.reserveDoubles(size*4);
+		}
+	}
+
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, Expr expr, size_t size) {
+		fillExpr(pointer, expr, size);
+	}
+
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, Expression<Expr> expr, size_t size) {
+		return fillExpr(pointer, (Expr &)expr, size);
+	};
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, WritableExpression<Expr> expr, size_t size) {
+		return fillExpr(pointer, (Expr &)expr, size);
+	};
+
+private:
+	// Most generic fill
+	template<class Pointer, class Expr>
+	void fillExpr(Pointer pointer, Expr expr, size_t size) {
+		fillBasic(pointer, expr, size);
+	}
+
+	template<class Pointer, class Expr>
+	void fillBasic(Pointer pointer, Expr expr, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			pointer[i] = expr.get(i);
+		}
+	}
+	template<class V, class Expr>
+	void fillBasic(SplitPointer<V> pointer, Expr expr, size_t size) {
+		using Complex = typename SplitPointer<V>::Complex;
+		for (size_t i = 0; i < size; ++i) {
+			Complex c = expr.get(i);
+			pointer.real[i] = c.real();
+			pointer.imag[i] = c.imag();
+		}
+	}
+	
+	template<typename V>
+	void clear(V *v, size_t size) {
+		for (size_t i = 0; i < size; ++i) v[i] = 0;
+	}
+	void clear(float *v, size_t size) {
+		arm_fill_f32(0.0f, v, uint32_t(size));
+	}
+	void clear(double *v, size_t size) {
+		for (size_t i = 0; i < size; ++i) v[i] = 0;
+	}
+	// Filling a split-complex vector with real values won't hit the specialisations below, so we handle it here
+	template<class Expr>
+	ItemType<Expr, float, void> fillBasic(SplitPointer<float> pointer, Expr expr, size_t size) {
+		fillExpr(pointer.real, expr, size);
+		clear(pointer.imag, size);
+	}
+	template<class Expr>
+	ItemType<Expr, double, void> fillBasic(SplitPointer<double> pointer, Expr expr, size_t size) {
+		fillExpr(pointer.real, expr, size);
+		clear(pointer.imag, size);
+	}
+	
+	// Copying from existing pointer
+	void fillExpr(RealPointer<float> pointer, expression::ReadableReal<float> expr, size_t size) {
+		arm_copy_f32(expr.pointer, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<float> pointer, WritableReal<float> expr, size_t size) {
+		arm_copy_f32(expr.pointer, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::ReadableReal<double> expr, size_t size) {
+		arm_copy_f64(expr.pointer, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<double> pointer, WritableReal<double> expr, size_t size) {
+		arm_copy_f64(expr.pointer, pointer, uint32_t(size));
+	}
+	void fillExpr(ComplexPointer<float> pointer, expression::ReadableComplex<float> expr, size_t size) {
+		arm_copy_f32(reinterpret_cast<const float *>(expr.pointer), reinterpret_cast<float *>(pointer), uint32_t(size*2));
+	}
+	void fillExpr(ComplexPointer<float> pointer, WritableComplex<float> expr, size_t size) {
+		arm_copy_f32(reinterpret_cast<const float *>(expr.pointer), reinterpret_cast<float *>(pointer), uint32_t(size*2));
+	}
+	void fillExpr(ComplexPointer<double> pointer, expression::ReadableComplex<double> expr, size_t size) {
+		arm_copy_f64(reinterpret_cast<const double *>(expr.pointer), reinterpret_cast<double *>(pointer), uint32_t(size*2));
+	}
+	void fillExpr(ComplexPointer<double> pointer, WritableComplex<double> expr, size_t size) {
+		arm_copy_f64(reinterpret_cast<const double *>(expr.pointer), reinterpret_cast<double *>(pointer), uint32_t(size*2));
+	}
+	void fillExpr(SplitPointer<float> pointer, expression::ReadableSplit<float> expr, size_t size) {
+		arm_copy_f32(expr.pointer.real, pointer.real, uint32_t(size));
+		arm_copy_f32(expr.pointer.imag, pointer.imag, uint32_t(size));
+	}
+	void fillExpr(SplitPointer<float> pointer, WritableSplit<float> expr, size_t size) {
+		arm_copy_f32(expr.pointer.real, pointer.real, uint32_t(size));
+		arm_copy_f32(expr.pointer.imag, pointer.imag, uint32_t(size));
+	}
+	void fillExpr(SplitPointer<double> pointer, expression::ReadableSplit<double> expr, size_t size) {
+		arm_copy_f64(expr.pointer.real, pointer.real, uint32_t(size));
+		arm_copy_f64(expr.pointer.imag, pointer.imag, uint32_t(size));
+	}
+	void fillExpr(SplitPointer<double> pointer, WritableSplit<double> expr, size_t size) {
+		arm_copy_f64(expr.pointer.real, pointer.real, uint32_t(size));
+		arm_copy_f64(expr.pointer.imag, pointer.imag, uint32_t(size));
+	}
+
+	// Real part of a split pointer
+	void fillExpr(RealPointer<float> pointer, expression::Real<expression::ReadableSplit<float>> expr, size_t size) {
+		arm_copy_f32(expr.a.pointer.real, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::Real<expression::ReadableSplit<double>> expr, size_t size) {
+		arm_copy_f64(expr.a.pointer.real, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<float> pointer, expression::Real<WritableSplit<float>> expr, size_t size) {
+		arm_copy_f32(expr.a.pointer.real, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::Real<WritableSplit<double>> expr, size_t size) {
+		arm_copy_f64(expr.a.pointer.real, pointer, uint32_t(size));
+	}
+	// Imaginary part
+	void fillExpr(RealPointer<float> pointer, expression::Imag<expression::ReadableSplit<float>> expr, size_t size) {
+		arm_copy_f32(expr.a.pointer.imag, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::Imag<expression::ReadableSplit<double>> expr, size_t size) {
+		arm_copy_f64(expr.a.pointer.imag, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<float> pointer, expression::Imag<WritableSplit<float>> expr, size_t size) {
+		arm_copy_f32(expr.a.pointer.imag, pointer, uint32_t(size));
+	}
+	void fillExpr(RealPointer<double> pointer, expression::Imag<WritableSplit<double>> expr, size_t size) {
+		arm_copy_f64(expr.a.pointer.imag, pointer, uint32_t(size));
+	}
+	// Filling with a constant
+	template<class V>
+	void fillExpr(RealPointer<float> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		float v = expr.value;
+		arm_fill_f32(v, pointer, uint32_t(size));
+	}
+	template<class V>
+	void fillExpr(RealPointer<double> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		double v = expr.value;
+		arm_fill_f64(v, pointer, uint32_t(size));
+	}
+//	template<class V>
+//	void fillExpr(ComplexPointer<float> pointer, expression::ConstantExpr<V> expr, size_t size) {
+//		std::complex<float> v = expr.value;
+//		auto vSplit = dspSplit(&v);
+//		auto pSplit = dspSplit(pointer);
+//		vDSP_zvfill(&vSplit, &pSplit, 2, size);
+//	}
+//	template<class V>
+//	void fillExpr(ComplexPointer<double> pointer, expression::ConstantExpr<V> expr, size_t size) {
+//		std::complex<double> v = expr.value;
+//		auto vSplit = dspSplit(&v);
+//		auto pSplit = dspSplit(pointer);
+//		vDSP_zvfillD(&vSplit, &pSplit, 2, size);
+//	}
+	template<class V>
+	void fillExpr(SplitPointer<float> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		std::complex<float> v = expr.value;
+		float vr = v.real(), vi = v.imag();
+		arm_fill_f32(vr, pointer.real, uint32_t(size));
+		arm_fill_f32(vi, pointer.imag, uint32_t(size));
+	}
+	template<class V>
+	void fillExpr(SplitPointer<double> pointer, expression::ConstantExpr<V> expr, size_t size) {
+		std::complex<double> v = expr.value;
+		double vr = v.real(), vi = v.imag();
+		arm_fill_f64(vr, pointer.real, uint32_t(size));
+		arm_fill_f64(vi, pointer.imag, uint32_t(size));
+	}
+
+// Forwards .fillExpr() to .fillName(), but doesn't define that
+#define SIGNALSMITH_AUDIO_LINEAR_OP1_R(Name) \
+	template<class A> \
+	void fillExpr(RealPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A> \
+	void fillExpr(RealPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(RealPointer<float> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(RealPointer<double> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	}
+#define SIGNALSMITH_AUDIO_LINEAR_OP1_C(Name) \
+	template<class A> \
+	void fillExpr(ComplexPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A> \
+	void fillExpr(ComplexPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(ComplexPointer<float> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(ComplexPointer<double> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	} \
+	template<class A> \
+	void fillExpr(SplitPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A> \
+	void fillExpr(SplitPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(SplitPointer<float> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	} \
+	template<class Expr> \
+	void fill##Name(SplitPointer<double> pointer, Expr expr, size_t size) { \
+		fillBasic(pointer, expr, size); \
+	}
+// R -> R operators
+#define SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Name, cmsis_prefix) \
+	template<class A> \
+	ItemType<A, float, void> fill##Name(RealPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a, size); \
+		cmsis_prefix##_f32(a, pointer, uint32_t(size)); \
+	} \
+	template<class A> \
+	ItemType<A, double, void> fill##Name(RealPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a, size); \
+		cmsis_prefix##_f64(a, pointer, uint32_t(size)); \
+	}
+// C -> C operators which are the same as element-wise R -> R ones
+#define SIGNALSMITH_AUDIO_LINEAR_TREE1_CCe(Name, cmsis_prefix) \
+	template<class A> \
+	ItemType<A, std::complex<float>, void> fill##Name(ComplexPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.complex(expr.a, size); \
+		cmsis_prefix##_f32(reinterpret_cast<const float *>(a), reinterpret_cast<float *>(pointer), size*2); \
+	} \
+	template<class A> \
+	ItemType<A, std::complex<double>, void> fill##Name(ComplexPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.complex(expr.a, size); \
+		cmsis_prefix##_f64(reinterpret_cast<const double *>(a), reinterpret_cast<double *>(pointer), size*2); \
+	}\
+	template<class A> \
+	ItemType<A, std::complex<float>, void> fill##Name(SplitPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto a = floats.split(expr.a, size); \
+		cmsis_prefix##_f32(a.real, pointer.real, size); \
+		cmsis_prefix##_f32(a.imag, pointer.imag, size); \
+	} \
+	template<class A> \
+	ItemType<A, std::complex<double>, void> fill##Name(SplitPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto a = doubles.split(expr.a, size); \
+		cmsis_prefix##_f64(a.real, pointer.real, size); \
+		cmsis_prefix##_f64(a.imag, pointer.imag, size); \
+	}
+// C -> R operators
+#define SIGNALSMITH_AUDIO_LINEAR_TREE1_RC(Name, cmsis_prefix) \
+	template<class A> \
+	ItemType<A, std::complex<float>, void> fill##Name(RealPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.complex(expr.a, size); \
+		cmsis_prefix##_f32(reinterpret_cast<const float *>(a), pointer, size); \
+	} \
+	template<class A> \
+	ItemType<A, std::complex<double>, void> fill##Name(RealPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.complex(expr.a, size); \
+		cmsis_prefix##_f64(reinterpret_cast<const double *>(a), pointer, size); \
+	}
+// C -> C operators
+#define SIGNALSMITH_AUDIO_LINEAR_TREE1_CC(Name, cmsis_prefix) \
+	template<class A> \
+	ItemType<A, std::complex<float>, void> fill##Name(ComplexPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.complex(expr.a, size, pointer); \
+		cmsis_prefix##_f32(reinterpret_cast<const float *>(a), reinterpret_cast<float *>(pointer), size); \
+	} \
+	template<class A> \
+	ItemType<A, std::complex<double>, void> fill##Name(ComplexPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.complex(expr.a, size, pointer); \
+		cmsis_prefix##_f64(reinterpret_cast<const double *>(a), reinterpret_cast<double *>(pointer), size); \
+	}\
+	template<class A> \
+	ItemType<A, std::complex<float>, void> fill##Name(SplitPointer<float> pointer, expression::Name<A> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.complex(expr.a, size); \
+		auto *r = floats(size*2); \
+		cmsis_prefix##_f32(reinterpret_cast<const float *>(a), r, size); \
+		deinterleave(r, pointer.real, pointer.imag, size); \
+	} \
+	template<class A> \
+	ItemType<A, std::complex<double>, void> fill##Name(SplitPointer<double> pointer, expression::Name<A> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.complex(expr.a, size); \
+		auto *r = doubles(size*2); \
+		cmsis_prefix##_f64(reinterpret_cast<const double *>(a), r, size); \
+		deinterleave(r, pointer.real, pointer.imag, size); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Abs)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Abs, arm_abs);
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RC(Abs, arm_cmplx_mag);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Neg)
+	SIGNALSMITH_AUDIO_LINEAR_OP1_C(Neg)
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Neg, arm_negate);
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_CCe(Neg, arm_negate);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Norm)
+	// Norm of real number just squares it
+	template<class A>
+	ItemType<A, float, void> fillNorm(RealPointer<float> pointer, expression::Norm<A> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.real(expr.a, size, pointer);
+		arm_mult_f32(a, a, pointer, uint32_t(size));
+	}
+	template<class A>
+	ItemType<A, double, void> fillNorm(RealPointer<double> pointer, expression::Norm<A> expr, size_t size) {
+		auto doubles = cached.doubleScope();
+		auto *a = doubles.real(expr.a, size, pointer);
+		arm_mult_f64(a, a, pointer, uint32_t(size));
+	}
+	// Special-case for when taking the norm of a split-pointer
+	void fillNorm(RealPointer<float> pointer, expression::Norm<expression::ReadableSplit<float>> expr, size_t size) {
+		auto real = expression::ReadableReal<float>(expr.a.pointer.real);
+		auto imag = expression::ReadableReal<float>(expr.a.pointer.imag);
+		auto newExpr = expression::makeAdd(expression::makeMul(real, real), expression::makeMul(imag, imag));
+		return fillExpr(pointer, newExpr, size);
+	}
+	void fillNorm(RealPointer<float> pointer, expression::Norm<WritableSplit<float>> expr, size_t size) {
+		auto real = expression::ReadableReal<float>(expr.a.pointer.real);
+		auto imag = expression::ReadableReal<float>(expr.a.pointer.imag);
+		auto newExpr = expression::makeAdd(expression::makeMul(real, real), expression::makeMul(imag, imag));
+		return fillExpr(pointer, newExpr, size);
+	}
+	void fillNorm(RealPointer<double> pointer, expression::Norm<expression::ReadableSplit<double>> expr, size_t size) {
+		auto real = expression::ReadableReal<double>(expr.a.pointer.real);
+		auto imag = expression::ReadableReal<double>(expr.a.pointer.imag);
+		auto newExpr = expression::makeAdd(expression::makeMul(real, real), expression::makeMul(imag, imag));
+		return fillExpr(pointer, newExpr, size);
+	}
+	void fillNorm(RealPointer<double> pointer, expression::Norm<WritableSplit<double>> expr, size_t size) {
+		auto real = expression::ReadableReal<double>(expr.a.pointer.real);
+		auto imag = expression::ReadableReal<double>(expr.a.pointer.imag);
+		auto newExpr = expression::makeAdd(expression::makeMul(real, real), expression::makeMul(imag, imag));
+		return fillExpr(pointer, newExpr, size);
+	}
+	SIGNALSMITH_AUDIO_LINEAR_TREE1_RC(Norm, arm_cmplx_mag_squared);
+	SIGNALSMITH_AUDIO_LINEAR_OP1_C(Conj)
+	template<class A> \
+	void fillConj(ComplexPointer<float> pointer, expression::Conj<A> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.complex(expr.a, size, pointer);
+		arm_cmplx_conj_f32(reinterpret_cast<const float *>(a), reinterpret_cast<float *>(pointer), size);
+	}
+	template<class A>
+	void fillConj(ComplexPointer<double> pointer, expression::Conj<A> expr, size_t size) {
+		this->fill(pointer, expr.a, size);
+		auto imagPtr = reinterpret_cast<double *>(pointer) + 1;
+		// There is no arm_cmplx_conj_f64, do a manual loop
+		for (size_t i = 0; i < size; ++i) {
+			double v = imagPtr[2*i];
+			imagPtr[2*i] = -v;
+		}
+	}
+	template<class A>
+	void fillConj(SplitPointer<float> pointer, expression::Conj<A> expr, size_t size) {
+		this->fill(pointer, expr.a, size);
+		arm_negate_f32(pointer.imag, pointer.imag, uint32_t(size));
+	}
+	template<class A>
+	void fillConj(SplitPointer<double> pointer, expression::Conj<A> expr, size_t size) {
+		this->fill(pointer, expr.a, size);
+		arm_negate_f64(pointer.imag, pointer.imag, uint32_t(size));
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Exp)
+	template<class A>
+	void fillExp(RealPointer<float> pointer, expression::Exp<A> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.real(expr.a, size, pointer);
+		arm_vexp_f32(a, pointer, uint32_t(size));
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Exp2)
+	template<class A>
+	void fillExp2(RealPointer<float> pointer, expression::Exp2<A> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.real(expr.a, size, pointer);
+		arm_scale_f32(a, 0.6931471805599453f, pointer, uint32_t(size));
+		arm_vexp_f32(pointer, pointer, uint32_t(size));
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Log)
+	template<class A>
+	void fillLog(RealPointer<float> pointer, expression::Log<A> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.real(expr.a, size, pointer);
+		arm_vlog_f32(a, pointer, uint32_t(size));
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Log2)
+	template<class A>
+	void fillLog2(RealPointer<float> pointer, expression::Log2<A> expr, size_t size) {
+		auto logExpr = expression::makeLog(expr.a);
+		fillBasic(pointer, logExpr, size);
+		arm_scale_f32(pointer, 1.4426950408889634f, pointer, uint32_t(size));
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Log10)
+	template<class A>
+	void fillLog10(RealPointer<float> pointer, expression::Log10<A> expr, size_t size) {
+		auto logExpr = expression::makeLog(expr.a);
+		fillBasic(pointer, logExpr, size);
+		arm_scale_f32(pointer, 0.43429448190325176f, pointer, uint32_t(size));
+	}
+
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Sqrt)
+	template<class A>
+	ItemType<A, float, void> fillSqrt(RealPointer<float> pointer, expression::Sqrt<A> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.real(expr.a, size, pointer);
+		// Use their fast-sqrt function
+		for (size_t i = 0; i < size; ++i) {
+			arm_sqrt_f32(a[i], &pointer[i]);
+		}
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Sin)
+	template<class A>
+	ItemType<A, float, void> fillSin(RealPointer<float> pointer, expression::Sin<A> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.real(expr.a, size, pointer);
+		// Use their fast-sqrt function
+		for (size_t i = 0; i < size; ++i) {
+			pointer[i] = arm_sin_f32(a[i]);
+		}
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Cos)
+	template<class A>
+	ItemType<A, float, void> fillSin(RealPointer<float> pointer, expression::Cos<A> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.real(expr.a, size, pointer);
+		// Use their fast-sqrt function
+		for (size_t i = 0; i < size; ++i) {
+			pointer[i] = arm_cos_f32(a[i]);
+		}
+	}
+//	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Ceil)
+//	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Ceil, vvceilf, vvceil);
+//	SIGNALSMITH_AUDIO_LINEAR_OP1_R(Floor)
+//	SIGNALSMITH_AUDIO_LINEAR_TREE1_RR(Floor, vvfloorf, vvfloor);
+#undef SIGNALSMITH_AUDIO_LINEAR_OP1_R
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE1_RR
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE1_RC
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE1_CC
+
+// Forwards .fillExpr() to .fillName(), but doesn't define that
+#define SIGNALSMITH_AUDIO_LINEAR_OP2_R(Name) \
+public: \
+	template<class A, class B> \
+	void fillExpr(RealPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A, class B> \
+	void fillExpr(RealPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+private:
+#define SIGNALSMITH_AUDIO_LINEAR_OP2_C(Name) \
+public: \
+	template<class A, class B> \
+	void fillExpr(ComplexPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A, class B> \
+	void fillExpr(ComplexPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A, class B> \
+	void fillExpr(SplitPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+	template<class A, class B> \
+	void fillExpr(SplitPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		fill##Name(pointer, expr, size); \
+	} \
+private:
+// R x R -> R
+#define SIGNALSMITH_AUDIO_LINEAR_TREE2_RRR(Name, cmsis_prefix) \
+	template<class A, class B> \
+	void fill##Name(RealPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a, size); \
+		auto *b = floats.real(expr.b, size); \
+		cmsis_prefix##_f32(a, b, pointer, uint32_t(size)); \
+	} \
+	template<class A, class B> \
+	ItemType<A, double, void> fill##Name(RealPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a, size); \
+		auto *b = doubles.real(expr.b, size); \
+		cmsis_prefix##_f64(a, b, pointer, uint32_t(size)); \
+	}
+// C x C -> C where it's elementwise
+#define SIGNALSMITH_AUDIO_LINEAR_TREE2_CCCe(Name, cmsis_prefix) \
+	template<class A, class B> \
+	void fill##Name(ComplexPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.complex(expr.a, size); \
+		auto *b = floats.complex(expr.b, size); \
+		cmsis_prefix##_f32(reinterpret_cast<const float *>(a), reinterpret_cast<const float *>(b), reinterpret_cast<float *>(pointer), size*2); \
+	} \
+	template<class A, class B> \
+	void fill##Name(ComplexPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.complex(expr.a, size); \
+		auto *b = doubles.complex(expr.b, size); \
+		cmsis_prefix##_f64(reinterpret_cast<const double *>(a), reinterpret_cast<const double *>(b), reinterpret_cast<double *>(pointer), size*2); \
+	}\
+	template<class A, class B> \
+	void fill##Name(SplitPointer<float> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto a = floats.split(expr.a, size); \
+		auto b = floats.split(expr.b, size); \
+		cmsis_prefix##_f32(a.real, b.real, pointer.real, size); \
+		cmsis_prefix##_f32(a.imag, b.imag, pointer.imag, size); \
+	} \
+	template<class A, class B> \
+	void fill##Name(SplitPointer<double> pointer, expression::Name<A, B> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto a = doubles.split(expr.a, size); \
+		auto b = doubles.split(expr.b, size); \
+		cmsis_prefix##_f64(a.real, b.real, pointer.real, size); \
+		cmsis_prefix##_f64(a.imag, b.imag, pointer.imag, size); \
+	}
+#define SIGNALSMITH_AUDIO_LINEAR_TREE2COMM_RRkR(Name, cmsis_prefix) \
+	template<class A, class V> \
+	void fill##Name(RealPointer<float> pointer, expression::Name<A, expression::ConstantExpr<V>> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		auto *a = floats.real(expr.a, size, pointer); \
+		float b = expr.b.value; \
+		cmsis_prefix##_f32(a, b, pointer, uint32_t(size)); \
+	} \
+	template<class A, class V> \
+	void fill##Name(RealPointer<double> pointer, expression::Name<A, expression::ConstantExpr<V>> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		auto *a = doubles.real(expr.a, size, pointer); \
+		double b = expr.b.value; \
+		cmsis_prefix##_f64(a, b, pointer, uint32_t(size)); \
+	} \
+	template<class V, class B> \
+	void fill##Name(RealPointer<float> pointer, expression::Name<expression::ConstantExpr<V>, B> expr, size_t size) { \
+		auto floats = cached.floatScope(); \
+		float a = expr.a.value; \
+		auto *b = floats.real(expr.b, size, pointer); \
+		cmsis_prefix##_f32(b, a, pointer, uint32_t(size)); \
+	} \
+	template<class V, class B> \
+	void fill##Name(RealPointer<double> pointer, expression::Name<expression::ConstantExpr<V>, B> expr, size_t size) { \
+		auto doubles = cached.doubleScope(); \
+		double a = expr.a.value; \
+		auto *b = doubles.real(expr.b, size, pointer); \
+		cmsis_prefix##_f64(b, a, pointer, uint32_t(size)); \
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP2_R(Add)
+	SIGNALSMITH_AUDIO_LINEAR_TREE2_RRR(Add, arm_add);
+	SIGNALSMITH_AUDIO_LINEAR_TREE2COMM_RRkR(Add, arm_offset);
+	SIGNALSMITH_AUDIO_LINEAR_OP2_C(Add)
+	SIGNALSMITH_AUDIO_LINEAR_TREE2_CCCe(Add, arm_add);
+	SIGNALSMITH_AUDIO_LINEAR_OP2_R(Sub)
+	SIGNALSMITH_AUDIO_LINEAR_TREE2_RRR(Sub, arm_sub);
+	SIGNALSMITH_AUDIO_LINEAR_OP2_C(Sub)
+	SIGNALSMITH_AUDIO_LINEAR_TREE2_CCCe(Sub, arm_sub);
+	// Flip a constant subtraction around into adding a negative constant, or negation + adding
+	template<class A, class V>
+	void fillSub(RealPointer<float> pointer, expression::Sub<A, expression::ConstantExpr<V>> expr, size_t size) {
+		expression::ConstantExpr<V> negB{-expr.b.value};
+		fillAdd(pointer, expression::makeAdd(expr.a, negB), size);
+	}
+	template<class A, class V>
+	void fillSub(RealPointer<double> pointer, expression::Sub<A, expression::ConstantExpr<V>> expr, size_t size) {
+		expression::ConstantExpr<V> negB{-expr.b.value};
+		fillAdd(pointer, expression::makeAdd(expr.a, negB), size);
+	}
+	template<class A, class V>
+	void fillSub(RealPointer<float> pointer, expression::Sub<expression::ConstantExpr<V>, A> expr, size_t size) {
+		expression::ConstantExpr<V> negA{-expr.a.value};
+		fillNeg(pointer, expression::makeNeg(expression::makeAdd(expr.b, negA)), size);
+	}
+	template<class A, class V>
+	void fillSub(RealPointer<double> pointer, expression::Sub<expression::ConstantExpr<V>, A> expr, size_t size) {
+		expression::ConstantExpr<V> negA{-expr.a.value};
+		fillNeg(pointer, expression::makeNeg(expression::makeAdd(expr.b, negA)), size);
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP2_R(Mul)
+	SIGNALSMITH_AUDIO_LINEAR_TREE2_RRR(Mul, arm_mult);
+	SIGNALSMITH_AUDIO_LINEAR_TREE2COMM_RRkR(Mul, arm_scale);
+	SIGNALSMITH_AUDIO_LINEAR_OP2_C(Mul)
+	template<class A, class B>
+	void fillMul(ComplexPointer<float> pointer, expression::Mul<A, B> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto *a = floats.complex(expr.a, size);
+		auto *b = floats.complex(expr.b, size);
+		arm_cmplx_mult_cmplx_f32(reinterpret_cast<const float *>(a), reinterpret_cast<const float *>(b), reinterpret_cast<float *>(pointer), size);
+	}
+	template<class A, class B>
+	void fillMul(ComplexPointer<double> pointer, expression::Mul<A, B> expr, size_t size) {
+		auto doubles = cached.doubleScope();
+		auto *a = doubles.complex(expr.a, size);
+		auto *b = doubles.complex(expr.b, size);
+		arm_cmplx_mult_cmplx_f64(reinterpret_cast<const double *>(a), reinterpret_cast<const double *>(b), reinterpret_cast<double *>(pointer), size);
+	}
+	template<class A, class B>
+	void fillMul(SplitPointer<float> pointer, expression::Mul<A, B> expr, size_t size) {
+		auto floats = cached.floatScope();
+		auto a = floats.split(expr.a, size);
+		auto b = floats.split(expr.b, size);
+		auto *tmp = floats(size);
+		arm_mult_f32(a.real, b.real, pointer.real, uint32_t(size));
+		arm_mult_f32(a.imag, b.imag, tmp, uint32_t(size));
+		arm_sub_f32(pointer.real, tmp, pointer.real, uint32_t(size));
+		arm_mult_f32(a.real, b.imag, tmp, uint32_t(size));
+		arm_mult_f32(a.imag, b.real, pointer.imag, uint32_t(size));
+		arm_add_f32(tmp, pointer.imag, pointer.imag, uint32_t(size));
+	}
+	template<class A, class B>
+	void fillMul(SplitPointer<double> pointer, expression::Mul<A, B> expr, size_t size) {
+		auto doubles = cached.doubleScope();
+		auto a = doubles.split(expr.a, size);
+		auto b = doubles.split(expr.b, size);
+		auto *tmp = doubles(size);
+		arm_mult_f64(a.real, b.real, pointer.real, uint32_t(size));
+		arm_mult_f64(a.imag, b.imag, tmp, uint32_t(size));
+		arm_sub_f64(pointer.real, tmp, pointer.real, uint32_t(size));
+		arm_mult_f64(a.real, b.imag, tmp, uint32_t(size));
+		arm_mult_f64(a.imag, b.real, pointer.imag, uint32_t(size));
+		arm_add_f64(tmp, pointer.imag, pointer.imag, uint32_t(size));
+	}
+	SIGNALSMITH_AUDIO_LINEAR_OP2_R(Div)
+	// Generic
+	template<class P, class A, class B>
+	void fillDiv(P p, expression::Div<A, B> expr, size_t size) {
+		fillBasic(p, expr, size);
+	}
+	// Turn division by constant into multiplication by its reciprocal
+	template<class A, class V>
+	void fillDiv(RealPointer<float> pointer, expression::Div<A, expression::ConstantExpr<V>> expr, size_t size) {
+		expression::ConstantExpr<V> recipB{1.0f/expr.b.value};
+		fillMul(pointer, expression::makeMul(expr.a, recipB), size);
+	}
+	template<class A, class V>
+	void fillDiv(RealPointer<double> pointer, expression::Sub<A, expression::ConstantExpr<V>> expr, size_t size) {
+		expression::ConstantExpr<V> recipB{1.0/expr.b.value};
+		fillMul(pointer, expression::makeMul(expr.a, recipB), size);
+	}
+//	// Otherwise, do a direct loop
+//	template<class A, class B>
+//	void fillDiv(RealPointer<float> pointer, expression::Div<A, B> expr, size_t size) {
+//		auto floats = cached.floatScope();
+//		auto *a = floats.real(expr.a, size);
+//		auto *b = floats.real(expr.b, size);
+//		for (size_t i = 0; i < size; ++i) {
+//			pointer[i] = a[i]/b[i];
+//		}
+//	}
+//	template<class A, class B>
+//	void fillDiv(RealPointer<double> pointer, expression::Div<A, B> expr, size_t size) {
+//		auto doubles = cached.doubleScope();
+//		auto *a = doubles.real(expr.a, size);
+//		auto *b = doubles.real(expr.b, size);
+//		for (size_t i = 0; i < size; ++i) {
+//			pointer[i] = a[i]/b[i];
+//		}
+//	}
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE2_RRR
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE2COMM_RRkR
+#undef SIGNALSMITH_AUDIO_LINEAR_TREE2_CCCe
+#undef SIGNALSMITH_AUDIO_LINEAR_OP2_R
+#undef SIGNALSMITH_AUDIO_LINEAR_OP2_C
+
+/*=========== move this down the file to gradually add overrides, and see which one makes it fail
+//*/
+
+protected:
+	CachedResults<LinearImpl> cached;
+
+	static void deinterleave(const float *interleaved, float *real, float *imag, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			real[i] = interleaved[2*i];
+			imag[i] = interleaved[2*i + 1];
+		}
+	}
+};
+
+}}; // namespace

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/linear-xsimd-dispatch.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/linear-xsimd-dispatch.cpp
@@ -1,0 +1,6 @@
+#if defined(SIGNALSMITH_USE_XSIMD) && defined(SIGNALSMITH_USE_XSIMD_DISPATCH) && defined(SIGNALSMITH_LINEAR_XSIMD_DISPATCH_ARCH)
+#	include "../linear.h"
+#else
+#	error Unless you're compiling for multiple architectures (using SIGNALSMITH_USE_XSIMD, SIGNALSMITH_USE_XSIMD_DISPATCH and SIGNALSMITH_LINEAR_XSIMD_DISPATCH_ARCH) then you shouldn't be building this file
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/linear-xsimd.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/platform/linear-xsimd.h
@@ -1,0 +1,818 @@
+#include "xsimd/xsimd.hpp"
+
+#include <cstring> // std::memcpy
+#include <cstdint> // uintptr_t
+#include <type_traits>
+
+#include "./basic-fill-warnings.h"
+//#include <iostream>
+//#ifndef LOG_EXPR
+//#	define LOG_EXPR(...) std::cout << #__VA_ARGS__ " = " << (__VA_ARGS__) << std::endl;
+//#endif
+
+namespace signalsmith { namespace linear {
+
+#if defined(__FAST_MATH__) && XSIMD_WITH_AVX2
+#	if defined(__clang__) && __clang_major__ < 18
+// https://github.com/xtensor-stack/xsimd/issues/1264#issuecomment-3967518377
+#		error There is a bug in Clang v17 and below, which means you need to turn off `-ffast-math` when using AVX2+
+#	endif
+#endif
+
+namespace _impl_fill {
+	static constexpr size_t maxAlignmentBytes = 64; // 512 bits
+
+	// These are the "aligned fill" functions.  The basic versions don't actually use `Arch` so they're safe to use on any architecture
+
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillBasic(RealPointer<V> pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		basicFillWarning<Expr>();
+		for (size_t i = fromIndex; i < toIndex; ++i) {
+			pointer[i] = V(expr.get(i));
+		}
+	}
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillBasic(ComplexPointer<V> pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		basicFillWarning<Expr>();
+		using C = std::complex<V>;
+		for (size_t i = fromIndex; i < toIndex; ++i) {
+			pointer[i] = C(expr.get(i));
+		}
+	}
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillBasic(SplitPointer<V> pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		basicFillWarning<Expr>();
+		using Complex = std::complex<V>;
+		for (size_t i = fromIndex; i < toIndex; ++i) {
+			Complex c = expr.get(i);
+			pointer.real[i] = c.real();
+			pointer.imag[i] = c.imag();
+		}
+	}
+	
+	template<class Arch, class V>
+	static constexpr bool notSupported() {
+		// Either compiling for a completely different architecture (e.g. trying to use `xsimd::neon64` on x86) or the vectors aren't wide enough
+		// TODO: a warning here, because ideally we shouldn't be trying to compile for the wrong architecture like that
+		return xsimd::batch<V, Arch>::size < 2;
+	}
+	
+	// Predeclare the chunking helpers
+	template<class Arch, class Pointer, class Expr>
+	XSIMD_INLINE void fillChunksUnary(Pointer pointer, Expr expr, size_t fromIndex, size_t toIndex);
+	template<class Arch, class Pointer, class Expr>
+	XSIMD_INLINE void fillChunksBinaryL(Pointer pointer, Expr expr, size_t fromIndex, size_t toIndex);
+	template<class Arch, class Pointer, class Expr>
+	XSIMD_INLINE void fillChunksBinaryR(Pointer pointer, Expr expr, size_t fromIndex, size_t toIndex);
+
+	template<class Arch, class Pointer, class Expr>
+	void fillAligned(Pointer pointer, Expr expr, size_t fromIndex, size_t toIndex, Arch) {
+		if constexpr (std::is_base_of_v<expression::BaseUnary, Expr>) {
+			if constexpr (std::is_base_of_v<expression::BasePointer, decltype(expr.a)>) {
+				// It's already as basic as it gets - although somehow not specialised, which is odd
+				fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+			} else {
+				fillChunksUnary<Arch>(pointer, expr, fromIndex, toIndex);
+			}
+		} else if constexpr (std::is_base_of_v<expression::BaseBinary, Expr>) {
+			if constexpr (std::is_base_of_v<expression::BasePointer, decltype(expr.a)> && std::is_base_of_v<expression::BasePointer, decltype(expr.b)>) {
+				// It's already as basic as it gets - although somehow not specialised, which is odd
+				fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+			} else if constexpr (std::is_base_of_v<expression::BasePointer, decltype(expr.a)>) {
+				fillChunksBinaryR<Arch>(pointer, expr, fromIndex, toIndex);
+			} else {
+				// The right side might be a pointer, or not - but let the recursion handle that.  The overhead of trying to chunk an already-chunked range worth the slightly simpler code
+				fillChunksBinaryL<Arch>(pointer, expr, fromIndex, toIndex);
+			}
+		} else {
+			fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+		}
+	}
+
+	// Constexpr size
+	template<typename V, size_t size>
+	XSIMD_INLINE static V * getPrevAligned(V *array) {
+		static_assert(size > 0, "alignment size cannot be 0");
+		static_assert(sizeof(size_t) == sizeof(uintptr_t), "size_t != uintptr_t, which is valid but weird enough (on modern systems) to be suspicious");
+		static constexpr uintptr_t alignBytes = sizeof(V)*size;
+		static constexpr uintptr_t alignMask = ~(alignBytes - 1);
+		uintptr_t asInt = reinterpret_cast<uintptr_t>(array);
+		return reinterpret_cast<V *>(asInt&alignMask);
+	}
+	template<typename V, size_t size>
+	XSIMD_INLINE static V * getNextAligned(V *array) {
+		return getPrevAligned<V, size>(array + (size - 1));
+	}
+	// Runtime size
+	template<typename V>
+	XSIMD_INLINE static V * getPrevAligned(V *array, size_t size) {
+		static_assert(sizeof(size_t) == sizeof(uintptr_t), "size_t != uintptr_t, which is valid but weird enough (on modern systems) to be suspicious");
+		return reinterpret_cast<V *>(reinterpret_cast<uintptr_t>(array)&~(sizeof(V)*size - 1));
+	}
+	template<typename V>
+	XSIMD_INLINE static V * getNextAligned(V *array, size_t size) {
+		return reinterpret_cast<V *>(reinterpret_cast<uintptr_t>(array + (size - 1))&~(sizeof(V)*size - 1));
+	}
+
+	//---- The following should only end up instantiated on systems where `Arch` is a fully usable XSimd architecture ----//
+
+#ifdef SIGNALSMITH_USE_XSIMD_DISPATCH
+#	if defined(__i386__) || defined(__x86_64__)
+#		define SIGNALSMITH_USE_XSIMD_DISPATCH_X86
+#	elif defined(__ARM_NEON)
+#		define SIGNALSMITH_USE_XSIMD_DISPATCH_ARM
+#	endif
+
+#	ifdef SIGNALSMITH_LINEAR_XSIMD_DISPATCH_ARCH
+// Declare a concrete specialisation for one particular architecture
+#		define SIGNALSMITH_LINEAR_ARCH_DISPATCH(fnName, ...) \
+			template void fnName<SIGNALSMITH_LINEAR_XSIMD_DISPATCH_ARCH>(__VA_ARGS__, SIGNALSMITH_LINEAR_XSIMD_DISPATCH_ARCH);
+#	elif defined(SIGNALSMITH_USE_XSIMD_DISPATCH_X86)
+// List the arch-specific specialisations which will be defined in other units
+#		define SIGNALSMITH_LINEAR_ARCH_DISPATCH(fnName, ...) \
+			extern template void fnName<xsimd::sse2>(__VA_ARGS__, xsimd::sse2); \
+			extern template void fnName<xsimd::sse4_2>(__VA_ARGS__, xsimd::sse4_2); \
+			extern template void fnName<xsimd::avx>(__VA_ARGS__, xsimd::avx); \
+			extern template void fnName<xsimd::avx2>(__VA_ARGS__, xsimd::avx2); \
+			extern template void fnName<xsimd::avx512f>(__VA_ARGS__, xsimd::avx512f);
+#	elif defined(SIGNALSMITH_USE_XSIMD_DISPATCH_ARM)
+#		define SIGNALSMITH_LINEAR_ARCH_DISPATCH(fnName, ...) \
+			extern template void fnName<xsimd::neon>(__VA_ARGS__, xsimd::neon); \
+			extern template void fnName<xsimd::neon64>(__VA_ARGS__, xsimd::neon64);
+#	endif
+#else
+#	define SIGNALSMITH_LINEAR_ARCH_DISPATCH(...)
+#endif
+
+	template<class Arch>
+	void getMemoryAlignment(size_t &result, Arch) {
+		// TODO: we can only do this check if we avoid compiling for redundant architectures (e.g. neon64 on an x64 target)
+		//static_assert(xsimd::batch<float, Arch>::size > 0, "This must only be compiled for the target where `Arch` is defined");
+		static_assert(Arch::alignment() <= maxAlignmentBytes, "maxAlignmentBytes is too small");
+		result = (Arch::alignment() < sizeof(double)) ? sizeof(double) : Arch::alignment();
+	}
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(getMemoryAlignment, size_t &);
+
+	template<class Arch, class V>
+	void fillConstantTyped(RealPointer<V> pointer, V value, size_t fromIndex, size_t toIndex, Arch) {
+		if constexpr (notSupported<Arch, V>()) {
+			for (size_t i = fromIndex; i < toIndex; ++i) {
+				pointer[i] = value;
+			}
+		} else {
+			using Batch = xsimd::batch<V, Arch>;
+			Batch batch{value};
+			for (size_t i = fromIndex; i < toIndex; i += Batch::size) {
+				batch.store_aligned(pointer + i);
+			}
+		}
+	}
+
+	template<class Arch, class V>
+	void fillConstantTyped(ComplexPointer<V> pointer, std::complex<V> value, size_t fromIndex, size_t toIndex, Arch) {
+		using C = std::complex<V>;
+		if constexpr (notSupported<Arch, C>()) {
+			for (size_t i = fromIndex; i < toIndex; ++i) {
+				pointer[i] = value;
+			}
+		} else {
+			using Batch = xsimd::batch<C, Arch>;
+			Batch batch{value};
+			for (size_t i = fromIndex; i < toIndex; i += Batch::size) {
+				batch.store_aligned(pointer + i);
+			}
+		}
+	}
+	template<class Arch, class V>
+	void fillConstantTyped(SplitPointer<V> pointer, std::complex<V> value, size_t fromIndex, size_t toIndex, Arch) {
+		using C = std::complex<V>;
+		if constexpr (notSupported<Arch, C>()) {
+			for (size_t i = fromIndex; i < toIndex; ++i) {
+				pointer.real[i] = value.real();
+				pointer.imag[i] = value.imag();
+			}
+		} else {
+			using Batch = xsimd::batch<V, Arch>;
+			Batch batchReal{value.real()}, batchImag{value.imag()};
+			for (size_t i = fromIndex; i < toIndex; i += Batch::size) {
+				batchReal.store_aligned(pointer.real + i);
+				batchImag.store_aligned(pointer.imag + i);
+			}
+		}
+	}
+	template<class Arch>
+	void fillConstant(RealPointer<float> pointer, float value, size_t fromIndex, size_t toIndex, Arch) {
+		fillConstantTyped<Arch, float>(pointer, value, fromIndex, toIndex, Arch{});
+	}
+	template<class Arch>
+	void fillConstant(RealPointer<double> pointer, double value, size_t fromIndex, size_t toIndex, Arch) {
+		fillConstantTyped<Arch, double>(pointer, value, fromIndex, toIndex, Arch{});
+	}
+	template<class Arch>
+	void fillConstant(ComplexPointer<float> pointer, std::complex<float> value, size_t fromIndex, size_t toIndex, Arch) {
+		fillConstantTyped<Arch, float>(pointer, value, fromIndex, toIndex, Arch{});
+	}
+	template<class Arch>
+	void fillConstant(ComplexPointer<double> pointer, std::complex<double> value, size_t fromIndex, size_t toIndex, Arch) {
+		fillConstantTyped<Arch, double>(pointer, value, fromIndex, toIndex, Arch{});
+	}
+	template<class Arch>
+	void fillConstant(SplitPointer<float> pointer, std::complex<float> value, size_t fromIndex, size_t toIndex, Arch) {
+		fillConstantTyped<Arch, float>(pointer, value, fromIndex, toIndex, Arch{});
+	}
+	template<class Arch>
+	void fillConstant(SplitPointer<double> pointer, std::complex<double> value, size_t fromIndex, size_t toIndex, Arch) {
+		fillConstantTyped<Arch, double>(pointer, value, fromIndex, toIndex, Arch{});
+	}
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillConstant, RealPointer<float>, float, size_t, size_t) \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillConstant, RealPointer<double>, double, size_t, size_t) \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillConstant, ComplexPointer<float>, std::complex<float>, size_t, size_t) \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillConstant, ComplexPointer<double>, std::complex<double>, size_t, size_t) \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillConstant, SplitPointer<float>, std::complex<float>, size_t, size_t) \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillConstant, SplitPointer<double>, std::complex<double>, size_t, size_t) \
+
+	template<class Arch, class V2, class Expr>
+	void fillAligned(RealPointer<float> pointer, expression::ConstantExpr<V2> expr, size_t fromIndex, size_t toIndex, Arch) {
+		fillConstant<Arch>(pointer, float(expr.value), fromIndex, toIndex);
+	}
+	template<class Arch, class V2, class Expr>
+	void fillAligned(RealPointer<double> pointer, expression::ConstantExpr<V2> expr, size_t fromIndex, size_t toIndex, Arch) {
+		fillConstant<Arch>(pointer, double(expr.value), fromIndex, toIndex);
+	}
+	template<class Arch, class V2, class Expr>
+	void fillAligned(ComplexPointer<float> pointer, expression::ConstantExpr<V2> expr, size_t fromIndex, size_t toIndex, Arch) {
+		using C = std::complex<float>;
+		fillConstant<Arch>(pointer, C(expr.value), fromIndex, toIndex);
+	}
+	template<class Arch, class V2, class Expr>
+	void fillAligned(ComplexPointer<double> pointer, expression::ConstantExpr<V2> expr, size_t fromIndex, size_t toIndex, Arch) {
+		using C = std::complex<double>;
+		fillConstant<Arch>(pointer, C(expr.value), fromIndex, toIndex);
+	}
+	template<class Arch, class V2, class Expr>
+	void fillAligned(SplitPointer<float> pointer, expression::ConstantExpr<V2> expr, size_t fromIndex, size_t toIndex, Arch) {
+		using C = std::complex<float>;
+		fillConstant<Arch>(pointer, C(expr.value), fromIndex, toIndex);
+	}
+	template<class Arch, class V2, class Expr>
+	void fillAligned(SplitPointer<double> pointer, expression::ConstantExpr<V2> expr, size_t fromIndex, size_t toIndex, Arch) {
+		using C = std::complex<double>;
+		fillConstant<Arch>(pointer, C(expr.value), fromIndex, toIndex);
+	}
+	
+	template<class Arch>
+	struct GetBatch {
+		template<class V>
+		XSIMD_INLINE static xsimd::batch<V, Arch> getBatch(const expression::ReadableReal<V> &expr, size_t index) {
+			return xsimd::batch<V, Arch>::load_unaligned(expr.pointer + index);
+		}
+		template<class V>
+		XSIMD_INLINE static xsimd::batch<std::complex<V>, Arch> getBatch(const expression::ReadableComplex<V> &expr, size_t index) {
+			return xsimd::batch<std::complex<V>, Arch>::load_unaligned(expr.pointer + index);
+		}
+		template<class V>
+		XSIMD_INLINE static xsimd::batch<std::complex<V>, Arch> getBatch(const expression::ReadableSplit<V> &expr, size_t index) {
+			return xsimd::batch<std::complex<V>, Arch>::load_unaligned(expr.pointer.real + index, expr.pointer.imag + index);
+		}
+
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Abs<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::abs(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Norm<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::norm(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Exp<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::exp(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Exp2<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::exp2(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Log<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::log(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Log2<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::log2(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Log10<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::log10(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Neg<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return -getBatch(expr.a, index);
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Floor<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::floor(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Ceil<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::ceil(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Conj<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::conj(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Sqrt<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::sqrt(getBatch(expr.a, index));
+		}
+		template<class Expr>
+		XSIMD_INLINE static auto getBatch(const expression::Cbrt<Expr> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::cbrt(getBatch(expr.a, index));
+		}
+
+		template<class ExprA, class ExprB>
+		XSIMD_INLINE static auto getBatch(const expression::Add<ExprA, ExprB> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return getBatch(expr.a, index) + getBatch(expr.b, index);
+		}
+		template<class ExprA, class ExprB>
+		XSIMD_INLINE static auto getBatch(const expression::Sub<ExprA, ExprB> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return getBatch(expr.a, index) - getBatch(expr.b, index);
+		}
+		template<class ExprA, class ExprB>
+		XSIMD_INLINE static auto getBatch(const expression::Mul<ExprA, ExprB> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return getBatch(expr.a, index) * getBatch(expr.b, index);
+		}
+		template<class ExprA, class ExprB>
+		XSIMD_INLINE static auto getBatch(const expression::Div<ExprA, ExprB> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return getBatch(expr.a, index) / getBatch(expr.b, index);
+		}
+		template<class ExprA, class ExprB>
+		XSIMD_INLINE static auto getBatch(const expression::Max<ExprA, ExprB> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::max(getBatch(expr.a, index), getBatch(expr.b, index));
+		}
+		template<class ExprA, class ExprB>
+		XSIMD_INLINE static auto getBatch(const expression::Min<ExprA, ExprB> &expr, size_t index) -> xsimd::batch<std::remove_cv_t<decltype(expr.get(0))>, Arch> {
+			return xsimd::min(getBatch(expr.a, index), getBatch(expr.b, index));
+		}
+	};
+
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillSpecialisedReal(RealPointer<V> pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		if constexpr (notSupported<Arch, V>()) {
+			fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+		} else {
+			using Batch = xsimd::batch<V, Arch>;
+			for (size_t i = fromIndex; i < toIndex; i += Batch::size) {
+				Batch b = GetBatch<Arch>::getBatch(expr, i);
+				b.store_aligned(pointer + i);
+			}
+		}
+	}
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillSpecialisedComplex(ComplexPointer<V> pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		if constexpr (notSupported<Arch, std::complex<V>>()) {
+			fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+		} else {
+			using Batch = xsimd::batch<std::complex<V>, Arch>;
+			for (size_t i = fromIndex; i < toIndex; i += Batch::size) {
+				Batch b = GetBatch<Arch>::getBatch(expr, i);
+				b.store_aligned(pointer + i);
+			}
+		}
+	}
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillSpecialisedSplit(SplitPointer<V> pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		if constexpr (notSupported<Arch, std::complex<V>>()) {
+			fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+		} else {
+			using Batch = xsimd::batch<std::complex<V>, Arch>;
+			for (size_t i = fromIndex; i < toIndex; i += Batch::size) {
+				Batch b = GetBatch<Arch>::getBatch(expr, i);
+				b.store_aligned(pointer.real + i, pointer.imag + i);
+			}
+		}
+	}
+
+#define SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(V, ...) \
+	template<class Arch> \
+	void fillAligned(RealPointer<V> pointer, __VA_ARGS__ expr, size_t fromIndex, size_t toIndex, Arch) { \
+		if constexpr(Arch::supported()) fillSpecialisedReal<Arch>(pointer, expr, fromIndex, toIndex); \
+	} \
+	template<class Arch> \
+	void fillAligned(ComplexPointer<V> pointer, __VA_ARGS__ expr, size_t fromIndex, size_t toIndex, Arch) { \
+		if constexpr(Arch::supported()) fillSpecialisedComplex<Arch>(pointer, expr, fromIndex, toIndex); \
+	} \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillAligned, RealPointer<V>, __VA_ARGS__, size_t, size_t) \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillAligned, ComplexPointer<V>, __VA_ARGS__, size_t, size_t)
+	
+#define SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(V, ...) \
+	template<class Arch> \
+	void fillAligned(ComplexPointer<V> pointer, __VA_ARGS__ expr, size_t fromIndex, size_t toIndex, Arch) { \
+		if constexpr(Arch::supported()) fillSpecialisedComplex<Arch>(pointer, expr, fromIndex, toIndex); \
+	} \
+	template<class Arch> \
+	void fillAligned(SplitPointer<V> pointer, __VA_ARGS__ expr, size_t fromIndex, size_t toIndex, Arch) { \
+		if constexpr(Arch::supported()) fillSpecialisedSplit<Arch>(pointer, expr, fromIndex, toIndex); \
+	} \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillAligned, ComplexPointer<V>, __VA_ARGS__, size_t, size_t) \
+	SIGNALSMITH_LINEAR_ARCH_DISPATCH(fillAligned, SplitPointer<V>, __VA_ARGS__, size_t, size_t)
+
+// Real unary operators
+#define SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Name) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(float, expression::Name<expression::ReadableReal<float>>) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(double, expression::Name<expression::ReadableReal<double>>)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Abs)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Floor)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Ceil)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Neg)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Exp)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Exp2)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Log)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Log2)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Log10)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Sqrt)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Cbrt)
+#undef SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP
+
+// Complex -> real unary operators
+#define SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Name) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(float, expression::Name<expression::ReadableComplex<float>>) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(double, expression::Name<expression::ReadableComplex<double>>) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(float, expression::Name<expression::ReadableSplit<float>>) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(double, expression::Name<expression::ReadableSplit<double>>)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Abs)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Norm)
+#undef SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP
+
+// Complex unary operators
+#define SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Name) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(float, expression::Name<expression::ReadableComplex<float>>) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(double, expression::Name<expression::ReadableComplex<double>>) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(float, expression::Name<expression::ReadableSplit<float>>) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(double, expression::Name<expression::ReadableSplit<double>>)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Conj)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Neg)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Exp)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Log)
+#undef SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP
+
+// Real binary operators
+#define SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Name) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(float, expression::Name<expression::ReadableReal<float>, expression::ReadableReal<float>>); \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_REAL(double, expression::Name<expression::ReadableReal<double>, expression::ReadableReal<double>>);
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Max)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Min)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Add)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Sub)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Mul)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Div)
+#undef SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP
+
+// Complex binary operators
+#define SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Name) \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(float, expression::Name<expression::ReadableComplex<float>, expression::ReadableComplex<float>>); \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(double, expression::Name<expression::ReadableComplex<double>, expression::ReadableComplex<double>>); \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(float, expression::Name<expression::ReadableSplit<float>, expression::ReadableSplit<float>>); \
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_COMPLEX(double, expression::Name<expression::ReadableSplit<double>, expression::ReadableSplit<double>>);
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Add)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Sub)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Mul)
+	SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP(Div)
+#undef SIGNALSMITH_LINEAR_ARCH_SPECIALISE_OP
+
+	//---- Chunking stuff ----//
+	// If we don't have a specialised version for a composite expression, unary/binary expressions can have their arguments filled first (using smaller chunks on the stack as temporary space) and then the outer operator is called on that pointer.
+	// This goes last so that it can see all the specialisations above
+
+#ifndef SIGNALSMITH_LINEAR_STACK_BLOCK_BYTES
+#	define SIGNALSMITH_LINEAR_STACK_BLOCK_BYTES 4096
+#endif
+	template<class Arch, class V>
+	struct StackBlockReal {
+		static constexpr size_t length = SIGNALSMITH_LINEAR_STACK_BLOCK_BYTES/sizeof(V);
+		static constexpr size_t alignmentSize = maxAlignmentBytes/sizeof(V);
+		
+		V maybeUnaligned[length + alignmentSize - 1];
+		V *aligned;
+	
+		StackBlockReal() : aligned(getNextAligned<V, alignmentSize>(maybeUnaligned)) {}
+	};
+
+	template<class Arch, class Pointer, class Expr>
+	XSIMD_INLINE void fillChunksUnary(Pointer pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		using E = expression::ElementType<decltype(expr.a)>;
+		if constexpr (!expression::isSplittable<E>()) {
+			using ReplacementExpr = typename Expr::template ReplaceWith<expression::ReadableReal<E>>;
+			StackBlockReal<Arch, E> stackBlock;
+
+			// Fill blockwise with values from `expr.a`
+			size_t blockEnd = fromIndex + stackBlock.length;
+			while (blockEnd < toIndex) {
+				auto stackPointer = stackBlock.aligned - fromIndex;
+				fillAligned<Arch>(stackPointer, expr.a, fromIndex, blockEnd, Arch{});
+				fillAligned<Arch>(pointer, ReplacementExpr{stackPointer}, fromIndex, blockEnd, Arch{});
+				// move to next block
+				fromIndex = blockEnd;
+				blockEnd = fromIndex + stackBlock.length;
+			}
+
+			if (fromIndex < toIndex) { // Final block
+				auto stackPointer = stackBlock.aligned - fromIndex;
+				fillAligned<Arch>(stackPointer, expr.a, fromIndex, toIndex, Arch{});
+				fillAligned<Arch>(pointer, ReplacementExpr{stackPointer}, fromIndex, toIndex, Arch{});
+			}
+		} else {
+			fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+		}
+	}
+
+	template<class Arch, class Pointer, class Expr>
+	XSIMD_INLINE void fillChunksBinaryL(Pointer pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		using E = expression::ElementType<decltype(expr.a)>;
+		if constexpr (!expression::isSplittable<E>()) {
+			using ReplacementExpr = typename Expr::template ReplaceWithL<expression::ReadableReal<E>>;
+			StackBlockReal<Arch, E> stackBlock;
+
+//std::cout << "<Chunking LHS: " << expr.a.name() << " in " << expr.name() << ">\n";
+//size_t blockCount = 0;
+			// Fill blockwise with values from `expr.a`
+			size_t blockEnd = fromIndex + stackBlock.length;
+			while (blockEnd < toIndex) {
+//++blockCount;
+				auto stackPointer = stackBlock.aligned - fromIndex;
+				fillAligned<Arch>(stackPointer, expr.a, fromIndex, blockEnd, Arch{});
+				fillAligned<Arch>(pointer, ReplacementExpr{stackPointer, expr.b}, fromIndex, blockEnd, Arch{});
+				// move to next block
+				fromIndex = blockEnd;
+				blockEnd = fromIndex + stackBlock.length;
+			}
+
+			if (fromIndex < toIndex) { // Final block
+//++blockCount;
+				auto stackPointer = stackBlock.aligned - fromIndex;
+				fillAligned<Arch>(stackPointer, expr.a, fromIndex, toIndex, Arch{});
+				fillAligned<Arch>(pointer, ReplacementExpr{stackPointer, expr.b}, fromIndex, toIndex, Arch{});
+			}
+//LOG_EXPR(blockCount);
+//std::cout << "\tdone chunking LHS " << expr.a.name() << "\n";
+
+		} else {
+			fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+		}
+	}
+
+	template<class Arch, class Pointer, class Expr>
+	XSIMD_INLINE void fillChunksBinaryR(Pointer pointer, Expr expr, size_t fromIndex, size_t toIndex) {
+		using E = expression::ElementType<decltype(expr.b)>;
+		if constexpr (!expression::isSplittable<E>()) {
+			using ReplacementExpr = typename Expr::template ReplaceWithR<expression::ReadableReal<E>>;
+			StackBlockReal<Arch, E> stackBlock;
+
+//std::cout << "<Chunking RHS: " << expr.b.name() << " in " << expr.name() << ">\n";
+//size_t blockCount = 0;
+			// Fill blockwise with values from `expr.a`
+			size_t blockEnd = fromIndex + stackBlock.length;
+			while (blockEnd < toIndex) {
+//++blockCount;
+				auto stackPointer = stackBlock.aligned - fromIndex;
+				fillAligned<Arch>(stackPointer, expr.b, fromIndex, blockEnd, Arch{});
+				fillAligned<Arch>(pointer, ReplacementExpr{expr.a, stackPointer}, fromIndex, blockEnd, Arch{});
+				// move to next block
+				fromIndex = blockEnd;
+				blockEnd = fromIndex + stackBlock.length;
+			}
+
+			if (fromIndex < toIndex) { // Final block
+//++blockCount;
+				auto stackPointer = stackBlock.aligned - fromIndex;
+				fillAligned<Arch>(stackPointer, expr.b, fromIndex, toIndex, Arch{});
+				fillAligned<Arch>(pointer, ReplacementExpr{expr.a, stackPointer}, fromIndex, toIndex, Arch{});
+			}
+//LOG_EXPR(blockCount);
+//std::cout << "\tdone chunking RHS " << expr.b.name() << "\n";
+		} else {
+			fillBasic<Arch>(pointer, expr, fromIndex, toIndex);
+		}
+	}
+}
+#undef SIGNALSMITH_LINEAR_ARCH_DISPATCH
+
+template<>
+struct LinearImpl<true> : public LinearImplBase<true> {
+	using Base = LinearImplBase<true>;
+
+	LinearImpl() : Base(this) {
+		basicFillWarningReset();
+		chooseArchitecture();
+	}
+
+	template<class V>
+	void reserve(size_t) {}
+
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, Expr expr, size_t size) {
+		fillExprDispatch(pointer, expr, size);
+	}
+
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, Expression<Expr> expr, size_t size) {
+		return fillExprDispatch(pointer, (Expr &)expr, size);
+	};
+	template<class Pointer, class Expr>
+	void fill(Pointer pointer, WritableExpression<Expr> expr, size_t size) {
+		return fillExprDispatch(pointer, (Expr &)expr, size);
+	};
+
+private:
+
+#ifdef SIGNALSMITH_USE_XSIMD_DISPATCH_X86
+	enum class Arch{sse2, sse4_2, avx, avx2, avx512f};
+	Arch bestArch = Arch::sse2;
+
+	void chooseArchitecture() {
+		auto available = xsimd::available_architectures();
+		if (available.has(xsimd::sse4_2{})) bestArch = Arch::sse4_2;
+		if (available.has(xsimd::avx{})) bestArch = Arch::avx;
+		if (available.has(xsimd::avx2{})) bestArch = Arch::avx2;
+		if (available.has(xsimd::avx512f{})) bestArch = Arch::avx512f;
+	}
+	
+	template<class Pointer, class Expr>
+	void fillExprDispatch(Pointer pointer, Expr expr, size_t size) {
+		switch(bestArch) {
+			case Arch::sse2: return fillExpr<xsimd::sse2>(pointer, expr, size);
+			case Arch::sse4_2: return fillExpr<xsimd::sse4_2>(pointer, expr, size);
+			case Arch::avx: return fillExpr<xsimd::avx>(pointer, expr, size);
+			case Arch::avx2: return fillExpr<xsimd::avx2>(pointer, expr, size);
+			case Arch::avx512f: return fillExpr<xsimd::avx512f>(pointer, expr, size);
+		}
+	}
+#elif defined(SIGNALSMITH_USE_XSIMD_DISPATCH_ARM)
+	enum class Arch{neon, neon64};
+	Arch bestArch = Arch::neon; // TODO: better fallback for non-NEON systems
+
+	void chooseArchitecture() {
+		auto available = xsimd::available_architectures();
+		if (available.has(xsimd::neon64{})) bestArch = Arch::neon64;
+	}
+	
+	template<class Pointer, class Expr>
+	void fillExprDispatch(Pointer pointer, Expr expr, size_t size) {
+		switch(bestArch) {
+			case Arch::neon: return fillExpr<xsimd::neon>(pointer, expr, size);
+			case Arch::neon64: return fillExpr<xsimd::neon64>(pointer, expr, size);
+		}
+	}
+#else
+	void chooseArchitecture() {/*nothing*/}
+
+	template<class Pointer, class Expr>
+	XSIMD_INLINE void fillExprDispatch(Pointer pointer, Expr expr, size_t size) {
+		// Use best guaranteed arch
+		fillExpr<xsimd::best_arch>(pointer, expr, size);
+	}
+#endif
+
+	// Generic fill
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillExpr(RealPointer<V> array, Expr expr, size_t size) {
+		size_t alignmentBytes = 0;
+		_impl_fill::getMemoryAlignment<Arch>(alignmentBytes, Arch{});
+		size_t alignmentItems = alignmentBytes/sizeof(V);
+		
+		V *arrayEnd = array + size;
+		V *alignedStart = _impl_fill::getNextAligned<V>(array, alignmentItems);
+		V *alignedEnd = _impl_fill::getPrevAligned<V>(arrayEnd, alignmentItems);
+		if (alignedEnd <= alignedStart) { // Too short to have an aligned section
+			for (size_t i = 0; i < size; ++i) {
+				array[i] = V(expr.get(i));
+			}
+			return;
+		}
+		// Unaligned starting block
+		size_t i = 0;
+		while (array + i < alignedStart) {
+			*(array + i) = V(expr.get(i));
+			++i;
+		}
+
+		// SIMD fill
+		size_t alignedEndI = size_t(alignedEnd - array);
+		_impl_fill::fillAligned<Arch>(array, expr, i, alignedEndI, Arch{});
+		
+		// Unaligned ending block
+		for (size_t i = alignedEndI; i < size; ++i) {
+			array[i] = V(expr.get(i));
+		}
+	}
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillExpr(ComplexPointer<V> array, Expr expr, size_t size) {
+		size_t alignmentBytes = 0;
+		_impl_fill::getMemoryAlignment<Arch>(alignmentBytes, Arch{});
+		size_t alignmentItems = alignmentBytes/sizeof(V);
+
+		using C = std::complex<V>;
+		C *arrayEnd = array + size;
+		C *alignedStart = _impl_fill::getNextAligned<C>(array, alignmentItems);
+		C *alignedEnd = _impl_fill::getPrevAligned<C>(arrayEnd, alignmentItems);
+		if (alignedEnd <= alignedStart) { // Too short to have an aligned section
+			for (size_t i = 0; i < size; ++i) {
+				array[i] = C(expr.get(i));
+			}
+			return;
+		}
+		size_t i = 0;
+		while (array + i < alignedStart) {
+			*(array + i) = C(expr.get(i));
+			++i;
+		}
+
+		// SIMD fill
+		size_t alignedEndI = size_t(alignedEnd - array);
+		_impl_fill::fillAligned<Arch>(array, expr, i, alignedEndI, Arch{});
+
+		for (size_t i = alignedEndI; i < size; ++i) {
+			array[i] = C(expr.get(i));
+		}
+	}
+	template<class Arch, class V, class Expr>
+	XSIMD_INLINE void fillExpr(SplitPointer<V> array, Expr expr, size_t size) {
+		size_t alignmentBytes = 0;
+		_impl_fill::getMemoryAlignment<Arch>(alignmentBytes, Arch{});
+		size_t alignmentItems = alignmentBytes/sizeof(V);
+
+		using C = std::complex<V>;
+		V *real = array.real;
+		V *realEnd = real + size;
+		V *realAlignedStart = _impl_fill::getNextAligned<V>(real, alignmentItems);
+		V *realAlignedEnd = _impl_fill::getPrevAligned<V>(realEnd, alignmentItems);
+		
+		bool alignmentReal = uintptr_t(array.real)&(alignmentBytes - 1);
+		bool alignmentImag = uintptr_t(array.imag)&(alignmentBytes - 1);
+		if (realAlignedEnd <= realAlignedStart || (alignmentReal != alignmentImag)) {
+			// Either too short to have an aligned section, or the real/imaginary parts have unequal alignment
+			for (size_t i = 0; i < size; ++i) {
+				array[i] = C(expr.get(i));
+			}
+			return;
+		}
+		size_t i = 0;
+		while (real + i < realAlignedStart) {
+			array[i] = C(expr.get(i));
+			++i;
+		}
+
+		// SIMD fill
+		size_t alignedEndI = size_t(realAlignedEnd - real);
+		_impl_fill::fillAligned<Arch>(array, expr, i, alignedEndI, Arch{});
+
+		for (size_t i = alignedEndI; i < size; ++i) {
+			array[i] = C(expr.get(i));
+		}
+	}
+	// Filling a split-complex vector with real values won't hit the specialisations below, so we handle it here
+	template<class Arch, class Expr>
+	XSIMD_INLINE ItemType<Expr, float, void> fillExpr(SplitPointer<float> pointer, Expr expr, size_t size) {
+		fillExpr<Arch>(pointer.real, expr, size);
+		fillExpr<Arch>(pointer.imag, expression::ConstantExpr<float>(0), size);
+	}
+	template<class Arch, class Expr>
+	XSIMD_INLINE ItemType<Expr, double, void> fillExpr(SplitPointer<double> pointer, Expr expr, size_t size) {
+		fillExpr<Arch>(pointer.real, expr, size);
+		fillExpr<Arch>(pointer.imag, expression::ConstantExpr<double>(0), size);
+	}
+	
+	// Copying from existing pointer
+	template<class Arch>
+	XSIMD_INLINE void fillExpr(RealPointer<float> pointer, expression::ReadableReal<float> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(float));
+	}
+	template<class Arch>
+	XSIMD_INLINE void fillExpr(RealPointer<float> pointer, WritableReal<float> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(float));
+	}
+	template<class Arch>
+	XSIMD_INLINE void fillExpr(RealPointer<double> pointer, expression::ReadableReal<double> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(double));
+	}
+	template<class Arch>
+	XSIMD_INLINE void fillExpr(RealPointer<double> pointer, WritableReal<double> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(double));
+	}
+	template<class Arch>
+	XSIMD_INLINE void fillExpr(ComplexPointer<float> pointer, expression::ReadableComplex<float> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(std::complex<float>));
+	}
+	template<class Arch>
+	XSIMD_INLINE void fillExpr(ComplexPointer<float> pointer, WritableComplex<float> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(std::complex<float>));
+	}
+	template<class Arch>
+	XSIMD_INLINE void fillExpr(ComplexPointer<double> pointer, expression::ReadableComplex<double> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(std::complex<double>));
+	}
+	template<class Arch>
+	XSIMD_INLINE void fillExpr(ComplexPointer<double> pointer, WritableComplex<double> expr, size_t size) {
+		std::memcpy(pointer, expr.pointer, size*sizeof(std::complex<double>));
+	}
+};
+
+}}; // namespace

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/stft.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-linear/stft.h
@@ -1,0 +1,700 @@
+#ifndef SIGNALSMITH_AUDIO_LINEAR_STFT_H
+#define SIGNALSMITH_AUDIO_LINEAR_STFT_H
+
+#include "./fft.h"
+
+namespace signalsmith { namespace linear {
+
+enum {
+	STFT_SPECTRUM_PACKED=0,
+	STFT_SPECTRUM_MODIFIED=1,
+	STFT_SPECTRUM_UNPACKED=2,
+};
+
+/// A self-normalising STFT, with variable position/window for output blocks
+template<typename Sample, bool splitComputation=false, int spectrumType=STFT_SPECTRUM_PACKED>
+struct DynamicSTFT {
+	static constexpr bool modified = (spectrumType == STFT_SPECTRUM_MODIFIED);
+	static constexpr bool unpacked = (spectrumType == STFT_SPECTRUM_UNPACKED);
+	RealFFT<Sample, splitComputation, modified> fft;
+
+	using Complex = std::complex<Sample>;
+
+	enum class WindowShape {ignore, acg, kaiser};
+	static constexpr WindowShape acg = WindowShape::acg;
+	static constexpr WindowShape kaiser = WindowShape::kaiser;
+	enum class Normalisation {none, synthesis, roundTrip};
+	static constexpr Normalisation normNone = Normalisation::none;
+	static constexpr Normalisation normSynthesis = Normalisation::synthesis;
+	static constexpr Normalisation normRoundTrip = Normalisation::roundTrip;
+
+	void configure(size_t inChannels, size_t outChannels, size_t blockSamples, size_t extraInputHistory=0, size_t intervalSamples=0, Sample asymmetry=0, size_t fftMinSize=0) {
+		_analysisChannels = inChannels;
+		_synthesisChannels = outChannels;
+		_blockSamples = blockSamples;
+		if (!fftMinSize) fftMinSize = blockSamples;
+		_fftSamples = fft.fastSizeAbove((fftMinSize + 1)/2)*2;
+		fft.resize(_fftSamples);
+		_fftBins = _fftSamples/2 + (spectrumType == STFT_SPECTRUM_UNPACKED);
+		
+		_inputLengthSamples = _blockSamples + extraInputHistory;
+		input.buffer.resize(_inputLengthSamples*_analysisChannels);
+
+		output.buffer.resize(_blockSamples*_synthesisChannels);
+		output.windowProducts.resize(_blockSamples);
+		spectrumBuffer.resize(_fftBins*std::max(_analysisChannels, _synthesisChannels));
+		timeBuffer.resize(std::max(_fftSamples, _blockSamples));
+
+		_analysisWindow.resize(_blockSamples);
+		_synthesisWindow.resize(_blockSamples);
+		setInterval(intervalSamples ? intervalSamples : blockSamples/4, acg, asymmetry);
+
+		reset();
+	}
+	
+	size_t blockSamples() const {
+		return _blockSamples;
+	}
+	size_t fftSamples() const {
+		return _fftSamples;
+	}
+	size_t defaultInterval() const {
+		return _defaultInterval;
+	}
+	size_t bands() const {
+		return _fftBins;
+	}
+	size_t analysisLatency() const {
+		return _blockSamples - _analysisOffset;
+	}
+	size_t synthesisLatency() const {
+		return _synthesisOffset;
+	}
+	size_t latency() const {
+		return synthesisLatency() + analysisLatency();
+	}
+	Sample binToFreq(Sample b) const {
+		return (modified ? b + Sample(0.5) : b)/_fftSamples;
+	}
+	Sample freqToBin(Sample f) const {
+		return modified ? f*_fftSamples - Sample(0.5) : f*_fftSamples;
+	}
+
+	void reset(Sample productWeight=1) {
+		input.pos = _blockSamples;
+		output.pos = 0;
+		for (auto &v : input.buffer) v = 0;
+		for (auto &v : output.buffer) v = 0;
+		for (auto &v : spectrumBuffer) v = 0;
+		for (auto &v : output.windowProducts) v = 0;
+		if (norm != normNone) {
+			addWindowProduct();
+			for (int i = int(_blockSamples) - int(_defaultInterval) - 1; i >= 0; --i) {
+				output.windowProducts[i] += output.windowProducts[i + _defaultInterval];
+			}
+		}
+		for (auto &v : output.windowProducts) v = v*productWeight + almostZero;
+		moveOutput(_defaultInterval); // ready for first block immediately
+	}
+
+	void writeInput(size_t channel, size_t offset, size_t length, const Sample *inputArray) {
+		Sample *buffer = input.buffer.data() + channel*_inputLengthSamples;
+
+		size_t offsetPos = (input.pos + offset)%_inputLengthSamples;
+		size_t inputWrapIndex = _inputLengthSamples - offsetPos;
+		size_t chunk1 = std::min(length, inputWrapIndex);
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = offsetPos + i;
+			buffer[i2] = inputArray[i];
+		}
+		for (size_t i = chunk1; i < length; ++i) {
+			size_t i2 = i + offsetPos -_inputLengthSamples;
+			buffer[i2] = inputArray[i];
+		}
+	}
+	void writeInput(size_t channel, size_t length, const Sample *inputArray) {
+		writeInput(channel, 0, length, inputArray);
+	}
+	void moveInput(size_t samples, bool clearInput=false) {
+		if (clearInput) {
+			size_t inputWrapIndex = _inputLengthSamples - input.pos;
+			size_t chunk1 = std::min(samples, inputWrapIndex);
+			for (size_t c = 0; c < _analysisChannels; ++c) {
+				Sample *buffer = input.buffer.data() + c*_inputLengthSamples;
+				for (size_t i = 0; i < chunk1; ++i) {
+					size_t i2 = input.pos + i;
+					buffer[i2] = 0;
+				}
+				for (size_t i = chunk1; i < samples; ++i) {
+					size_t i2 = i + input.pos - _inputLengthSamples;
+					buffer[i2] = 0;
+				}
+			}
+		}
+
+		input.pos = (input.pos + samples)%_inputLengthSamples;
+		_samplesSinceAnalysis += samples;
+	}
+	size_t samplesSinceAnalysis() const {
+		return _samplesSinceAnalysis;
+	}
+
+	/// When no more synthesis is expected, let output taper away to 0 based on windowing.  Otherwise, the output will be scaled as if there's just a very long block interval, which can exaggerate artefacts and numerical errors.  You still can't read more than `blockSamples()` into the future.
+	void finishOutput(Sample strength=1, size_t offset=0) {
+		Sample maxWindowProduct = 0;
+		
+		size_t chunk1 = std::max(offset, std::min(_blockSamples, _blockSamples - output.pos));
+		
+		for (size_t i = offset; i < chunk1; ++i) {
+			size_t i2 = output.pos + i;
+			Sample &wp = output.windowProducts[i2];
+			maxWindowProduct = std::max(wp, maxWindowProduct);
+			wp += (maxWindowProduct - wp)*strength;
+		}
+		for (size_t i = chunk1; i < _blockSamples; ++i) {
+			size_t i2 = i + output.pos - _blockSamples;
+			Sample &wp = output.windowProducts[i2];
+			maxWindowProduct = std::max(wp, maxWindowProduct);
+			wp += (maxWindowProduct - wp)*strength;
+		}
+	}
+
+	void readOutput(size_t channel, size_t offset, size_t length, Sample *outputArray) {
+		Sample *buffer = output.buffer.data() + channel*_blockSamples;
+		size_t offsetPos = (output.pos + offset)%_blockSamples;
+		size_t outputWrapIndex = _blockSamples - offsetPos;
+		size_t chunk1 = std::min(length, outputWrapIndex);
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = offsetPos + i;
+			outputArray[i] = buffer[i2]/output.windowProducts[i2];
+		}
+		for (size_t i = chunk1; i < length; ++i) {
+			size_t i2 = i + offsetPos - _blockSamples;
+			outputArray[i] = buffer[i2]/output.windowProducts[i2];
+		}
+	}
+	void readOutput(size_t channel, size_t length, Sample *outputArray) {
+		return readOutput(channel, 0, length, outputArray);
+	}
+	void addOutput(size_t channel, size_t offset, size_t length, const Sample *newOutputArray) {
+		length = std::min(_blockSamples, length);
+		Sample *buffer = output.buffer.data() + channel*_blockSamples;
+		size_t offsetPos = (output.pos + offset)%_blockSamples;
+		size_t outputWrapIndex = _blockSamples - offsetPos;
+		size_t chunk1 = std::min(length, outputWrapIndex);
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = offsetPos + i;
+			buffer[i2] += newOutputArray[i]*output.windowProducts[i2];
+		}
+		for (size_t i = chunk1; i < length; ++i) {
+			size_t i2 = i + offsetPos - _blockSamples;
+			buffer[i2] += newOutputArray[i]*output.windowProducts[i2];
+		}
+	}
+	void addOutput(size_t channel, size_t length, const Sample *newOutputArray) {
+		return addOutput(channel, 0, length, newOutputArray);
+	}
+	void replaceOutput(size_t channel, size_t offset, size_t length, const Sample *newOutputArray) {
+		length = std::min(_blockSamples, length);
+		Sample *buffer = output.buffer.data() + channel*_blockSamples;
+		size_t offsetPos = (output.pos + offset)%_blockSamples;
+		size_t outputWrapIndex = _blockSamples - offsetPos;
+		size_t chunk1 = std::min(length, outputWrapIndex);
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = offsetPos + i;
+			buffer[i2] = newOutputArray[i]*output.windowProducts[i2];
+		}
+		for (size_t i = chunk1; i < length; ++i) {
+			size_t i2 = i + offsetPos - _blockSamples;
+			buffer[i2] = newOutputArray[i]*output.windowProducts[i2];
+		}
+	}
+	void replaceOutput(size_t channel, size_t length, const Sample *newOutputArray) {
+		return replaceOutput(channel, 0, length, newOutputArray);
+	}
+	void moveOutput(size_t samples) {
+		if (samples == 1) { // avoid all the loops/chunks if we can
+			for (size_t c = 0; c < _synthesisChannels; ++c) {
+				output.buffer[output.pos + c*_blockSamples] = 0;
+			}
+			output.windowProducts[output.pos] = almostZero;
+			if (++output.pos >= _blockSamples) output.pos = 0;
+			return;
+		}
+		// Zero the output buffer as we cross it
+		size_t outputWrapIndex = _blockSamples - output.pos;
+		size_t chunk1 = std::min(samples, outputWrapIndex);
+		for (size_t c = 0; c < _synthesisChannels; ++c) {
+			Sample *buffer = output.buffer.data() + c*_blockSamples;
+			for (size_t i = 0; i < chunk1; ++i) {
+				size_t i2 = output.pos + i;
+				buffer[i2] = 0;
+			}
+			for (size_t i = chunk1; i < samples; ++i) {
+				size_t i2 = i + output.pos - _blockSamples;
+				buffer[i2] = 0;
+			}
+		}
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = output.pos + i;
+			output.windowProducts[i2] = almostZero;
+		}
+		for (size_t i = chunk1; i < samples; ++i) {
+			size_t i2 = i + output.pos - _blockSamples;
+			output.windowProducts[i2] = almostZero;
+		}
+		output.pos = (output.pos + samples)%_blockSamples;
+		_samplesSinceSynthesis += samples;
+	}
+	size_t samplesSinceSynthesis() const {
+		return _samplesSinceSynthesis;
+	}
+	
+	Complex * spectrum(size_t channel) {
+		return spectrumBuffer.data() + channel*_fftBins;
+	}
+	const Complex * spectrum(size_t channel) const {
+		return spectrumBuffer.data() + channel*_fftBins;
+	}
+
+	Sample * analysisWindow() {
+		return _analysisWindow.data();
+	}
+	const Sample * analysisWindow() const {
+		return _analysisWindow.data();
+	}
+	// Sets the centre index of the window
+	void analysisOffset(size_t offset) {
+		_analysisOffset = offset;
+	}
+	size_t analysisOffset() const {
+		return _analysisOffset;
+	}
+	Sample * synthesisWindow() {
+		return _synthesisWindow.data();
+	}
+	const Sample * synthesisWindow() const {
+		return _synthesisWindow.data();
+	}
+	// Sets the centre index of the window
+	void synthesisOffset(size_t offset) {
+		_synthesisOffset = offset;
+	}
+	size_t synthesisOffset() const {
+		return _synthesisOffset;
+	}
+	
+	void setInterval(size_t defaultInterval, WindowShape windowShape=WindowShape::ignore, Sample asymmetry=0) {
+		_defaultInterval = defaultInterval;
+		if (windowShape == WindowShape::ignore) return;
+
+		if (windowShape == acg) {
+			auto window = ApproximateConfinedGaussian::withBandwidth(double(_blockSamples)/defaultInterval);
+			window.fill(_synthesisWindow, _blockSamples, asymmetry, false);
+		} else if (windowShape == kaiser) {
+			auto window = Kaiser::withBandwidth(double(_blockSamples)/defaultInterval, true);
+			window.fill(_synthesisWindow,  _blockSamples, asymmetry, true);
+		}
+
+		_analysisOffset = _synthesisOffset = _blockSamples/2;
+		if (_analysisChannels == 0) {
+			for (auto &v : _analysisWindow) v = 1;
+		} else if (asymmetry == 0) {
+			forcePerfectReconstruction(_synthesisWindow, _blockSamples, _defaultInterval);
+			for (size_t i = 0; i < _blockSamples; ++i) {
+				_analysisWindow[i] = _synthesisWindow[i];
+			}
+		} else {
+			for (size_t i = 0; i < _blockSamples; ++i) {
+				_analysisWindow[i] = _synthesisWindow[_blockSamples - 1 - i];
+			}
+		}
+		// Set offsets to peak's index
+		for (size_t i = 0; i < _blockSamples; ++i) {
+			if (_analysisWindow[i] > _analysisWindow[_analysisOffset]) _analysisOffset = i;
+			if (_synthesisWindow[i] > _synthesisWindow[_synthesisOffset]) _synthesisOffset = i;
+		}
+	}
+	void setNormalisation(Normalisation mode) {
+		norm = mode;
+	}
+	
+	void analyse(size_t samplesInPast=0) {
+		for (size_t s = 0; s < analyseSteps(); ++s) {
+			analyseStep(s, samplesInPast);
+		}
+	}
+	size_t analyseSteps() const {
+		return splitComputation ? _analysisChannels*(fft.steps() + 1) : _analysisChannels;
+	}
+	void analyseStep(size_t step, std::size_t samplesInPast=0) {
+		size_t fftSteps = splitComputation ? fft.steps() : 0;
+		size_t channel = step/(fftSteps + 1);
+		step -= channel*(fftSteps + 1);
+		
+		if (step-- == 0) { // extra step at start of each channel: copy windowed input into buffer
+			size_t offsetPos = (_inputLengthSamples*2 + input.pos - _blockSamples - samplesInPast)%_inputLengthSamples;
+			size_t inputWrapIndex = _inputLengthSamples - offsetPos;
+			size_t chunk1 = std::min(_analysisOffset, inputWrapIndex);
+			size_t chunk2 = std::max(_analysisOffset, std::min(_blockSamples, inputWrapIndex));
+
+			_samplesSinceAnalysis = samplesInPast;
+			size_t bufferSize = timeBuffer.size(); // Use this rather than FFT size to handle undersized-FFT case
+			Sample *buffer = input.buffer.data() + channel*_inputLengthSamples;
+			for (size_t i = 0; i < chunk1; ++i) {
+				Sample w = modified ? -_analysisWindow[i] : _analysisWindow[i];
+				size_t ti = i + (bufferSize - _analysisOffset);
+				size_t bi = offsetPos + i;
+				timeBuffer[ti] = buffer[bi]*w;
+			}
+			for (size_t i = chunk1; i < _analysisOffset; ++i) {
+				Sample w = modified ? -_analysisWindow[i] : _analysisWindow[i];
+				size_t ti = i + (bufferSize - _analysisOffset);
+				size_t bi = i + offsetPos - _inputLengthSamples;
+				timeBuffer[ti] = buffer[bi]*w;
+			}
+			for (size_t i = _analysisOffset; i < chunk2; ++i) {
+				Sample w = _analysisWindow[i];
+				size_t ti = i - _analysisOffset;
+				size_t bi = offsetPos + i;
+				timeBuffer[ti] = buffer[bi]*w;
+			}
+			for (size_t i = chunk2; i < _blockSamples; ++i) {
+				Sample w = _analysisWindow[i];
+				size_t ti = i - _analysisOffset;
+				size_t bi = i + offsetPos - _inputLengthSamples;
+				timeBuffer[ti] = buffer[bi]*w;
+			}
+			if (_fftSamples >= _blockSamples) {
+				for (size_t i = _blockSamples - _analysisOffset; i < _fftSamples - _analysisOffset; ++i) {
+					timeBuffer[i] = 0;
+				}
+			} else { // undersized FFT - move first part of analysis window forwards in the buffer
+				size_t delta = _blockSamples - _fftSamples;
+				for (size_t i = _fftSamples - _analysisOffset; i < _blockSamples - _analysisOffset; ++i) {
+					timeBuffer[i] += timeBuffer[delta + i];
+				}
+				for (size_t i = _blockSamples - _analysisOffset; i < _fftSamples; ++i) {
+					timeBuffer[i] = timeBuffer[delta + i];
+				}
+			}
+			if (hookTimeInput) hookTimeInput(hookContext, channel, timeBuffer.data(), _fftSamples - _analysisOffset, _fftSamples, _blockSamples - _analysisOffset);
+			if (splitComputation) return;
+		}
+		auto *spectrumPtr = spectrum(channel);
+		if (splitComputation) {
+			fft.fft(step, timeBuffer.data(), spectrumPtr);
+			if (unpacked && step == fft.steps() - 1) {
+				spectrumPtr[_fftBins - 1] = spectrumPtr[0].imag();
+				spectrumPtr[0].imag(0);
+			}
+		} else {
+			fft.fft(timeBuffer.data(), spectrum(channel));
+			if (unpacked) {
+				spectrumPtr[_fftBins - 1] = spectrumPtr[0].imag();
+				spectrumPtr[0].imag(0);
+			}
+		}
+	}
+
+	void synthesise() {
+		for (size_t s = 0; s < synthesiseSteps(); ++s) {
+			synthesiseStep(s);
+		}
+	}
+	size_t synthesiseSteps() const {
+		return splitComputation ? (_synthesisChannels*(fft.steps() + 1) + 1) : _synthesisChannels;
+	}
+	void synthesiseStep(size_t step) {
+		if (step == 0) { // Extra first step which adds in the effective gain for a pure analysis-synthesis cycle
+			addWindowProduct();
+			if (splitComputation) return;
+		}
+		if (splitComputation) --step;
+
+		size_t fftSteps = splitComputation ? fft.steps() : 0;
+		size_t channel = step/(fftSteps + 1);
+		step -= channel*(fftSteps + 1);
+
+		auto *spectrumPtr = spectrum(channel);
+		if (unpacked && step == 0) { // re-pack
+			spectrumPtr[0].imag(spectrumPtr[_fftBins - 1].real());
+		}
+
+		if (splitComputation) {
+			if (step < fftSteps) {
+				fft.ifft(step, spectrumPtr, timeBuffer.data());
+				return;
+			}
+		} else {
+			fft.ifft(spectrumPtr, timeBuffer.data());
+		}
+		
+		// extra step after each channel's FFT
+		Sample *buffer = output.buffer.data() + channel*_blockSamples;
+		size_t outputWrapIndex = _blockSamples - output.pos;
+		size_t chunk1 = std::min(_synthesisOffset, outputWrapIndex);
+		size_t chunk2 = std::min(_blockSamples, std::max(_synthesisOffset, outputWrapIndex));
+
+		if (hookTimeOutput) hookTimeOutput(hookContext, channel, timeBuffer.data(), _fftSamples - _synthesisOffset, _fftSamples, _blockSamples - _synthesisOffset);
+
+		// Use the FFT size (rather than `timeBuffer.size()`) to handle the undersized-FFT case
+		for (size_t i = 0; i < chunk1; ++i) {
+			Sample w = modified ? -_synthesisWindow[i] : _synthesisWindow[i];
+			size_t ti = i + (_fftSamples - _synthesisOffset);
+			size_t bi = output.pos + i;
+			buffer[bi] += timeBuffer[ti]*w;
+		}
+		for (size_t i = chunk1; i < _synthesisOffset; ++i) {
+			Sample w = modified ? -_synthesisWindow[i] : _synthesisWindow[i];
+			size_t ti = i + (_fftSamples - _synthesisOffset);
+			size_t bi = i + output.pos - _blockSamples;
+			buffer[bi] += timeBuffer[ti]*w;
+		}
+		for (size_t i = _synthesisOffset; i < chunk2; ++i) {
+			Sample w = _synthesisWindow[i];
+			size_t ti = i - _synthesisOffset;
+			size_t bi = output.pos + i;
+			buffer[bi] += timeBuffer[ti]*w;
+		}
+		for (size_t i = chunk2; i < _blockSamples; ++i) {
+			Sample w = _synthesisWindow[i];
+			size_t ti = i - _synthesisOffset;
+			size_t bi = i + output.pos - _blockSamples;
+			buffer[bi] += timeBuffer[ti]*w;
+		}
+	}
+
+#define COMPAT_SPELLING(name, alt) \
+	template<class ...Args> \
+	void alt(Args &&...args) { \
+		name(std::forward<Args>(args)...); \
+	}
+	COMPAT_SPELLING(analyse, analyze);
+	COMPAT_SPELLING(analyseStep, analyseStep);
+	COMPAT_SPELLING(analyseSteps, analyzeSteps);
+	COMPAT_SPELLING(synthesise, synthesize);
+	COMPAT_SPELLING(synthesiseStep, synthesizeStep);
+	COMPAT_SPELLING(synthesiseSteps, synthesizeSteps);
+
+	/// Input (only available so we can save/restore the input state)
+	struct Input {
+		void swap(Input &other) {
+			std::swap(pos, other.pos);
+			std::swap(buffer, other.buffer);
+		}
+		
+		Input & operator=(const Input &other) {
+			pos = other.pos;
+			buffer.assign(other.buffer.begin(), other.buffer.end());
+			return *this;
+		}
+	private:
+		friend struct DynamicSTFT;
+		size_t pos = 0;
+		std::vector<Sample> buffer;
+	};
+	Input input;
+	
+	/// Output (only available so we can save/restore the output state)
+	struct Output {
+		void swap(Output &other) {
+			std::swap(pos, other.pos);
+			std::swap(buffer, other.buffer);
+			std::swap(windowProducts, other.windowProducts);
+		}
+
+		Output & operator=(const Output &other) {
+			pos = other.pos;
+			buffer.assign(other.buffer.begin(), other.buffer.end());
+			windowProducts.assign(other.windowProducts.begin(), other.windowProducts.end());
+			return *this;
+		}
+	private:
+		friend struct DynamicSTFT;
+		size_t pos = 0;
+		std::vector<Sample> buffer;
+		std::vector<Sample> windowProducts;
+	};
+	Output output;
+
+protected:
+	void *hookContext;
+	
+	/* 0 .... postEnd, ____, preStart .... preEnd  */
+	typedef void (*TimeHook)(void *, size_t channel, Sample *timeBuffer, size_t preStart, size_t preEnd, size_t postEnd);
+	TimeHook hookTimeInput = nullptr;
+	TimeHook hookTimeOutput = nullptr;
+
+private:
+	static constexpr Sample almostZero = 1e-30;
+
+	size_t _analysisChannels, _synthesisChannels, _inputLengthSamples, _blockSamples, _fftSamples, _fftBins;
+	size_t _defaultInterval = 0;
+
+	std::vector<Sample> _analysisWindow, _synthesisWindow;
+	size_t _analysisOffset = 0, _synthesisOffset = 0;
+
+	std::vector<Complex> spectrumBuffer;
+	std::vector<Sample> timeBuffer;
+
+	size_t _samplesSinceSynthesis = 0, _samplesSinceAnalysis = 0;
+	
+	Normalisation norm = normRoundTrip;
+	void addWindowProduct() {
+		_samplesSinceSynthesis = 0;
+
+		int windowShift = int(_synthesisOffset) - int(_analysisOffset);
+		size_t wMin = std::max<ptrdiff_t>(0, windowShift);
+		size_t wMax = std::min<ptrdiff_t>(_blockSamples, int(_blockSamples) + windowShift);
+
+		Sample *windowProduct = output.windowProducts.data();
+		size_t outputWrapIndex = _blockSamples - output.pos;
+		size_t chunk1 = std::min<size_t>(wMax, std::max<size_t>(wMin, outputWrapIndex));
+		Sample scaling = _fftSamples;
+		if (norm == normRoundTrip) {
+			for (size_t i = wMin; i < chunk1; ++i) {
+				Sample wa = _analysisWindow[i - windowShift];
+				Sample ws = _synthesisWindow[i];
+				size_t bi = output.pos + i;
+				windowProduct[bi] += wa*ws*scaling;
+			}
+			for (size_t i = chunk1; i < wMax; ++i) {
+				Sample wa = _analysisWindow[i - windowShift];
+				Sample ws = _synthesisWindow[i];
+				size_t bi = i + output.pos - _blockSamples;
+				windowProduct[bi] += wa*ws*scaling;
+			}
+		} else if (norm == normSynthesis) {
+			for (size_t i = wMin; i < chunk1; ++i) {
+				Sample ws = _synthesisWindow[i];
+				size_t bi = output.pos + i;
+				windowProduct[bi] += ws*scaling;
+			}
+			for (size_t i = chunk1; i < wMax; ++i) {
+				Sample ws = _synthesisWindow[i];
+				size_t bi = i + output.pos - _blockSamples;
+				windowProduct[bi] += ws*scaling;
+			}
+		} else {
+			for (size_t i = wMin; i < chunk1; ++i) {
+				size_t bi = output.pos + i;
+				windowProduct[bi] = scaling;
+			}
+			for (size_t i = chunk1; i < wMax; ++i) {
+				size_t bi = i + output.pos - _blockSamples;
+				windowProduct[bi] = scaling;
+			}
+		}
+	}
+	
+	// Copied from DSP library `windows.h`
+	class Kaiser {
+		inline static double bessel0(double x) {
+			const double significanceLimit = 1e-4;
+			double result = 0;
+			double term = 1;
+			double m = 0;
+			while (term > significanceLimit) {
+				result += term;
+				++m;
+				term *= (x*x)/(4*m*m);
+			}
+
+			return result;
+		}
+		double beta;
+		double invB0;
+		
+		static double heuristicBandwidth(double bandwidth) {
+			return bandwidth + 8/((bandwidth + 3)*(bandwidth + 3)) + 0.25*std::max(3 - bandwidth, 0.0);
+		}
+	public:
+		Kaiser(double beta) : beta(beta), invB0(1/bessel0(beta)) {}
+
+		static Kaiser withBandwidth(double bandwidth, bool heuristicOptimal=false) {
+			return Kaiser(bandwidthToBeta(bandwidth, heuristicOptimal));
+		}
+		static double bandwidthToBeta(double bandwidth, bool heuristicOptimal=false) {
+			if (heuristicOptimal) { // Heuristic based on numerical search
+				bandwidth = heuristicBandwidth(bandwidth);
+			}
+			bandwidth = std::max(bandwidth, 2.0);
+			double alpha = std::sqrt(bandwidth*bandwidth*0.25 - 1);
+			return alpha*M_PI;
+		}
+		
+		template<typename Data>
+		void fill(Data &&data, size_t size, double warp, bool isForSynthesis) const {
+			double invSize = 1.0/size;
+			size_t offsetI = (size&1) ? 1 : (isForSynthesis ? 0 : 2);
+			for (size_t i = 0; i < size; ++i) {
+				double r = (2*i + offsetI)*invSize - 1;
+				r = (r + warp)/(1 + r*warp);
+				double arg = std::sqrt(1 - r*r);
+				data[i] = bessel0(beta*arg)*invB0;
+			}
+			if (warp) {
+				// Warp window vertically as well, to restore some width
+				for (size_t i = 0; i < size; ++i) {
+					data[i] *= std::sqrt((warp + 1)/(1 + warp*(2*data[i] - 1)));
+				}
+			}
+		}
+	};
+
+	class ApproximateConfinedGaussian {
+		double gaussianFactor;
+		
+		double gaussian(double x) const {
+			return std::exp(-x*x*gaussianFactor);
+		}
+	public:
+		static double bandwidthToSigma(double bandwidth) {
+			return 0.3/std::sqrt(bandwidth);
+		}
+		static ApproximateConfinedGaussian withBandwidth(double bandwidth) {
+			return ApproximateConfinedGaussian(bandwidthToSigma(bandwidth));
+		}
+
+		ApproximateConfinedGaussian(double sigma) : gaussianFactor(0.0625/(sigma*sigma)) {}
+	
+		/// Fills an arbitrary container
+		template<typename Data>
+		void fill(Data &&data, size_t size, double warp, bool isForSynthesis) const {
+			double invSize = 1.0/size;
+			double offsetScale = gaussian(1)/(gaussian(3) + gaussian(-1));
+			double norm = 1/(gaussian(0) - 2*offsetScale*(gaussian(2)));
+			size_t offsetI = (size&1) ? 1 : (isForSynthesis ? 0 : 2);
+			for (size_t i = 0; i < size; ++i) {
+				double r = (2*i + offsetI)*invSize - 1;
+				r = (r + warp)/(1 + r*warp);
+				data[i] = norm*(gaussian(r) - offsetScale*(gaussian(r - 2) + gaussian(r + 2)));
+			}
+			if (warp) {
+				// Warp window vertically as well, to restore some width
+				for (size_t i = 0; i < size; ++i) {
+					data[i] *= std::sqrt((warp + 1)/(1 + warp*(2*data[i] - 1)));
+				}
+			}
+		}
+	};
+
+	template<typename Data>
+	void forcePerfectReconstruction(Data &&data, size_t windowLength, size_t interval) {
+		for (size_t i = 0; i < interval; ++i) {
+			double sum2 = 0;
+			for (size_t index = i; index < windowLength; index += interval) {
+				sum2 += data[index]*data[index];
+			}
+			double factor = 1/std::sqrt(sum2);
+			for (size_t index = i; index < windowLength; index += interval) {
+				data[index] *= factor;
+			}
+		}
+	}
+};
+
+}} // namespace
+
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-stretch.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/signalsmith-stretch.h
@@ -1,0 +1,1060 @@
+#ifndef SIGNALSMITH_STRETCH_H
+#define SIGNALSMITH_STRETCH_H
+
+#include "signalsmith-linear/stft.h" // https://github.com/Signalsmith-Audio/linear
+
+#include <vector>
+#include <array>
+#include <algorithm>
+#include <functional>
+#include <random>
+#include <limits>
+#include <type_traits>
+
+namespace signalsmith { namespace stretch {
+
+namespace _impl {
+	template<bool conjugateSecond=false, typename V>
+	static std::complex<V> mul(const std::complex<V> &a, const std::complex<V> &b) {
+		return conjugateSecond ? std::complex<V>{
+			b.real()*a.real() + b.imag()*a.imag(),
+				b.real()*a.imag() - b.imag()*a.real()
+		} : std::complex<V>{
+			a.real()*b.real() - a.imag()*b.imag(),
+			a.real()*b.imag() + a.imag()*b.real()
+		};
+	}
+	template<typename V>
+	static V norm(const std::complex<V> &a) {
+		V r = a.real(), i = a.imag();
+		return r*r + i*i;
+	}
+}
+
+template<typename Sample=float, class RandomEngine=void>
+struct SignalsmithStretch {
+	static constexpr size_t version[3] = {1, 3, 2};
+
+	SignalsmithStretch() : randomEngine(std::random_device{}()) {}
+	SignalsmithStretch(long seed) : randomEngine(seed) {}
+		
+	// The difference between the internal position (centre of a block) and the input samples you're supplying
+	int inputLatency() const {
+		return int(stft.analysisLatency());
+	}
+	int outputLatency() const {
+		return int(stft.synthesisLatency() + _splitComputation*stft.defaultInterval());
+	}
+	
+	void reset() {
+		stft.reset(0.1);
+		stashedInput = stft.input;
+		stashedOutput = stft.output;
+		
+		prevInputOffset = -1;
+		_channelBands.assign(_channelBands.size(), Band());
+		silenceCounter = 0;
+		didSeek = false;
+		blockProcess = {};
+		freqEstimateWeighted = freqEstimateWeight = 0;
+	}
+
+	// Configures using a default preset
+	void presetDefault(int nChannels, Sample sampleRate, bool splitComputation=false) {
+		configure(nChannels, static_cast<int>(sampleRate*0.12), static_cast<int>(sampleRate*0.03), splitComputation);
+	}
+	void presetCheaper(int nChannels, Sample sampleRate, bool splitComputation=true) {
+		configure(nChannels, static_cast<int>(sampleRate*0.1), static_cast<int>(sampleRate*0.04), splitComputation);
+	}
+
+	// Manual setup
+	void configure(int nChannels, int blockSamples, int intervalSamples, bool splitComputation=false) {
+		_splitComputation = splitComputation;
+		channels = nChannels;
+		stft.configure(channels, channels, blockSamples, intervalSamples + 1);
+		stft.setInterval(intervalSamples, stft.kaiser);
+		stft.reset(Sample(0.1));
+		stashedInput = stft.input;
+		stashedOutput = stft.output;
+
+		bands = int(stft.bands());
+		_channelBands.assign(bands*channels, Band());
+		
+		peaks.reserve(bands/2);
+		energy.resize(bands);
+		smoothedEnergy.resize(bands);
+		outputMap.resize(bands);
+		channelPredictions.resize(channels*bands);
+
+		blockProcess = {};
+		formantMetric.resize(bands + 2);
+
+		tmpProcessBuffer.resize(blockSamples + intervalSamples);
+		tmpPreRollBuffer.resize(outputLatency()*channels);
+	}
+	// For querying the existing config
+	int blockSamples() const {
+		return int(stft.blockSamples());
+	}
+	int intervalSamples() const {
+		return int(stft.defaultInterval());
+	}
+	bool splitComputation() const {
+		return _splitComputation;
+	}
+
+	/// Frequency multiplier, and optional tonality limit (as multiple of sample-rate)
+	void setTransposeFactor(Sample multiplier, Sample tonalityLimit=0) {
+		freqMultiplier = multiplier;
+		if (tonalityLimit > 0) {
+			freqTonalityLimit = tonalityLimit/std::sqrt(multiplier); // compromise between input and output limits
+		} else {
+			freqTonalityLimit = 1;
+		}
+		customFreqMap = nullptr;
+	}
+	void setTransposeSemitones(Sample semitones, Sample tonalityLimit=0) {
+		setTransposeFactor(std::pow(2, semitones/12), tonalityLimit);
+	}
+	// Sets a custom frequency map - should be monotonically increasing
+	void setFreqMap(std::function<Sample(Sample)> inputToOutput) {
+		customFreqMap = inputToOutput;
+	}
+
+	void setFormantFactor(Sample multiplier, bool compensatePitch=false) {
+		formantMultiplier = multiplier;
+		invFormantMultiplier = 1/multiplier;
+		formantCompensation = compensatePitch;
+	}
+	void setFormantSemitones(Sample semitones, bool compensatePitch=false) {
+		setFormantFactor(std::pow(2, semitones/12), compensatePitch);
+	}
+	// Rough guesstimate of the fundamental frequency, used for formant analysis. 0 means attempting to detect the pitch
+	void setFormantBase(Sample baseFreq=0) {
+		formantBaseFreq = baseFreq;
+	}
+	
+	// Provide previous input ("pre-roll") to smoothly change the input location without interrupting the output.  This doesn't do any calculation, just copies intput to a buffer.
+	// You should ideally feed it `seekLength()` frames of input, unless it's directly after a `.reset()` (in which case `.outputSeek()` might be a better choice)
+	template<class Inputs>
+	void seek(Inputs &&inputs, int inputSamples, double playbackRate) {
+		tmpProcessBuffer.resize(0);
+		tmpProcessBuffer.resize(stft.blockSamples() + stft.defaultInterval());
+
+		int startIndex = std::max<int>(0, inputSamples - int(tmpProcessBuffer.size())); // start position in input
+		int padStart = int(tmpProcessBuffer.size() + startIndex) - inputSamples; // start position in tmpProcessBuffer
+
+		Sample totalEnergy = 0;
+		for (int c = 0; c < channels; ++c) {
+			auto &&inputChannel = inputs[c];
+			for (int i = startIndex; i < inputSamples; ++i) {
+				Sample s = inputChannel[i];
+				totalEnergy += s*s;
+				tmpProcessBuffer[i - startIndex + padStart] = s;
+			}
+			
+			stft.writeInput(c, tmpProcessBuffer.size(), tmpProcessBuffer.data());
+		}
+		stft.moveInput(tmpProcessBuffer.size());
+		if (totalEnergy >= noiseFloor) {
+			silenceCounter = 0;
+			silenceFirst = true;
+		}
+		didSeek = true;
+		seekTimeFactor = (playbackRate*stft.defaultInterval() > 1) ? 1/playbackRate : stft.defaultInterval();
+	}
+	int seekLength() const {
+		return int(stft.blockSamples() + stft.defaultInterval());
+	}
+	
+	// Moves the input position *and* pre-calculates some output, so that the next samples returned from `.process()` are aligned to the beginning of the sample.
+	// The time-stretch rate is inferred from `inputLength`, so use `.outputSeekLength()` to get a correct value for that.
+	template<class Inputs>
+	void outputSeek(Inputs &&inputs, int inputLength) {
+		// TODO: add fade-out parameter to avoid clicks, instead of doing a full reset
+		reset();
+		// Assume we've been handed enough surplus input to produce `outputLatency()` samples of pre-roll
+		int surplusInput = std::max<int>(inputLength - inputLatency(), 0);
+		Sample playbackRate = surplusInput/Sample(outputLatency());
+
+		// Move the input position to the start of the sound
+		int seekSamples = inputLength - surplusInput;
+		seek(inputs, seekSamples, playbackRate);
+		
+		tmpPreRollBuffer.resize(outputLatency()*channels);
+		struct BufferOutput {
+			Sample *samples;
+			int length;
+			
+			Sample * operator[](int c) {
+				return samples + c*length;
+			}
+		} preRollOutput{tmpPreRollBuffer.data(), outputLatency()};
+		
+		// Use the surplus input to produce pre-roll output
+		OffsetIO<Inputs> offsetInput{inputs, seekSamples};
+		process(offsetInput, surplusInput, preRollOutput, preRollOutput.length);
+		
+		// put the thing down, flip it and reverse it
+		for (auto &v : tmpPreRollBuffer) v = -v;
+		for (int c = 0; c < channels; ++c) {
+			std::reverse(preRollOutput[c], preRollOutput[c] + preRollOutput.length);
+			stft.addOutput(c, preRollOutput.length, preRollOutput[c]);
+		}
+	}
+	int outputSeekLength(Sample playbackRate) const {
+		return inputLatency() + playbackRate*outputLatency();
+	}
+
+	template<class Inputs, class Outputs>
+	void process(Inputs &&inputs, int inputSamples, Outputs &&outputs, int outputSamples) {
+#ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_START
+		SIGNALSMITH_STRETCH_PROFILE_PROCESS_START(inputSamples, outputSamples);
+#endif
+		int prevCopiedInput = 0;
+		auto copyInput = [&](int toIndex){
+
+			int length = std::min<int>(int(stft.blockSamples() + stft.defaultInterval()), toIndex - prevCopiedInput);
+			tmpProcessBuffer.resize(length);
+			int offset = toIndex - length;
+			for (int c = 0; c < channels; ++c) {
+				auto &&inputBuffer = inputs[c];
+				for (int i = 0; i < length; ++i) {
+					tmpProcessBuffer[i] = inputBuffer[i + offset];
+				}
+				stft.writeInput(c, length, tmpProcessBuffer.data());
+			}
+			stft.moveInput(length);
+			prevCopiedInput = toIndex;
+		};
+
+		Sample totalEnergy = 0;
+		for (int c = 0; c < channels; ++c) {
+			auto &&inputChannel = inputs[c];
+			for (int i = 0; i < inputSamples; ++i) {
+				Sample s = inputChannel[i];
+				totalEnergy += s*s;
+			}
+		}
+
+		if (totalEnergy < noiseFloor) {
+			if (silenceCounter >= 2*stft.blockSamples()) {
+				if (silenceFirst) { // first block of silence processing
+					silenceFirst = false;
+					//stft.reset();
+					blockProcess = {};
+					for (auto &b : _channelBands) {
+						b.input = b.prevInput = b.output = 0;
+						b.inputEnergy = 0;
+					}
+				}
+			
+				if (inputSamples > 0) {
+					// copy from the input, wrapping around if needed
+					for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+						int inputIndex = outputIndex%inputSamples;
+						for (int c = 0; c < channels; ++c) {
+							outputs[c][outputIndex] = inputs[c][inputIndex];
+						}
+					}
+				} else {
+					for (int c = 0; c < channels; ++c) {
+						auto &&outputChannel = outputs[c];
+						for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+							outputChannel[outputIndex] = 0;
+						}
+					}
+				}
+
+				// Store input in history buffer
+				copyInput(inputSamples);
+				return;
+			} else {
+				silenceCounter += inputSamples;
+			}
+		} else {
+			silenceCounter = 0;
+			silenceFirst = true;
+		}
+		
+		for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+			bool newBlock = blockProcess.samplesSinceLast >= stft.defaultInterval();
+			if (newBlock) {
+				blockProcess.step = 0;
+				blockProcess.steps = 0; // how many processing steps this block will have
+				blockProcess.samplesSinceLast = 0;
+				
+				// Time to process a spectrum!  Where should it come from in the input?
+				int inputOffset = static_cast<int>(std::round(outputIndex*Sample(inputSamples)/outputSamples));
+				int inputInterval = inputOffset - prevInputOffset;
+				prevInputOffset = inputOffset;
+				
+				copyInput(inputOffset);
+				stashedInput = stft.input; // save the input state, since that's what we'll analyse later
+				if (_splitComputation) {
+					stashedOutput = stft.output; // save the current output, and read from it
+					stft.moveOutput(stft.defaultInterval()); // the actual input jumps forward in time by one interval, ready for the synthesis
+				}
+
+				blockProcess.newSpectrum = didSeek || (inputInterval > 0);
+				blockProcess.mappedFrequencies = customFreqMap || freqMultiplier != 1;
+				if (blockProcess.newSpectrum) {
+					// make sure the previous input is the correct distance in the past (give or take 1 sample)
+					blockProcess.reanalysePrev = didSeek || std::abs(inputInterval - int(stft.defaultInterval())) > 1;
+					if (blockProcess.reanalysePrev) blockProcess.steps += stft.analyseSteps() + 1;
+
+					// analyse a new input
+					blockProcess.steps += stft.analyseSteps() + 1;
+				}
+				
+				blockProcess.processFormants = formantMultiplier != 1 || (formantCompensation && blockProcess.mappedFrequencies);
+
+				blockProcess.timeFactor = didSeek ? seekTimeFactor : stft.defaultInterval()/static_cast<Sample>(std::max(1, inputInterval));
+				didSeek = false;
+
+				updateProcessSpectrumSteps();
+				blockProcess.steps += processSpectrumSteps;
+
+				blockProcess.steps += stft.synthesiseSteps() + 1;
+			}
+			
+			size_t processToStep = newBlock ? blockProcess.steps : 0;
+			if (_splitComputation) {
+				Sample processRatio = Sample(blockProcess.samplesSinceLast + 1)/stft.defaultInterval();
+				processToStep = std::min(blockProcess.steps, static_cast<size_t>((blockProcess.steps + 0.999f)*processRatio));
+			}
+			
+			while (blockProcess.step < processToStep) {
+				size_t step = blockProcess.step++;
+#ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_STEP
+				SIGNALSMITH_STRETCH_PROFILE_PROCESS_STEP(step, blockProcess.steps);
+#endif
+				if (blockProcess.newSpectrum) {
+					if (blockProcess.reanalysePrev) {
+						// analyse past input
+						if (step < stft.analyseSteps()) {
+							stashedInput.swap(stft.input);
+							stft.analyseStep(step, stft.defaultInterval());
+							stashedInput.swap(stft.input);
+							continue;
+						}
+						step -= stft.analyseSteps();
+						if (step < 1) {
+							// Copy previous analysis to our band objects
+							for (int c = 0; c < channels; ++c) {
+								auto channelBands = bandsForChannel(c);
+								auto *spectrumBands = stft.spectrum(c);
+								for (int b = 0; b < bands; ++b) {
+									channelBands[b].prevInput = spectrumBands[b];
+								}
+							}
+							continue;
+						}
+						step -= 1;
+					}
+
+					// Analyse latest (stashed) input
+					if (step < stft.analyseSteps()) {
+						stashedInput.swap(stft.input);
+						stft.analyseStep(step);
+						stashedInput.swap(stft.input);
+						continue;
+					}
+					step -= stft.analyseSteps();
+					if (step < 1) {
+						// Copy analysed spectrum into our band objects
+						for (int c = 0; c < channels; ++c) {
+							auto channelBands = bandsForChannel(c);
+							auto *spectrumBands = stft.spectrum(c);
+							for (int b = 0; b < bands; ++b) {
+								channelBands[b].input = spectrumBands[b];
+							}
+						}
+						continue;
+					}
+					step -= 1;
+				}
+
+				if (step < processSpectrumSteps) {
+					processSpectrum(step);
+					continue;
+				}
+				step -= processSpectrumSteps;
+
+				if (step < 1) {
+					// Copy band objects into spectrum
+					for (int c = 0; c < channels; ++c) {
+						auto channelBands = bandsForChannel(c);
+						auto *spectrumBands = stft.spectrum(c);
+						for (int b = 0; b < bands; ++b) {
+							spectrumBands[b] = channelBands[b].output;
+						}
+					}
+					continue;
+				}
+				step -= 1;
+				
+				if (step < stft.synthesiseSteps()) {
+					stft.synthesiseStep(step);
+					continue;
+				}
+			}
+#ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP
+			SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP();
+#endif
+
+			++blockProcess.samplesSinceLast;
+			if (_splitComputation) stashedOutput.swap(stft.output);
+			for (int c = 0; c < channels; ++c) {
+				auto &&outputChannel = outputs[c];
+				Sample v = 0;
+				stft.readOutput(c, 1, &v);
+				outputChannel[outputIndex] = v;
+			}
+			stft.moveOutput(1);
+			if (_splitComputation) stashedOutput.swap(stft.output);
+		}
+		
+		copyInput(inputSamples);
+		prevInputOffset -= inputSamples;
+#ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_END
+		SIGNALSMITH_STRETCH_PROFILE_PROCESS_END();
+#endif
+	}
+
+	// Read the remaining output, providing no further input.  If `outputSamples` is more than one interval, it will compute additional blocks assuming a zero-valued input
+	template<class Outputs>
+	void flush(Outputs &&outputs, int outputSamples, Sample playbackRate=0) {
+		struct Zeros {
+			struct Channel {
+				Sample operator[](int) {
+					return 0;
+				}
+			};
+			Channel operator[](int) {
+				return {};
+			}
+		} zeros;
+		// If we're asked for more than an interval of extra output, then zero-pad the input
+		int outputBlock = std::max<int>(0, outputSamples - stft.defaultInterval());
+		if (outputBlock > 0) process(zeros, outputBlock*playbackRate, outputs, outputBlock);
+
+		int tailSamples = outputSamples - outputBlock; // at most one interval
+		tmpProcessBuffer.resize(tailSamples);
+		stft.finishOutput(1);
+		for (int c = 0; c < channels; ++c) {
+			stft.readOutput(c, tailSamples, tmpProcessBuffer.data());
+			auto &&outputChannel = outputs[c];
+			for (int i = 0; i < tailSamples; ++i) {
+				outputChannel[outputBlock + i] = tmpProcessBuffer[i];
+			}
+			stft.readOutput(c, tailSamples, tailSamples, tmpProcessBuffer.data());
+			for (int i = 0; i < tailSamples; ++i) {
+				outputChannel[outputBlock + tailSamples - 1 - i] -= tmpProcessBuffer[i];
+			}
+		}
+		stft.reset(0.1f);
+		// Reset the phase-vocoder stuff, so the next block gets a fresh start
+		for (int c = 0; c < channels; ++c) {
+			auto channelBands = bandsForChannel(c);
+			for (int b = 0; b < bands; ++b) {
+				channelBands[b].prevInput = channelBands[b].output = 0;
+			}
+		}
+	}
+
+	// Process a complete audio buffer all in one go
+	template<class Inputs, class Outputs>
+	bool exact(Inputs &&inputs, int inputSamples, Outputs &&outputs, int outputSamples) {
+		Sample playbackRate = inputSamples/Sample(outputSamples);
+		auto seekLength = outputSeekLength(playbackRate);
+		if (inputSamples < seekLength) {
+			// to short for this - zero the output just to be polite
+			for (int c = 0; c < channels; ++c) {
+				auto &&channel = outputs[c];
+				for (int i = 0; i < outputSamples; ++i) {
+					channel[i] = 0;
+				}
+			}
+			return false;
+		}
+
+		outputSeek(inputs, seekLength);
+
+		int outputIndex = outputSamples - seekLength/playbackRate;
+		OffsetIO<Inputs> offsetInput{inputs, seekLength};
+		process(offsetInput, inputSamples - seekLength, outputs, outputIndex);
+		
+		OffsetIO<Outputs> offsetOutput{outputs, outputIndex};
+		flush(offsetOutput, outputSamples - outputIndex, playbackRate);
+		return true;
+	}
+
+private:
+	bool _splitComputation = false;
+	struct {
+		size_t samplesSinceLast = std::numeric_limits<size_t>::max();
+		size_t steps = 0;
+		size_t step = 0;
+		
+		bool newSpectrum = false;
+		bool reanalysePrev = false;
+		bool mappedFrequencies = false;
+		bool processFormants = false;
+		Sample timeFactor;
+	} blockProcess;
+
+	using Complex = std::complex<Sample>;
+	static constexpr Sample noiseFloor{Sample(1e-15)};
+	static constexpr Sample maxCleanStretch{2}; // time-stretch ratio before we start randomising phases
+	size_t silenceCounter = 0;
+	bool silenceFirst = true;
+
+	Sample freqMultiplier = 1, freqTonalityLimit = 0.5;
+	std::function<Sample(Sample)> customFreqMap = nullptr;
+	
+	bool formantCompensation = false; // compensate for pitch/freq change
+	Sample formantMultiplier = 1, invFormantMultiplier = 1;
+
+	using STFT = signalsmith::linear::DynamicSTFT<Sample, false, true>;
+	STFT stft;
+	typename STFT::Input stashedInput;
+	typename STFT::Output stashedOutput;
+	
+	std::vector<Sample> tmpProcessBuffer, tmpPreRollBuffer;
+
+	int channels = 0, bands = 0;
+	int prevInputOffset = -1;
+	bool didSeek = false;
+	Sample seekTimeFactor = 1;
+
+	Sample bandToFreq(Sample b) const {
+		return stft.binToFreq(b);
+	}
+	Sample freqToBand(Sample f) const {
+		return stft.freqToBin(f);
+	}
+	
+	struct Band {
+		Complex input, prevInput{0};
+		Complex output{0};
+		Sample inputEnergy;
+	};
+	std::vector<Band> _channelBands;
+	Band * bandsForChannel(int channel) {
+		return _channelBands.data() + channel*bands;
+	}
+	template<Complex Band::*member>
+	Complex getBand(int channel, int index) {
+		if (index < 0 || index >= bands) return 0;
+		return _channelBands[index + channel*bands].*member;
+	}
+	template<Complex Band::*member>
+	Complex getFractional(int channel, int lowIndex, Sample fractional) {
+		Complex low = getBand<member>(channel, lowIndex);
+		Complex high = getBand<member>(channel, lowIndex + 1);
+		return low + (high - low)*fractional;
+	}
+	template<Complex Band::*member>
+	Complex getFractional(int channel, Sample inputIndex) {
+		int lowIndex = static_cast<int>(std::floor(inputIndex));
+		Sample fracIndex = inputIndex - lowIndex;
+		return getFractional<member>(channel, lowIndex, fracIndex);
+	}
+	template<Sample Band::*member>
+	Sample getBand(int channel, int index) {
+		if (index < 0 || index >= bands) return 0;
+		return _channelBands[index + channel*bands].*member;
+	}
+	template<Sample Band::*member>
+	Sample getFractional(int channel, int lowIndex, Sample fractional) {
+		Sample low = getBand<member>(channel, lowIndex);
+		Sample high = getBand<member>(channel, lowIndex + 1);
+		return low + (high - low)*fractional;
+	}
+	template<Sample Band::*member>
+	Sample getFractional(int channel, Sample inputIndex) {
+		int lowIndex = std::floor(inputIndex);
+		Sample fracIndex = inputIndex - lowIndex;
+		return getFractional<member>(channel, lowIndex, fracIndex);
+	}
+
+	struct Peak {
+		Sample input, output;
+	};
+	std::vector<Peak> peaks;
+	std::vector<Sample> energy, smoothedEnergy;
+	struct PitchMapPoint {
+		Sample inputBin, freqGrad;
+	};
+	std::vector<PitchMapPoint> outputMap;
+	
+	struct Prediction {
+		Sample energy = 0;
+		Complex input;
+
+		Complex makeOutput(Complex phase) {
+			Sample phaseNorm = _impl::norm(phase);
+			if (phaseNorm <= noiseFloor) {
+				phase = input; // prediction is too weak, fall back to the input
+				phaseNorm = _impl::norm(input) + noiseFloor;
+			}
+			return phase*std::sqrt(energy/phaseNorm);
+		}
+	};
+	std::vector<Prediction> channelPredictions;
+	Prediction * predictionsForChannel(int c) {
+		return channelPredictions.data() + c*bands;
+	}
+
+	// If RandomEngine=void, use std::default_random_engine;
+	using RandomEngineImpl = typename std::conditional<
+		std::is_void<RandomEngine>::value,
+		std::default_random_engine,
+		RandomEngine
+	>::type;
+	RandomEngineImpl randomEngine;
+
+	size_t processSpectrumSteps = 0;
+	static constexpr size_t splitMainPrediction = 8; // it's just heavy, since we're blending up to 4 different phase predictions
+	void updateProcessSpectrumSteps() {
+		processSpectrumSteps = 0;
+		if (blockProcess.newSpectrum) processSpectrumSteps += channels;
+		if (blockProcess.mappedFrequencies) {
+			processSpectrumSteps += smoothEnergySteps;
+			processSpectrumSteps += 1; // findPeaks
+		}
+		processSpectrumSteps += 1; // updating the output map
+		processSpectrumSteps += channels; // preliminary phase-vocoder prediction
+		processSpectrumSteps += splitMainPrediction;
+		if (blockProcess.newSpectrum) processSpectrumSteps += 1; // .input -> .prevInput
+		if (blockProcess.processFormants) processSpectrumSteps += 3;
+	}
+	void processSpectrum(size_t step) {
+		Sample timeFactor = blockProcess.timeFactor;
+		
+		Sample smoothingBins = Sample(stft.fftSamples())/stft.defaultInterval();
+		int longVerticalStep = static_cast<int>(std::round(smoothingBins));
+		timeFactor = std::max<Sample>(timeFactor, 1/maxCleanStretch);
+		bool randomTimeFactor = (timeFactor > maxCleanStretch);
+		std::uniform_real_distribution<Sample> timeFactorDist(maxCleanStretch*2*randomTimeFactor - timeFactor, timeFactor);
+
+		if (blockProcess.newSpectrum) {
+			if (step < size_t(channels)) {
+				int channel = int(step);
+				auto bins = bandsForChannel(channel);
+
+				Complex rot = std::polar(Sample(1), bandToFreq(0)*stft.defaultInterval()*Sample(2*M_PI));
+				Sample freqStep = bandToFreq(1) - bandToFreq(0);
+				Complex rotStep = std::polar(Sample(1), freqStep*stft.defaultInterval()*Sample(2*M_PI));
+				 
+				for (int b = 0; b < bands; ++b) {
+					auto &bin = bins[b];
+					bin.output = _impl::mul(bin.output, rot);
+					bin.prevInput = _impl::mul(bin.prevInput, rot);
+					rot = _impl::mul(rot, rotStep);
+				}
+				return;
+			}
+			step -= channels;
+		}
+		if (blockProcess.mappedFrequencies) {
+			if (step < smoothEnergySteps) {
+				smoothEnergy(step, smoothingBins);
+				return;
+			}
+			step -= smoothEnergySteps;
+			if (step-- == 0) {
+				findPeaks();
+				return;
+			}
+		}
+		if (step-- == 0) {
+			if (blockProcess.mappedFrequencies) {
+				updateOutputMap();
+			} else { // we're not pitch-shifting, so no need to find peaks etc.
+				for (int c = 0; c < channels; ++c) {
+					Band *bins = bandsForChannel(c);
+					for (int b = 0; b < bands; ++b) {
+						bins[b].inputEnergy = _impl::norm(bins[b].input);
+					}
+				}
+
+				for (int b = 0; b < bands; ++b) {
+					outputMap[b] = {Sample(b), 1};
+				}
+			}
+			return;
+		}
+		if (blockProcess.processFormants) {
+			if (step < 3) {
+				updateFormants(step);
+				return;
+			}
+			step -= 3;
+		}
+		// Preliminary output prediction from phase-vocoder
+		if (step < size_t(channels)) {
+			int c = int(step);
+			Band *bins = bandsForChannel(c);
+			auto *predictions = predictionsForChannel(c);
+			for (int b = 0; b < bands; ++b) {
+				auto mapPoint = outputMap[b];
+				int lowIndex = static_cast<int>(std::floor(mapPoint.inputBin));
+				Sample fracIndex = mapPoint.inputBin - lowIndex;
+
+				Prediction &prediction = predictions[b];
+				Sample prevEnergy = prediction.energy;
+				prediction.energy = getFractional<&Band::inputEnergy>(c, lowIndex, fracIndex);
+				prediction.energy *= std::max<Sample>(0, mapPoint.freqGrad); // scale the energy according to local stretch factor
+				prediction.input = getFractional<&Band::input>(c, lowIndex, fracIndex);
+
+				auto &outputBin = bins[b];
+				Complex prevInput = getFractional<&Band::prevInput>(c, lowIndex, fracIndex);
+				Complex freqTwist = _impl::mul<true>(prediction.input, prevInput);
+				Complex phase = _impl::mul(outputBin.output, freqTwist);
+				outputBin.output = phase/(std::max(prevEnergy, prediction.energy) + noiseFloor);
+			}
+			return;
+		}
+		step -= channels;
+
+		if (step < splitMainPrediction) {
+			// Re-predict using phase differences between frequencies
+			size_t chunk = step;
+			int startB = int(bands*chunk/splitMainPrediction);
+			int endB = int(bands*(chunk + 1)/splitMainPrediction);
+			for (int b = startB; b < endB; ++b) {
+				// Find maximum-energy channel and calculate that
+				int maxChannel = 0;
+				Sample maxEnergy = predictionsForChannel(0)[b].energy;
+				for (int c = 1; c < channels; ++c) {
+					Sample e = predictionsForChannel(c)[b].energy;
+					if (e > maxEnergy) {
+						maxChannel = c;
+						maxEnergy = e;
+					}
+				}
+
+				auto *predictions = predictionsForChannel(maxChannel);
+				auto &prediction = predictions[b];
+				auto *bins = bandsForChannel(maxChannel);
+				auto &outputBin = bins[b];
+
+				Complex phase = 0;
+				auto mapPoint = outputMap[b];
+
+				// Upwards vertical steps
+				if (b > 0) {
+					Sample binTimeFactor = randomTimeFactor ? timeFactorDist(randomEngine) : timeFactor;
+					Complex downInput = getFractional<&Band::input>(maxChannel, mapPoint.inputBin - binTimeFactor);
+					Complex shortVerticalTwist = _impl::mul<true>(prediction.input, downInput);
+
+					auto &downBin = bins[b - 1];
+					phase += _impl::mul(downBin.output, shortVerticalTwist);
+					
+					if (b >= longVerticalStep) {
+						Complex longDownInput = getFractional<&Band::input>(maxChannel, mapPoint.inputBin - longVerticalStep*binTimeFactor);
+						Complex longVerticalTwist = _impl::mul<true>(prediction.input, longDownInput);
+
+						auto &longDownBin = bins[b - longVerticalStep];
+						phase += _impl::mul(longDownBin.output, longVerticalTwist);
+					}
+				}
+				// Downwards vertical steps
+				if (b < bands - 1) {
+					auto &upPrediction = predictions[b + 1];
+					auto &upMapPoint = outputMap[b + 1];
+
+					Sample binTimeFactor = randomTimeFactor ? timeFactorDist(randomEngine) : timeFactor;
+					Complex downInput = getFractional<&Band::input>(maxChannel, upMapPoint.inputBin - binTimeFactor);
+					Complex shortVerticalTwist = _impl::mul<true>(upPrediction.input, downInput);
+
+					auto &upBin = bins[b + 1];
+					phase += _impl::mul<true>(upBin.output, shortVerticalTwist);
+					
+					if (b < bands - longVerticalStep) {
+						auto &longUpPrediction = predictions[b + longVerticalStep];
+						auto &longUpMapPoint = outputMap[b + longVerticalStep];
+
+						Complex longDownInput = getFractional<&Band::input>(maxChannel, longUpMapPoint.inputBin - longVerticalStep*binTimeFactor);
+						Complex longVerticalTwist = _impl::mul<true>(longUpPrediction.input, longDownInput);
+
+						auto &longUpBin = bins[b + longVerticalStep];
+						phase += _impl::mul<true>(longUpBin.output, longVerticalTwist);
+					}
+				}
+
+				outputBin.output = prediction.makeOutput(phase);
+				
+				// All other bins are locked in phase
+				for (int c = 0; c < channels; ++c) {
+					if (c != maxChannel) {
+						auto &channelBin = bandsForChannel(c)[b];
+						auto &channelPrediction = predictionsForChannel(c)[b];
+						
+						Complex channelTwist = _impl::mul<true>(channelPrediction.input, prediction.input);
+						Complex channelPhase = _impl::mul(outputBin.output, channelTwist);
+						channelBin.output = channelPrediction.makeOutput(channelPhase);
+					}
+				}
+			}
+			return;
+		}
+		step -= splitMainPrediction;
+
+		if (blockProcess.newSpectrum) {
+			if (step-- == 0) {
+				for (auto &bin : _channelBands) {
+					bin.prevInput = bin.input;
+				}
+			}
+		}
+	}
+	
+	// Produces smoothed energy across all channels
+	static constexpr size_t smoothEnergySteps = 3;
+	Sample smoothEnergyState = 0;
+	void smoothEnergy(size_t step, Sample smoothingBins) {
+		Sample smoothingSlew = 1/(1 + smoothingBins*Sample(0.5));
+		if (step-- == 0) {
+			for (auto &e : energy) e = 0;
+			for (int c = 0; c < channels; ++c) {
+				Band *bins = bandsForChannel(c);
+				for (int b = 0; b < bands; ++b) {
+					Sample e = _impl::norm(bins[b].input);
+					bins[b].inputEnergy = e; // Used for interpolating prediction energy
+					energy[b] += e;
+				}
+			}
+			for (int b = 0; b < bands; ++b) {
+				smoothedEnergy[b] = energy[b];
+			}
+			smoothEnergyState = 0;
+			return;
+		}
+
+		// The two other steps are repeated smoothing passes, down and up
+		Sample e = smoothEnergyState;
+		for (int b = bands - 1; b >= 0; --b) {
+			e += (smoothedEnergy[b] - e)*smoothingSlew;
+			smoothedEnergy[b] = e;
+		}
+		for (int b = 0; b < bands; ++b) {
+			e += (smoothedEnergy[b] - e)*smoothingSlew;
+			smoothedEnergy[b] = e;
+		}
+		smoothEnergyState = e;
+	}
+	
+	Sample mapFreq(Sample freq) const {
+		if (customFreqMap) return customFreqMap(freq);
+		if (freq > freqTonalityLimit) {
+			return freq + (freqMultiplier - 1)*freqTonalityLimit;
+		}
+		return freq*freqMultiplier;
+	}
+	
+	// Identifies spectral peaks using energy across all channels
+	void findPeaks() {
+		peaks.resize(0);
+		
+		int start = 0;
+		while (start < bands) {
+			if (energy[start] > smoothedEnergy[start]) {
+				int end = start;
+				Sample bandSum = 0, energySum = 0;
+				while (end < bands && energy[end] > smoothedEnergy[end]) {
+					bandSum += end*energy[end];
+					energySum += energy[end];
+					++end;
+				}
+				Sample avgBand = bandSum/energySum;
+				Sample avgFreq = bandToFreq(avgBand);
+				peaks.emplace_back(Peak{avgBand, freqToBand(mapFreq(avgFreq))});
+
+				start = end;
+			}
+			++start;
+		}
+	}
+	
+	void updateOutputMap() {
+		if (peaks.empty()) {
+			for (int b = 0; b < bands; ++b) {
+				outputMap[b] = {Sample(b), 1};
+			}
+			return;
+		}
+		Sample bottomOffset = peaks[0].input - peaks[0].output;
+		for (int b = 0; b < std::min(bands, static_cast<int>(std::ceil(peaks[0].output))); ++b) {
+			outputMap[b] = {b + bottomOffset, 1};
+		}
+		// Interpolate between points
+		for (size_t p = 1; p < peaks.size(); ++p) {
+			const Peak &prev = peaks[p - 1], &next = peaks[p];
+			Sample rangeScale = 1/(next.output - prev.output);
+			Sample outOffset = prev.input - prev.output;
+			Sample outScale = next.input - next.output - prev.input + prev.output;
+			Sample gradScale = outScale*rangeScale;
+			int startBin = std::max(0, static_cast<int>(std::ceil(prev.output)));
+			int endBin = std::min(bands, static_cast<int>(std::ceil(next.output)));
+			for (int b = startBin; b < endBin; ++b) {
+				Sample r = (b - prev.output)*rangeScale;
+				Sample h = r*r*(3 - 2*r);
+				Sample outB = b + outOffset + h*outScale;
+				
+				Sample gradH = 6*r*(1 - r);
+				Sample gradB = 1 + gradH*gradScale;
+				
+				outputMap[b] = {outB, gradB};
+			}
+		}
+		Sample topOffset = peaks.back().input - peaks.back().output;
+		for (int b = std::max(0, static_cast<int>(peaks.back().output)); b < bands; ++b) {
+			outputMap[b] = {b + topOffset, 1};
+		}
+	}
+
+	// If we mapped formants the same way as mapFreq(), this would be the inverse
+	Sample invMapFormant(Sample freq) const {
+		if (freq*invFormantMultiplier > freqTonalityLimit) {
+			return freq + (1 - formantMultiplier)*freqTonalityLimit;
+		}
+		return freq*invFormantMultiplier;
+	}
+
+	Sample freqEstimateWeighted = 0;
+	Sample freqEstimateWeight = 0;
+	Sample estimateFrequency() {
+		// 3 highest peaks in the input
+		std::array<int, 3> peakIndices{0, 0, 0};
+		for (int b = 1; b < bands - 1; ++b) {
+			Sample e = formantMetric[b];
+			// local maxima only
+			if (e < formantMetric[b - 1] || e <= formantMetric[b + 1]) continue;
+			
+			if (e > formantMetric[peakIndices[0]]) {
+				if (e > formantMetric[peakIndices[1]]) {
+					if (e > formantMetric[peakIndices[2]]) {
+						peakIndices = {peakIndices[1], peakIndices[2], b};
+					} else {
+						peakIndices = {peakIndices[1], b, peakIndices[2]};
+					}
+				} else {
+					peakIndices[0] = b;
+				}
+			}
+		}
+		
+		// VERY rough pitch estimation
+		int peakEstimate = peakIndices[2];
+		if (formantMetric[peakIndices[1]] > formantMetric[peakIndices[2]]*0.1) {
+			int diff = std::abs(peakEstimate - peakIndices[1]);
+			if (diff > peakEstimate/8 && diff < peakEstimate*7/8) peakEstimate = peakEstimate%diff;
+			if (formantMetric[peakIndices[0]] > formantMetric[peakIndices[2]]*0.01) {
+				diff = std::abs(peakEstimate - peakIndices[0]);
+				if (diff > peakEstimate/8 && diff < peakEstimate*7/8) peakEstimate = peakEstimate%diff;
+			}
+		}
+		Sample weight = formantMetric[peakIndices[2]];
+		// Smooth it out a bit
+		freqEstimateWeighted += (peakEstimate*weight - freqEstimateWeighted)*Sample(0.25);
+		freqEstimateWeight += (weight - freqEstimateWeight)*Sample(0.25);
+		
+		return freqEstimateWeighted/(freqEstimateWeight + Sample(1e-30));
+	}
+	
+	Sample freqEstimate;
+	
+	std::vector<Sample> formantMetric;
+	Sample formantBaseFreq = 0;
+	void updateFormants(size_t step) {
+		if (step-- == 0) {
+			for (auto &e : formantMetric) e = 0;
+			for (int c = 0; c < channels; ++c) {
+				Band *bins = bandsForChannel(c);
+				for (int b = 0; b < bands; ++b) {
+					formantMetric[b] += bins[b].inputEnergy;
+				}
+			}
+
+			freqEstimate = freqToBand(formantBaseFreq);
+			if (formantBaseFreq <= 0) freqEstimate = estimateFrequency();
+		} else if (step-- == 0) {
+			Sample decay = 1 - 1/(freqEstimate*Sample(0.5) + 1);
+			Sample e = 0;
+			for (size_t repeat = 0; repeat < 2; ++repeat) {
+				for (int b = bands - 1; b >= 0; --b) {
+					e = std::max(formantMetric[b], e*decay);
+					formantMetric[b] = e;
+				}
+				for (int b = 0; b < bands; ++b) {
+					e = std::max(formantMetric[b], e*decay);
+					formantMetric[b] = e;
+				}
+			}
+			decay = 1/decay;
+			for (size_t repeat = 0; repeat < 2; ++repeat) {
+				for (int b = bands - 1; b >= 0; --b) {
+					e = std::min(formantMetric[b], e*decay);
+					formantMetric[b] = e;
+				}
+				for (int b = 0; b < bands; ++b) {
+					e = std::min(formantMetric[b], e*decay);
+					formantMetric[b] = e;
+				}
+			}
+		} else {
+			auto getFormant = [&](Sample band) -> Sample {
+				if (band < 0) return 0;
+				band = std::min(band, static_cast<Sample>(bands));
+				int floorBand = std::floor(band);
+				Sample fracBand = band - floorBand;
+				Sample low = formantMetric[floorBand], high = formantMetric[floorBand + 1];
+				return low + (high - low)*fracBand;
+			};
+
+			for (int b = 0; b < bands; ++b) {
+				Sample inputF = bandToFreq(static_cast<Sample>(b));
+				Sample outputF = formantCompensation ? mapFreq(inputF) : inputF;
+				outputF = invMapFormant(outputF);
+
+				Sample inputE = formantMetric[b];
+				Sample targetE = getFormant(freqToBand(outputF));
+
+				Sample formantRatio = targetE/(inputE + Sample(1e-30));
+				Sample energyRatio = formantRatio;
+
+				for (int c = 0; c < channels; ++c) {
+					Band *bins = bandsForChannel(c);
+					// This is what's used to decide the output energy, so this affects the output
+					bins[b].inputEnergy *= energyRatio;
+				}
+			}
+		}
+	}
+
+	// Proxy class to avoid copying/allocating anything
+	template<class Io>
+	struct OffsetIO {
+		Io &io;
+		int offset;
+
+		struct Channel {
+			Io &io;
+			int channel;
+			int offset;
+			
+			auto operator[](int i) -> decltype(io[0][0]) {
+				return io[channel][i + offset];
+			}
+		};
+		Channel operator[](int c) {
+			return {io, c, offset};
+		}
+	};
+};
+
+}} // namespace
+#endif // include guard

--- a/Packages/PlaybackDSP/Sources/PlaybackDSP/TimeStretchStream.swift
+++ b/Packages/PlaybackDSP/Sources/PlaybackDSP/TimeStretchStream.swift
@@ -1,0 +1,45 @@
+import CPlaybackDSP
+import Foundation
+
+/// Stateful mono Float32 stretching. Keep one instance for a continuous source;
+/// create a new instance after seeking or changing speed. Call only serially.
+public final class TimeStretchStream {
+    public static let engineName = "Signalsmith Stretch"
+    private let handle: UnsafeMutableRawPointer
+    private var isFinished = false
+
+    public enum Failure: Error {
+        case invalidConfiguration
+        case invalidSamples
+        case processingFailed
+        case alreadyFinished
+    }
+
+    public init(sampleRate: Double, rate: Double) throws {
+        guard let handle = sayit_stretch_create(sampleRate, rate) else {
+            throw Failure.invalidConfiguration
+        }
+        self.handle = handle
+    }
+
+    deinit { sayit_stretch_destroy(handle) }
+
+    /// Finalization drains lookahead and trims padding to round(inputFrames / rate).
+    /// At 1×, samples pass through unchanged.
+    public func process(_ samples: [Float], final: Bool = false) throws -> [Float] {
+        guard !isFinished else { throw Failure.alreadyFinished }
+        guard samples.count <= Int(Int32.max), samples.allSatisfy(\.isFinite) else {
+            throw Failure.invalidSamples
+        }
+        var count: Int32 = 0
+        let result = samples.withUnsafeBufferPointer {
+            sayit_stretch_process(handle, $0.baseAddress, Int32($0.count), final ? 1 : 0, &count)
+        }
+        guard count >= 0 else { throw Failure.processingFailed }
+        isFinished = final
+        guard count > 0, let result else { return [] }
+        let output = Array(UnsafeBufferPointer(start: result, count: Int(count)))
+        guard output.allSatisfy(\.isFinite) else { throw Failure.processingFailed }
+        return output
+    }
+}

--- a/Packages/PlaybackDSP/Sources/PlaybackDSPRender/main.swift
+++ b/Packages/PlaybackDSP/Sources/PlaybackDSPRender/main.swift
@@ -1,0 +1,65 @@
+@preconcurrency import AVFoundation
+import Foundation
+import PlaybackDSP
+
+// Offline listening fixtures use exactly the same streaming wrapper as playback.
+// Usage: swift run -c release --package-path Packages/PlaybackDSP PlaybackDSPRender input.wav output-directory
+@main
+struct RenderComparison {
+    static func main() throws {
+        guard CommandLine.arguments.count == 3 else {
+            print("Usage: PlaybackDSPRender input-audio output-directory")
+            return
+        }
+        let source = URL(fileURLWithPath: CommandLine.arguments[1])
+        let destination = URL(fileURLWithPath: CommandLine.arguments[2], isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        let input = try AVAudioFile(forReading: source, commonFormat: .pcmFormatFloat32, interleaved: false)
+        let sampleRate = input.processingFormat.sampleRate
+        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: input.processingFormat, frameCapacity: 4096),
+              let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1) else {
+            throw TimeStretchStream.Failure.invalidConfiguration
+        }
+        print("engine,rate,input_frames,output_frames,processing_seconds")
+        for rate in [0.5, 0.75, 1.0, 1.25, 1.5, 2.0] {
+            let url = destination.appendingPathComponent("speed-\(rate).wav")
+            guard !FileManager.default.fileExists(atPath: url.path) else {
+                throw CocoaError(.fileWriteFileExists)
+            }
+            let output = try AVAudioFile(forWriting: url, settings: format.settings)
+            let stream = try TimeStretchStream(sampleRate: sampleRate, rate: rate)
+            var outputFrames = 0
+            var processingSeconds = 0.0
+            input.framePosition = 0
+            func write(_ samples: [Float], final: Bool = false) throws {
+                let start = ContinuousClock.now
+                let stretched = try stream.process(samples, final: final)
+                let elapsed = start.duration(to: .now).components
+                processingSeconds += Double(elapsed.seconds) + Double(elapsed.attoseconds) / 1e18
+                guard !stretched.isEmpty else { return }
+                guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(stretched.count)),
+                      let channel = buffer.floatChannelData?[0] else {
+                    throw TimeStretchStream.Failure.processingFailed
+                }
+                buffer.frameLength = AVAudioFrameCount(stretched.count)
+                for index in stretched.indices { channel[index] = stretched[index] }
+                try output.write(from: buffer)
+                outputFrames += stretched.count
+            }
+            while input.framePosition < input.length {
+                try input.read(into: inputBuffer)
+                guard let channels = inputBuffer.floatChannelData, inputBuffer.frameLength > 0 else {
+                    throw TimeStretchStream.Failure.invalidSamples
+                }
+                let channelCount = Int(input.processingFormat.channelCount)
+                var mono = [Float](repeating: 0, count: Int(inputBuffer.frameLength))
+                for channel in 0..<channelCount {
+                    for frame in mono.indices { mono[frame] += channels[channel][frame] / Float(channelCount) }
+                }
+                try write(mono)
+            }
+            try write([], final: true)
+            print("\(TimeStretchStream.engineName),\(rate),\(input.length),\(outputFrames),\(processingSeconds)")
+        }
+    }
+}

--- a/Packages/PlaybackDSP/Tests/PlaybackDSPTests/TimeStretchTests.swift
+++ b/Packages/PlaybackDSP/Tests/PlaybackDSPTests/TimeStretchTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import PlaybackDSP
+
+@Suite("Pitch-preserving playback DSP")
+struct TimeStretchTests {
+    static let rates = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+
+    static func tone(sampleRate: Double, duration: Double = 3) -> [Float] {
+        (0..<Int(sampleRate * duration)).map { frame in
+            let time = Double(frame) / sampleRate
+            let envelope = min(1, time / 0.02, (duration - time) / 0.02)
+            return Float(0.25 * envelope * sin(2 * .pi * 220 * time))
+        }
+    }
+
+    @Test("All speeds preserve pitch, duration and level", arguments: rates, [24_000.0, 44_100.0, 48_000.0])
+    func pitchAndDuration(rate: Double, sampleRate: Double) throws {
+        let input = Self.tone(sampleRate: sampleRate)
+        let stream = try TimeStretchStream(sampleRate: sampleRate, rate: rate)
+        var output: [Float] = []
+        // Irregular chunks exercise cumulative rounding and continuous state.
+        for start in stride(from: 0, to: input.count, by: 997) {
+            output += try stream.process(Array(input[start..<min(start + 997, input.count)]))
+        }
+        output += try stream.process([], final: true)
+        #expect(output.count == Int((Double(input.count) / rate).rounded()))
+        #expect(output.allSatisfy { $0.isFinite })
+        let middle = Array(output[Int(sampleRate / 4)..<(output.count - Int(sampleRate / 4))])
+        let rms = sqrt(middle.reduce(0.0) { $0 + Double($1 * $1) } / Double(middle.count))
+        let crossings = zip(middle, middle.dropFirst()).filter { $0 <= 0 && $1 > 0 }.count
+        let frequency = Double(crossings) * sampleRate / Double(middle.count)
+        #expect(abs(frequency - 220) < 3)
+        #expect(rms > 0.10 && rms < 0.25)
+        #expect((output.map { abs($0) }.max() ?? 0) < 0.5)
+        if rate == 1 { #expect(output == input) }
+    }
+
+    @Test("Short clips drain their tail at every speed", arguments: rates)
+    func shortTail(rate: Double) throws {
+        for count in [1, 37, 240, 2400] {
+            let stream = try TimeStretchStream(sampleRate: 24_000, rate: rate)
+            let output = try stream.process([Float](repeating: 0.1, count: count), final: true)
+            #expect(output.count == Int((Double(count) / rate).rounded()))
+            #expect(output.allSatisfy { $0.isFinite })
+        }
+    }
+
+    @Test("Invalid inputs fail and finalized streams cannot be reused")
+    func invalidInputs() throws {
+        for rate in [0, -1, 3, Double.nan, Double.infinity] {
+            #expect(throws: TimeStretchStream.Failure.self) {
+                try TimeStretchStream(sampleRate: 24_000, rate: rate)
+            }
+        }
+        #expect(throws: TimeStretchStream.Failure.self) {
+            try TimeStretchStream(sampleRate: 0, rate: 1)
+        }
+        let stream = try TimeStretchStream(sampleRate: 24_000, rate: 1.5)
+        #expect(throws: TimeStretchStream.Failure.self) { try stream.process([.nan]) }
+        #expect(try stream.process([], final: true).isEmpty)
+        #expect(throws: TimeStretchStream.Failure.self) { try stream.process([0]) }
+    }
+
+    @Test("New streams after seek or speed change do not carry old audio")
+    func resetIsolation() throws {
+        let first = try TimeStretchStream(sampleRate: 24_000, rate: 2)
+        _ = try first.process(Self.tone(sampleRate: 24_000))
+        let second = try TimeStretchStream(sampleRate: 24_000, rate: 0.5)
+        let silence = try second.process([Float](repeating: 0, count: 24_000), final: true)
+        #expect(silence.allSatisfy { abs($0) < 0.0001 })
+    }
+}

--- a/SayIt.xcodeproj/project.pbxproj
+++ b/SayIt.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		2F13AD95B66B59D9BEFAB69D /* VoiceProfileRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48CC76FCF104B6EA0CCFFC3 /* VoiceProfileRecord.swift */; };
 		2F98443BCC6A9CE666AFF7D2 /* SayItCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E5B162BA286FB4707D990A4 /* SayItCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		30F806119784A3EA06D08732 /* APITokenCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AADDFBAF6765A7A9E46F6F /* APITokenCreation.swift */; };
+		31CB6C9597C1FD2312EB3DE6 /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */; };
 		32FC4CC7ADAA06A627E07AD0 /* HTTPEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEAC3BEEF3A43EBD6DCF107 /* HTTPEventStreamTests.swift */; };
 		35C5858DED5258F9813091A5 /* SynthesisError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF73CF550608FF1F4C96C1B /* SynthesisError.swift */; };
 		360339154AB4814D00BBCB3B /* TokenCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62B45AACA98296E67663E5A /* TokenCreationSheet.swift */; };
@@ -126,7 +127,7 @@
 		3E69D945BB53BFBF82FCAA9D /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68391B4A83D06AD4C1FFAA0 /* OnboardingView.swift */; };
 		3F22D38886E6E44E0156F0F7 /* VoiceDiscoveryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AD71761AE179BEA6A20967 /* VoiceDiscoveryRequest.swift */; };
 		40F3797F2C6B54BD494E8C74 /* APITokenDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8697FFA4EB481A4A7FB1A3A /* APITokenDigestTests.swift */; };
-		419CB00AB6F80C7F4A3F46BC /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */; };
+		419CB00AB6F80C7F4A3F46BC /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 71DDF93755CA3F43B4C3D31B /* MLXAudioCore */; };
 		41DE1A049C2D3BFE630D7177 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 12D3C7903194A06085F4C99C /* Atomics */; };
 		4251B261B2659D5CB44E474C /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C074F8772DC89E43CE2A267 /* DesignTokens.swift */; };
 		435E896B82A959E7FDFB0403 /* SayItApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CEBAFD3BF5D864C5BD06D /* SayItApplication.swift */; };
@@ -176,6 +177,7 @@
 		560101541C1F3A848FE2B02F /* SayItSelectionAgentMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E19E0A44E938CCC17DEF7EE /* SayItSelectionAgentMain.swift */; };
 		560D74E1A13F3E50F535D55F /* MenuFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504A1CDB257EFB01D742FAE6 /* MenuFooterView.swift */; };
 		560E27275E9D1815E261F41E /* TimeInterval+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7392C8CFFBB121658EBD9597 /* TimeInterval+Formatting.swift */; };
+		56D2AEA8E65D228BBC9509CF /* TimeStretchPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */; };
 		56ECCB4BAC727F46AA2408EF /* VoiceCloneRequirements.swift in Sources */ = {isa = PBXBuildFile; fileRef = E052AB297B6730E47BF28A4D /* VoiceCloneRequirements.swift */; };
 		56F431F50DFF88F2785B215B /* SpeechTitleGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF89D0850C4A3A612A71C738 /* SpeechTitleGeneratorTests.swift */; };
 		57F882F8230C74C9C260774F /* UpdateOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DD06F06BB2F0F12013A199 /* UpdateOffer.swift */; };
@@ -208,7 +210,7 @@
 		660B9287719F72B11783D3C1 /* ResumeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = C159E47E305909312F3675A5 /* ResumeCommand.swift */; };
 		662931D02D9303078BB8AE62 /* VoiceTuningSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61809FAC6AB3B4223A714878 /* VoiceTuningSpace.swift */; };
 		673810EDC217C5CD2640A55A /* PlaybackRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6517CAB9846FFD0FD879B897 /* PlaybackRate.swift */; };
-		690DD7FC6DABD5D8A65B7A48 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 71DDF93755CA3F43B4C3D31B /* MLXAudioCore */; };
+		690DD7FC6DABD5D8A65B7A48 /* PlaybackDSP in Frameworks */ = {isa = PBXBuildFile; productRef = 7D5589CFD718091E8391DB68 /* PlaybackDSP */; };
 		69CE3A628AAE1587B7976D71 /* VoiceStudioSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AEFBFB440C0388E52C0DEC /* VoiceStudioSnapshot.swift */; };
 		6B2A2003079910D0A146A378 /* SayItHTTPServer+PlaybackRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC29C1C1131C5748DA67D61 /* SayItHTTPServer+PlaybackRoutes.swift */; };
 		6B8EA518D4DB7702985F43FA /* RegisteredServiceStartup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB5BBA9182ED3B21E5A1465 /* RegisteredServiceStartup.swift */; };
@@ -946,6 +948,7 @@
 		456A6147E5C1F299C5F70B42 /* AccessibilityAncestorSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAncestorSearch.swift; sourceTree = "<group>"; };
 		45838FA1413995858EC9E5C3 /* StatusHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusHeaderView.swift; sourceTree = "<group>"; };
 		45FA49ACF4B53BA6833BADA6 /* SKILL.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SKILL.md; sourceTree = "<group>"; };
+		4616A529E899E2F12ACCA917 /* PlaybackDSP */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PlaybackDSP; path = Packages/PlaybackDSP; sourceTree = SOURCE_ROOT; };
 		46A2C77FAF415C25A265B262 /* HTTPSubmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPSubmission.swift; sourceTree = "<group>"; };
 		46C4FDBB3A3112F47070537F /* APITokenPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenPreset.swift; sourceTree = "<group>"; };
 		4704665E76548BC4B54EAAE2 /* VoiceCloneRequirementsSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCloneRequirementsSnapshot.swift; sourceTree = "<group>"; };
@@ -1132,6 +1135,7 @@
 		B825339FFDAD336D58CA0052 /* SpeechChunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechChunk.swift; sourceTree = "<group>"; };
 		B9BFBF98DB02E32E3E824EF6 /* BackendPrimitiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPrimitiveTests.swift; sourceTree = "<group>"; };
 		BA18E0AFEFF10C13815F3D6D /* APITokenScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenScope.swift; sourceTree = "<group>"; };
+		BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeStretchPlaybackTests.swift; sourceTree = "<group>"; };
 		BB95F4768AD968BE1C4CBCD1 /* SayItStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItStyles.swift; sourceTree = "<group>"; };
 		BD2C197A18B385CC45949276 /* DiagnosticEvent+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiagnosticEvent+Snapshot.swift"; sourceTree = "<group>"; };
 		BE4174D1D4EB7E48D19724DA /* SelectionCaptureFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionCaptureFlow.swift; sourceTree = "<group>"; };
@@ -1280,10 +1284,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				690DD7FC6DABD5D8A65B7A48 /* PlaybackDSP in Frameworks */,
 				0922BE8F5F7353F975466383 /* SayItCore.framework in Frameworks */,
 				89AD3D4D8907B9BD8BC76B7F /* SayItProtocol.framework in Frameworks */,
-				690DD7FC6DABD5D8A65B7A48 /* MLXAudioCore in Frameworks */,
-				419CB00AB6F80C7F4A3F46BC /* MLXAudioTTS in Frameworks */,
+				419CB00AB6F80C7F4A3F46BC /* MLXAudioCore in Frameworks */,
+				31CB6C9597C1FD2312EB3DE6 /* MLXAudioTTS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1935,6 +1940,7 @@
 			isa = PBXGroup;
 			children = (
 				D5368688F97DCA95208246D6 /* Fixtures */,
+				E6A9ADAA62A15BD6C74D2CEF /* Packages */,
 				04D76396770A2F14616CD133 /* Resources */,
 				4835E83DFC07A19B7BC7DEF9 /* Resources */,
 				180CF2F43C8748887CC1F6A5 /* SayIt */,
@@ -2164,6 +2170,14 @@
 			path = Tests/SayItUpdateTests;
 			sourceTree = "<group>";
 		};
+		E6A9ADAA62A15BD6C74D2CEF /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				4616A529E899E2F12ACCA917 /* PlaybackDSP */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
 		EA01701396BB7A5E45BFB811 /* Diagnostics */ = {
 			isa = PBXGroup;
 			children = (
@@ -2261,6 +2275,7 @@
 				C66497ED594E15E3EF2CF5FD /* SpeechQueuePolicyTests.swift */,
 				DC8FE48DDB4640E0887AC670 /* SynthesisActorTests.swift */,
 				40828984E8B5F3F75C795F92 /* SynthesisOperationLifecycleTests.swift */,
+				BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */,
 				9E44B62D54EF87F46363D70C /* VoiceProfileStoreTests.swift */,
 				9842DB392263544D975DAA5F /* VoiceTuningPolicyTests.swift */,
 			);
@@ -2353,6 +2368,7 @@
 			);
 			name = SayItBackend;
 			packageProductDependencies = (
+				7D5589CFD718091E8391DB68 /* PlaybackDSP */,
 				71DDF93755CA3F43B4C3D31B /* MLXAudioCore */,
 				A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */,
 			);
@@ -2731,6 +2747,7 @@
 				C93AA06F3A6E248872ED93BC /* XCRemoteSwiftPackageReference "swift-collections" */,
 				2E71412ABA0D3631AC8F7E2B /* XCRemoteSwiftPackageReference "swift-nio" */,
 				8FA3A87EEEF8E0DC0F7CA93B /* XCRemoteSwiftPackageReference "Yams" */,
+				84D82FD5D4C643C189B34542 /* XCLocalSwiftPackageReference "Packages/PlaybackDSP" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 932443B985F40D816A0FD3B7 /* Products */;
@@ -3317,6 +3334,7 @@
 				F88A3CF15CA4053F7D587898 /* SpeechQueuePolicyTests.swift in Sources */,
 				BD7E756DBD67FF169CDD68C2 /* SynthesisActorTests.swift in Sources */,
 				97FFD241C34F9894CF4E8B9E /* SynthesisOperationLifecycleTests.swift in Sources */,
+				56D2AEA8E65D228BBC9509CF /* TimeStretchPlaybackTests.swift in Sources */,
 				04EDE873EF293B5BAFCD4C49 /* VoiceProfileStoreTests.swift in Sources */,
 				2D698A1F3469FA1866B99A24 /* VoiceTuningPolicyTests.swift in Sources */,
 			);
@@ -4486,6 +4504,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		84D82FD5D4C643C189B34542 /* XCLocalSwiftPackageReference "Packages/PlaybackDSP" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/PlaybackDSP;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		0FB0C4A704F0962960BDE609 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -4588,6 +4613,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = EDE9B52C93821E68A0BAF348 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */;
 			productName = MLXAudioCore;
+		};
+		7D5589CFD718091E8391DB68 /* PlaybackDSP */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PlaybackDSP;
 		};
 		966CEFC1C422D50A7DA22CD1 /* DequeModule */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Sources/SayItBackend/Playback/PlaybackController.swift
+++ b/Sources/SayItBackend/Playback/PlaybackController.swift
@@ -3,6 +3,7 @@
 import Foundation
 @preconcurrency import MediaPlayer
 import Observation
+import PlaybackDSP
 import SayItCore
 import SayItProtocol
 
@@ -10,7 +11,7 @@ import SayItProtocol
 @Observable
 final class PlaybackController: BackendPlaybackControlling {
     static let modelSwitchFadeDuration: Duration = .milliseconds(24)
-    static let highQualityTimePitchOverlap: Float = 32
+    static let timeStretchEngineName = TimeStretchStream.engineName
     static let schedulingHorizon: TimeInterval = 12
     static let schedulingChunkDuration: TimeInterval = 2
     static let fileReadFrameCount = 65_536
@@ -23,7 +24,11 @@ final class PlaybackController: BackendPlaybackControlling {
 
     private let engine = AVAudioEngine()
     private let player = AVAudioPlayerNode()
-    private let timePitch = AVAudioUnitTimePitch()
+    private var timeStretch: TimeStretchStream?
+    private var processingIsComplete = false
+    private var pendingSourceFrames: Int64 = 0
+    private var scheduledOutputFrames: Int64 = 0
+    private var renderRate: Double = 1
     private let timeline = TimelineDriver()
     private var audioConfigurationTask: Task<Void, Never>?
     private var audioConfigurationRecoveryTask: Task<Void, Never>?
@@ -97,7 +102,19 @@ final class PlaybackController: BackendPlaybackControlling {
     }
     var rate: Double = 1 {
         didSet {
-            timePitch.rate = Float(rate)
+            guard rate != oldValue else { return }
+            let wasPlaying = state == .playing
+            let anchor = currentPlaybackTime()
+            do {
+                if hasStoredAudio {
+                    try rescheduleAudio(from: anchor)
+                    elapsed = anchor
+                    lastStablePlaybackTime = anchor
+                    if wasPlaying { try startPlayback() }
+                }
+            } catch {
+                reportFailure(error, shouldResume: wasPlaying)
+            }
             scheduleCompletionWatchdog()
             updateNowPlaying()
         }
@@ -126,10 +143,6 @@ final class PlaybackController: BackendPlaybackControlling {
 
     init() {
         engine.attach(player)
-        engine.attach(timePitch)
-        timePitch.rate = Float(rate)
-        timePitch.pitch = 0
-        timePitch.overlap = Self.highQualityTimePitchOverlap
         configureRemoteCommands()
         monitorAudioConfiguration()
     }
@@ -345,6 +358,12 @@ final class PlaybackController: BackendPlaybackControlling {
     func finishBuffering() {
         synthesisIsComplete = true
         estimatedDuration = generatedDuration
+        do {
+            try scheduleAvailableAudio()
+        } catch {
+            reportFailure(error)
+            return
+        }
         if state == .buffering {
             play()
         } else {
@@ -492,16 +511,7 @@ final class PlaybackController: BackendPlaybackControlling {
         engine.stop()
         player.stop()
         engine.disconnectNodeOutput(player)
-        engine.disconnectNodeOutput(timePitch)
-        engine.connect(player, to: timePitch, format: format)
-        engine.connect(
-            timePitch,
-            to: engine.mainMixerNode,
-            format: format
-        )
-        timePitch.rate = Float(rate)
-        timePitch.pitch = 0
-        timePitch.overlap = Self.highQualityTimePitchOverlap
+        engine.connect(player, to: engine.mainMixerNode, format: format)
         engine.prepare()
         configuredSampleRate = format.sampleRate
         try ensureEngineRunning()
@@ -601,6 +611,7 @@ final class PlaybackController: BackendPlaybackControlling {
     ) {
         let generation = scheduleGeneration
         scheduledBufferCount += 1
+        scheduledOutputFrames += Int64(buffer.frameLength)
         player.scheduleBuffer(
             buffer,
             completionCallbackType: .dataPlayedBack
@@ -636,6 +647,11 @@ final class PlaybackController: BackendPlaybackControlling {
         completionWatchdogTask = nil
         scheduleGeneration &+= 1
         scheduledBufferCount = 0
+        scheduledOutputFrames = 0
+        pendingSourceFrames = 0
+        timeStretch = nil
+        processingIsComplete = false
+        renderRate = rate
         if var frameScheduler {
             frameScheduler.reset(startingAt: frameScheduler.nextFrame)
             self.frameScheduler = frameScheduler
@@ -658,38 +674,54 @@ final class PlaybackController: BackendPlaybackControlling {
     }
 
     private func scheduleAvailableAudio() throws {
-        guard let pcmStore, var frameScheduler else { return }
-        while let range = frameScheduler.nextRange(
-            availableFrameCount: pcmStore.frameCount
-        ) {
-            var samples = try pcmStore.readFrames(
+        guard let pcmStore, var frameScheduler, !processingIsComplete else { return }
+        if timeStretch == nil {
+            renderRate = rate
+            timeStretch = try TimeStretchStream(sampleRate: sampleRate, rate: renderRate)
+        }
+        guard let timeStretch else { return }
+        while let range = frameScheduler.nextRange(availableFrameCount: pcmStore.frameCount) {
+            let samples = try pcmStore.readFrames(
                 startingAt: range.lowerBound,
                 count: Int(range.count)
             )
             guard samples.count == range.count else {
                 throw CocoaError(.fileReadCorruptFile)
             }
-            if shouldFadeInNextScheduledBuffer {
-                samples = PCMTransitionRamp.fadeInHead(
-                    samples,
-                    frameCount: transitionFrameCount
-                )
-                shouldFadeInNextScheduledBuffer = false
-            }
-            let buffer = try makeBuffer(
-                samples: samples,
-                sampleRate: sampleRate
-            )
-            if configuredSampleRate == nil {
-                try prepareAudioGraph(for: buffer.format)
-            } else {
-                try ensureEngineRunning()
-            }
-            try validatePlayerFormat(for: buffer)
-            schedule(buffer, sourceFrameCount: Int64(range.count))
+            let output = try timeStretch.process(samples)
+            pendingSourceFrames += Int64(range.count)
             frameScheduler.didSchedule(range)
+            try scheduleProcessedAudio(output)
+        }
+        if synthesisIsComplete, frameScheduler.nextFrame == pcmStore.frameCount {
+            let tail = try timeStretch.process([], final: true)
+            try scheduleProcessedAudio(tail)
+            // A unity-rate stream has no delayed output to attach this accounting to.
+            if pendingSourceFrames > 0 {
+                frameScheduler.didComplete(frameCount: pendingSourceFrames)
+                pendingSourceFrames = 0
+            }
+            processingIsComplete = true
         }
         self.frameScheduler = frameScheduler
+    }
+
+    private func scheduleProcessedAudio(_ output: [Float]) throws {
+        guard !output.isEmpty else { return }
+        var samples = output
+        if shouldFadeInNextScheduledBuffer {
+            samples = PCMTransitionRamp.fadeInHead(samples, frameCount: transitionFrameCount)
+            shouldFadeInNextScheduledBuffer = false
+        }
+        let buffer = try makeBuffer(samples: samples, sampleRate: sampleRate)
+        if configuredSampleRate == nil {
+            try prepareAudioGraph(for: buffer.format)
+        } else {
+            try ensureEngineRunning()
+        }
+        try validatePlayerFormat(for: buffer)
+        schedule(buffer, sourceFrameCount: pendingSourceFrames)
+        pendingSourceFrames = 0
     }
 
     private func currentPlaybackTime() -> TimeInterval {
@@ -701,7 +733,8 @@ final class PlaybackController: BackendPlaybackControlling {
         }
         return min(
             scheduleOffset
-                + Double(playerTime.sampleTime) / playerTime.sampleRate,
+                + Double(min(playerTime.sampleTime, scheduledOutputFrames))
+                    / playerTime.sampleRate * renderRate,
             generatedDuration
         )
     }
@@ -722,7 +755,7 @@ final class PlaybackController: BackendPlaybackControlling {
               scheduledBufferCount == 0 else {
             return
         }
-        if synthesisIsComplete {
+        if synthesisIsComplete, processingIsComplete {
             completePlayback()
         } else if state == .playing {
             enterBufferingState()
@@ -789,10 +822,14 @@ final class PlaybackController: BackendPlaybackControlling {
     }
 
     private func enterBufferingState() {
-        elapsed = generatedDuration
+        // Restart from the audible source position, including the processor's
+        // held-back lookahead, when progressive synthesis catches up.
+        elapsed = currentPlaybackTime()
         lastStablePlaybackTime = elapsed
         invalidateScheduledAudio()
-        scheduleOffset = elapsed
+        let frame = Int64((elapsed * sampleRate).rounded(.down))
+        frameScheduler?.reset(startingAt: frame)
+        scheduleOffset = Double(frame) / sampleRate
         state = .buffering
         updateNowPlaying()
     }

--- a/Tests/SayItBackendTests/BackendProjectionTests.swift
+++ b/Tests/SayItBackendTests/BackendProjectionTests.swift
@@ -97,6 +97,6 @@ struct BackendProjectionTests {
         #expect(PlaybackController.preferredStartBufferDuration(for: 0.5) == 1.2)
         #expect(PlaybackController.preferredStartBufferDuration(for: 1) == 1.2)
         #expect(PlaybackController.preferredStartBufferDuration(for: 2) == 2.4)
-        #expect(PlaybackController.highQualityTimePitchOverlap == 32)
+        #expect(PlaybackController.timeStretchEngineName == "Signalsmith Stretch")
     }
 }

--- a/Tests/SayItBackendTests/TimeStretchPlaybackTests.swift
+++ b/Tests/SayItBackendTests/TimeStretchPlaybackTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import SayItCore
+import SayItProtocol
+import Testing
+@testable import SayItBackend
+
+// Uses the real output graph, muted. Opt in on a Mac with an audio output device.
+@Suite("Time-stretched playback integration", .serialized,
+       .enabled(if: ProcessInfo.processInfo.environment["SAYIT_PLAYBACK_INTEGRATION"] == "1"))
+@MainActor
+struct TimeStretchPlaybackTests {
+    private func enqueue(_ playback: PlaybackController, id: UUID, duration: Double, index: Int = 0) throws {
+        let samples = (0..<Int(24_000 * duration)).map {
+            Float(0.1 * sin(2 * .pi * 220 * Double($0) / 24_000))
+        }
+        try playback.enqueue(AudioChunk(requestID: id, index: index, samples: samples,
+                                        sampleRate: 24_000, startsParagraph: false))
+    }
+
+    private func waitUntilFinished(_ playback: PlaybackController, timeout: Double) async throws {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while playback.state != .finished && playback.state != .failed && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(playback.state == .finished)
+        #expect(playback.failureMessage == nil)
+    }
+
+    @Test("Real output graph finishes at the requested speed", arguments: [0.5, 0.75, 1.0, 1.25, 1.5, 2.0])
+    func duration(rate: Double) async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = rate
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP integration fixture", estimatedDuration: 1, modelID: nil)
+        try enqueue(playback, id: id, duration: 1)
+        let start = ContinuousClock.now
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 1 / rate + 2)
+        let wall = start.duration(to: .now)
+        #expect(wall > .seconds(1 / rate - 0.2))
+        #expect(wall < .seconds(1 / rate + 0.75))
+        #expect(abs(playback.elapsed - 1) < 0.001)
+    }
+
+    @Test("Speed changes, paused seeks and replay preserve source position")
+    func controls() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 0.5
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP control fixture", estimatedDuration: 2, modelID: nil)
+        try enqueue(playback, id: id, duration: 2)
+        playback.finishBuffering()
+        try await Task.sleep(for: .milliseconds(300))
+        let before = playback.elapsed
+        playback.rate = 2
+        #expect(playback.state == .playing)
+        #expect(abs(playback.elapsed - before) < 0.15)
+        playback.pause()
+        #expect(playback.state == .paused)
+        playback.rate = 0.75
+        #expect(playback.state == .paused)
+        playback.seek(to: 1.5)
+        #expect(abs(playback.elapsed - 1.5) < 0.001)
+        playback.play()
+        try await waitUntilFinished(playback, timeout: 2)
+        playback.rate = 2
+        playback.play()
+        try await waitUntilFinished(playback, timeout: 3)
+    }
+
+    @Test("Progressive underruns retain the delayed audio and completion tail")
+    func progressive() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 1.5
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP progressive fixture", estimatedDuration: 1, modelID: nil)
+        try enqueue(playback, id: id, duration: 0.5)
+        playback.play()
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(playback.state == .buffering)
+        #expect(playback.elapsed < playback.generatedDuration)
+        try enqueue(playback, id: id, duration: 0.5, index: 1)
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 2)
+        #expect(abs(playback.elapsed - 1) < 0.001)
+    }
+
+    @Test("Long playback replenishes the scheduling horizon")
+    func schedulingHorizon() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 2
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP horizon fixture", estimatedDuration: 13, modelID: nil)
+        try enqueue(playback, id: id, duration: 13)
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 9)
+        #expect(abs(playback.elapsed - 13) < 0.001)
+    }
+}

--- a/Tests/SayItPlaybackTests/AudioArchiveTests.swift
+++ b/Tests/SayItPlaybackTests/AudioArchiveTests.swift
@@ -8,7 +8,7 @@ struct AudioArchiveTests {
     @Test("Playback uses high quality time stretching")
     @MainActor
     func playbackUsesHighQualityTimeStretching() {
-        #expect(PlaybackController.highQualityTimePitchOverlap == 32)
+        #expect(PlaybackController.timeStretchEngineName == "Signalsmith Stretch")
         #expect(
             PlaybackController.preferredStartBufferDuration(for: 1) == 1.2
         )

--- a/project.yml
+++ b/project.yml
@@ -8,6 +8,8 @@ options:
   groupSortPosition: top
 
 packages:
+  PlaybackDSP:
+    path: Packages/PlaybackDSP
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     exactVersion: 2.9.6
@@ -105,6 +107,8 @@ targets:
     sources:
       - path: Sources/SayItBackend
     dependencies:
+      - package: PlaybackDSP
+        product: PlaybackDSP
       - target: SayItCore
       - target: SayItProtocol
       - package: MLXAudio


### PR DESCRIPTION
Compare pitch-preserving playback using Signalsmith Stretch instead of AVAudioUnitTimePitch. This is one independent listening experiment based on main; it is not intended to be merged alongside the other engine experiments.

The existing 0.5–2× controls now drive a continuous native Float32 stretcher. Original audio and exports remain unchanged, 1× bypasses processing, and speed changes reschedule from the audible source position. The implementation compensates processing latency, drains the final tail, and retains pending audio across progressive underruns. The MIT-licensed upstream sources and FFT dependency are pinned and vendored; no external runtime installation is required.

Validation:
- DSP tests passed across 0.5, 0.75, 1, 1.25, 1.5 and 2× at 24, 44.1 and 48 kHz, checking duration, pitch, level, finite samples, short tails and reset isolation.
- Muted real-output integration tests passed for all six speeds, live rate changes, paused seeks, replay, progressive underruns and scheduling beyond the buffer horizon.
- Full package suite: 358 tests passed, with the compiled MLX Metal library supplied using the repository's existing test setup.
- Local app build, signing verification, package linkage, updater and catalog checks passed. Upstream MLX dependency warnings remain.
- The offline renderer produced six speech WAVs with the expected sample counts. It measures processing time but does not claim perceptual superiority.

Run `swift test --package-path Packages/PlaybackDSP -c release` for DSP validation. Set `SAYIT_PLAYBACK_INTEGRATION=1` when running `TimeStretchPlaybackTests` on a Mac with an audio output device. The standalone `PlaybackDSPRender` command renders the same saved speech file at all comparison speeds; usage and the listening checklist are in `Packages/PlaybackDSP/README.md`.

For listening, keep native Speaking Pace at Natural and use the same voice/text or saved source audio across branches. Test metallic artifacts, consonants and voice warmth, especially at 0.5× and 2×. Only run one local comparison app at a time because the variants share the local application's identity and settings.
