### PR TITLE
Compare Sonic pitch-preserving playback

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .executable(name: "SayIt", targets: ["SayIt"])
     ],
     dependencies: [
+        .package(path: "Packages/PlaybackDSP"),
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.6"),
         .package(
             url: "https://github.com/Blaizzy/mlx-audio-swift.git",
@@ -71,6 +72,7 @@ let package = Package(
         .target(
             name: "SayItBackend",
             dependencies: [
+                .product(name: "PlaybackDSP", package: "PlaybackDSP"),
                 "SayItCore",
                 "SayItProtocol",
                 .product(name: "MLXAudioCore", package: "mlx-audio-swift"),

--- a/Packages/PlaybackDSP/Package.swift
+++ b/Packages/PlaybackDSP/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "PlaybackDSP",
+    platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "PlaybackDSP", targets: ["PlaybackDSP"]),
+        .executable(name: "PlaybackDSPRender", targets: ["PlaybackDSPRender"])
+    ],
+    targets: [
+        .target(
+            name: "CPlaybackDSP",
+            exclude: ["vendor/LICENSE"],
+            sources: ["TimeStretch.cpp", "vendor/sonic.c"],
+            publicHeadersPath: "include",
+            cxxSettings: [.headerSearchPath("vendor")]
+        ),
+        .target(name: "PlaybackDSP", dependencies: ["CPlaybackDSP"]),
+        .testTarget(name: "PlaybackDSPTests", dependencies: ["PlaybackDSP"]),
+        .executableTarget(name: "PlaybackDSPRender", dependencies: ["PlaybackDSP"])
+    ],
+    cxxLanguageStandard: .cxx17
+)

--- a/Packages/PlaybackDSP/README.md
+++ b/Packages/PlaybackDSP/README.md
@@ -1,0 +1,26 @@
+# Sonic playback comparison
+
+This experimental branch replaces Apple's playback time stretcher with Sonic,
+using its quality setting of 1. Playback speed remains 0.5–2× with unchanged pitch.
+At 1× the original PCM bypasses processing. A continuous processor spans scheduling
+chunks; final lookahead is drained and output is trimmed to the expected duration.
+Source audio and exports stay original.
+
+Vendored unmodified sources: waywardgeek/sonic at `b93885d`, under Apache 2.0; the
+license is beside the sources. Sonic's Float API internally uses 16-bit samples.
+The wrapper clamps non-unity inputs to [-1, 1] before conversion to prevent integer
+overflow. This precision tradeoff is part of the experiment, not hidden behind
+an assertion that every engine uses identical internal arithmetic.
+
+Run `swift test --package-path Packages/PlaybackDSP -c release` for DSP tests, then
+`./Scripts/build-app.sh` for the local app. Compare the same voice/text and keep
+native Speaking Pace at Natural. Test 0.5, 0.75, 1, 1.25, 1.5 and 2×, including
+mid-sentence rate changes, pause/resume, seek, progressive generation, and replay.
+This is a listening experiment, not a claim of perceptual superiority.
+
+To render a saved speech file at every comparison speed, run
+`swift run -c release --package-path Packages/PlaybackDSP PlaybackDSPRender input.wav output-directory`.
+Use a fresh output directory for each engine. The CSV reports sample counts and
+DSP processing time; the six WAV files can be compared directly. No audio or
+measurements are uploaded. Only run one comparison app at a time; the variants
+share the local app identity and settings.

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/TimeStretch.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/TimeStretch.cpp
@@ -1,0 +1,80 @@
+#include "TimeStretch.h"
+#include "vendor/sonic.h"
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+struct Stream {
+    sonicStream sonic;
+    double rate, sampleRate;
+    int64_t inputFrames = 0, deliveredFrames = 0;
+    bool finished = false;
+    std::vector<float> pending, output;
+
+    Stream(double sampleRate, double rate) : rate(rate), sampleRate(sampleRate) {
+        sonic = sonicCreateStream(int(sampleRate), 1);
+        if (!sonic) throw std::bad_alloc();
+        sonicSetSpeed(sonic, float(rate));
+        sonicSetPitch(sonic, 1);
+        sonicSetRate(sonic, 1);
+        sonicSetVolume(sonic, 1);
+        sonicSetQuality(sonic, 1);
+    }
+    ~Stream() { sonicDestroyStream(sonic); }
+
+    void process(const float *input, int count, bool final) {
+        if (finished) throw std::runtime_error("Stream already finalized");
+        output.clear();
+        inputFrames += count;
+        auto expected = std::llround(inputFrames / rate);
+        if (rate == 1) {
+            if (count) output.assign(input, input + count);
+            deliveredFrames += count;
+        } else {
+            // Sonic's upstream Float API converts internally to signed 16-bit.
+            // Clamp before that conversion to prevent overflow for hot PCM.
+            std::vector<float> bounded(count);
+            for (int i = 0; i < count; ++i) bounded[i] = std::clamp(input[i], -1.0f, 1.0f);
+            if (!sonicWriteFloatToStream(sonic, bounded.data(), count)) throw std::bad_alloc();
+            if (final) {
+                // Supply lookahead before flushing and crop to the cumulative
+                // target, avoiding per-chunk rounding and a clipped final phoneme.
+                std::vector<float> padding(int(std::ceil(sampleRate * 0.2)), 0);
+                if (!sonicWriteFloatToStream(sonic, padding.data(), int(padding.size()))
+                    || !sonicFlushStream(sonic)) throw std::bad_alloc();
+            }
+            int available = sonicSamplesAvailable(sonic);
+            auto offset = pending.size();
+            pending.resize(offset + available);
+            if (available && sonicReadFloatFromStream(sonic, pending.data() + offset, available) != available)
+                throw std::runtime_error("Incomplete read");
+            auto keep = std::min<int64_t>(pending.size(), expected - deliveredFrames);
+            output.assign(pending.begin(), pending.begin() + keep);
+            pending.erase(pending.begin(), pending.begin() + keep);
+            deliveredFrames += keep;
+            if (final && deliveredFrames != expected) throw std::runtime_error("Incomplete tail");
+        }
+        finished = final;
+    }
+};
+}
+extern "C" void *sayit_stretch_create(double sampleRate, double rate) {
+    if (!std::isfinite(sampleRate) || sampleRate < 8000 || sampleRate > 192000
+        || !std::isfinite(rate) || rate < 0.5 || rate > 2) return nullptr;
+    try { return new Stream(sampleRate, rate); } catch (...) { return nullptr; }
+}
+extern "C" void sayit_stretch_destroy(void *handle) { delete static_cast<Stream *>(handle); }
+extern "C" const float *sayit_stretch_process(void *handle, const float *input, int count,
+                                             int final, int *outputCount) {
+    *outputCount = -1;
+    if (!handle || count < 0 || (count && !input)) return nullptr;
+    try {
+        auto &stream = *static_cast<Stream *>(handle);
+        stream.process(input, count, final != 0);
+        *outputCount = int(stream.output.size());
+        return stream.output.data();
+    } catch (...) { return nullptr; }
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/include/TimeStretch.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/include/TimeStretch.h
@@ -1,0 +1,15 @@
+#ifndef SAYIT_TIME_STRETCH_H
+#define SAYIT_TIME_STRETCH_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Each handle belongs to one serial processing context. No audio callback work.
+void *sayit_stretch_create(double sample_rate, double playback_rate);
+void sayit_stretch_destroy(void *handle);
+// Output is owned by handle until the next call. A negative count signals failure.
+const float *sayit_stretch_process(void *handle, const float *input, int count,
+                                  int final, int *output_count);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/LICENSE
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/sonic.c
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/sonic.c
@@ -1,0 +1,1247 @@
+/* Sonic library
+   Copyright 2010
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+#include "sonic.h"
+
+#include <limits.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+    The following code was used to generate the following sinc lookup table.
+
+    #include <limits.h>
+    #include <math.h>
+    #include <stdio.h>
+
+    double findHannWeight(int N, double x) {
+        return 0.5*(1.0 - cos(2*M_PI*x/N));
+    }
+
+    double findSincCoefficient(int N, double x) {
+        double hannWindowWeight = findHannWeight(N, x);
+        double sincWeight;
+
+        x -= N/2.0;
+        if (x > 1e-9 || x < -1e-9) {
+            sincWeight = sin(M_PI*x)/(M_PI*x);
+        } else {
+            sincWeight = 1.0;
+        }
+        return hannWindowWeight*sincWeight;
+    }
+
+    int main() {
+        double x;
+        int i;
+        int N = 12;
+
+        for (i = 0, x = 0.0; x <= N; x += 0.02, i++) {
+            printf("%u %d\n", i, (int)(SHRT_MAX*findSincCoefficient(N, x)));
+        }
+        return 0;
+    }
+*/
+
+#define CLAMP(val, min, max) \
+  ((val) < (min) ? (min) : (val) > (max) ? (max) : (val))
+
+/* The number of points to use in the sinc FIR filter for resampling. */
+#define SINC_FILTER_POINTS \
+  12 /* I am not able to hear improvement with higher N. */
+#define SINC_TABLE_SIZE 601
+
+/* Lookup table for windowed sinc function of SINC_FILTER_POINTS points. */
+static short sincTable[SINC_TABLE_SIZE] = {
+    0,     0,     0,     0,     0,     0,     0,     -1,    -1,    -2,    -2,
+    -3,    -4,    -6,    -7,    -9,    -10,   -12,   -14,   -17,   -19,   -21,
+    -24,   -26,   -29,   -32,   -34,   -37,   -40,   -42,   -44,   -47,   -48,
+    -50,   -51,   -52,   -53,   -53,   -53,   -52,   -50,   -48,   -46,   -43,
+    -39,   -34,   -29,   -22,   -16,   -8,    0,     9,     19,    29,    41,
+    53,    65,    79,    92,    107,   121,   137,   152,   168,   184,   200,
+    215,   231,   247,   262,   276,   291,   304,   317,   328,   339,   348,
+    357,   363,   369,   372,   374,   375,   373,   369,   363,   355,   345,
+    332,   318,   300,   281,   259,   234,   208,   178,   147,   113,   77,
+    39,    0,     -41,   -85,   -130,  -177,  -225,  -274,  -324,  -375,  -426,
+    -478,  -530,  -581,  -632,  -682,  -731,  -779,  -825,  -870,  -912,  -951,
+    -989,  -1023, -1053, -1080, -1104, -1123, -1138, -1149, -1154, -1155, -1151,
+    -1141, -1125, -1105, -1078, -1046, -1007, -963,  -913,  -857,  -796,  -728,
+    -655,  -576,  -492,  -403,  -309,  -210,  -107,  0,     111,   225,   342,
+    462,   584,   708,   833,   958,   1084,  1209,  1333,  1455,  1575,  1693,
+    1807,  1916,  2022,  2122,  2216,  2304,  2384,  2457,  2522,  2579,  2625,
+    2663,  2689,  2706,  2711,  2705,  2687,  2657,  2614,  2559,  2491,  2411,
+    2317,  2211,  2092,  1960,  1815,  1658,  1489,  1308,  1115,  912,   698,
+    474,   241,   0,     -249,  -506,  -769,  -1037, -1310, -1586, -1864, -2144,
+    -2424, -2703, -2980, -3254, -3523, -3787, -4043, -4291, -4529, -4757, -4972,
+    -5174, -5360, -5531, -5685, -5819, -5935, -6029, -6101, -6150, -6175, -6175,
+    -6149, -6096, -6015, -5905, -5767, -5599, -5401, -5172, -4912, -4621, -4298,
+    -3944, -3558, -3141, -2693, -2214, -1705, -1166, -597,  0,     625,   1277,
+    1955,  2658,  3386,  4135,  4906,  5697,  6506,  7332,  8173,  9027,  9893,
+    10769, 11654, 12544, 13439, 14335, 15232, 16128, 17019, 17904, 18782, 19649,
+    20504, 21345, 22170, 22977, 23763, 24527, 25268, 25982, 26669, 27327, 27953,
+    28547, 29107, 29632, 30119, 30569, 30979, 31349, 31678, 31964, 32208, 32408,
+    32565, 32677, 32744, 32767, 32744, 32677, 32565, 32408, 32208, 31964, 31678,
+    31349, 30979, 30569, 30119, 29632, 29107, 28547, 27953, 27327, 26669, 25982,
+    25268, 24527, 23763, 22977, 22170, 21345, 20504, 19649, 18782, 17904, 17019,
+    16128, 15232, 14335, 13439, 12544, 11654, 10769, 9893,  9027,  8173,  7332,
+    6506,  5697,  4906,  4135,  3386,  2658,  1955,  1277,  625,   0,     -597,
+    -1166, -1705, -2214, -2693, -3141, -3558, -3944, -4298, -4621, -4912, -5172,
+    -5401, -5599, -5767, -5905, -6015, -6096, -6149, -6175, -6175, -6150, -6101,
+    -6029, -5935, -5819, -5685, -5531, -5360, -5174, -4972, -4757, -4529, -4291,
+    -4043, -3787, -3523, -3254, -2980, -2703, -2424, -2144, -1864, -1586, -1310,
+    -1037, -769,  -506,  -249,  0,     241,   474,   698,   912,   1115,  1308,
+    1489,  1658,  1815,  1960,  2092,  2211,  2317,  2411,  2491,  2559,  2614,
+    2657,  2687,  2705,  2711,  2706,  2689,  2663,  2625,  2579,  2522,  2457,
+    2384,  2304,  2216,  2122,  2022,  1916,  1807,  1693,  1575,  1455,  1333,
+    1209,  1084,  958,   833,   708,   584,   462,   342,   225,   111,   0,
+    -107,  -210,  -309,  -403,  -492,  -576,  -655,  -728,  -796,  -857,  -913,
+    -963,  -1007, -1046, -1078, -1105, -1125, -1141, -1151, -1155, -1154, -1149,
+    -1138, -1123, -1104, -1080, -1053, -1023, -989,  -951,  -912,  -870,  -825,
+    -779,  -731,  -682,  -632,  -581,  -530,  -478,  -426,  -375,  -324,  -274,
+    -225,  -177,  -130,  -85,   -41,   0,     39,    77,    113,   147,   178,
+    208,   234,   259,   281,   300,   318,   332,   345,   355,   363,   369,
+    373,   375,   374,   372,   369,   363,   357,   348,   339,   328,   317,
+    304,   291,   276,   262,   247,   231,   215,   200,   184,   168,   152,
+    137,   121,   107,   92,    79,    65,    53,    41,    29,    19,    9,
+    0,     -8,    -16,   -22,   -29,   -34,   -39,   -43,   -46,   -48,   -50,
+    -52,   -53,   -53,   -53,   -52,   -51,   -50,   -48,   -47,   -44,   -42,
+    -40,   -37,   -34,   -32,   -29,   -26,   -24,   -21,   -19,   -17,   -14,
+    -12,   -10,   -9,    -7,    -6,    -4,    -3,    -2,    -2,    -1,    -1,
+    0,     0,     0,     0,     0,     0,     0};
+
+/* These functions allocate out of a static array rather than calling
+   calloc/realloc/free if the NO_MALLOC flag is defined.  Otherwise, call
+   calloc/realloc/free as usual.  This is useful for running on small
+   microcontrollers. */
+#ifndef SONIC_NO_MALLOC
+
+/* Just call calloc. */
+static void* sonicCalloc(int num, int size) { return calloc(num, size); }
+
+/* Just call realloc */
+static void* sonicRealloc(void* p, int oldNum, int newNum, int size) {
+  return realloc(p, newNum * size);
+}
+
+/* Just call free. */
+static void sonicFree(void* p) { free(p); }
+
+#else
+
+#ifndef SONIC_MAX_MEMORY
+/* Large enough for speedup/slowdown at 8KHz, 16-bit mono samples/second. */
+#define SONIC_MAX_MEMORY (16 * 1024)
+#endif
+
+/* This static buffer is used to hold data allocated for the sonicStream struct
+   and its buffers.  There should never be more than one sonicStream in use at a
+   time when using SONIC_NO_MALLOC mode.  Calls to realloc move the data to the
+   end of memoryBuffer.  Calls to free reset the memory buffer to empty. */
+static void*
+    memoryBufferAligned[(SONIC_MAX_MEMORY + sizeof(void) - 1) / sizeof(void*)];
+static unsigned char* memoryBuffer = (unsigned char*)memoryBufferAligned;
+static int memoryBufferPos = 0;
+
+/* Allocate elements from a static memory buffer. */
+static void* sonicCalloc(int num, int size) {
+  int len = num * size;
+
+  if (memoryBufferPos + len > SONIC_MAX_MEMORY) {
+    return 0;
+  }
+  unsigned char* p = memoryBuffer + memoryBufferPos;
+  memoryBufferPos += len;
+  memset(p, 0, len);
+  return p;
+}
+
+/* Preferably, SONIC_MAX_MEMORY has been set large enough that this is never
+ * called. */
+static void* sonicRealloc(void* p, int oldNum, int newNum, int size) {
+  if (newNum <= oldNum) {
+    return p;
+  }
+  void* newBuffer = sonicCalloc(newNum, size);
+  if (newBuffer == NULL) {
+    return NULL;
+  }
+  memcpy(newBuffer, p, oldNum * size);
+  return newBuffer;
+}
+
+/* Reset memoryBufferPos to 0.  We asssume all data is freed at the same time.
+ */
+static void sonicFree(void* p) { memoryBufferPos = 0; }
+
+#endif
+
+struct sonicStreamStruct {
+#ifdef SONIC_SPECTROGRAM
+  sonicSpectrogram spectrogram;
+#endif /* SONIC_SPECTROGRAM */
+  short* inputBuffer;
+  short* outputBuffer;
+  short* pitchBuffer;
+  short* downSampleBuffer;
+  void* userData;
+  float speed;
+  float volume;
+  float pitch;
+  float rate;
+  /* The point of the following 3 new variables is to gracefully handle rapidly
+     changing input speed.
+
+     samplePeriod is just 1.0/sampleRate.  It is used in accumulating
+     inputPlayTime, which is how long we expect the total time should be to play
+     the current input samples in the input buffer.  timeError keeps track of
+     the error in play time created when playing < 2.0X speed, where we either
+     insert or delete a whole pitch period.  This can cause the output generated
+     from the input to be off in play time by up to a pitch period.  timeError
+     replaces PICOLA's concept of the number of samples to play unmodified after
+     a pitch period insertion or deletion.  If speeding up, and the error is >=
+     0.0, then remove a pitch period, and play samples unmodified until
+     timeError is >= 0 again.  If slowing down, and the error is <= 0.0,
+     then add a pitch period, and play samples unmodified until timeError is <=
+     0 again. */
+  float samplePeriod; /* How long each output sample takes to play. */
+  /* How long we expect the entire input buffer to take to play. */
+  float inputPlayTime;
+  /* The difference in when the latest output sample was played vs when we
+   * wanted.  */
+  float timeError;
+  int oldRatePosition;
+  int newRatePosition;
+  int quality;
+  int numChannels;
+  int inputBufferSize;
+  int pitchBufferSize;
+  int outputBufferSize;
+  int numInputSamples;
+  int numOutputSamples;
+  int numPitchSamples;
+  int minPeriod;
+  int maxPeriod;
+  int maxRequired;
+  int remainingInputToCopy;
+  int sampleRate;
+  int prevPeriod;
+  int prevMinDiff;
+};
+
+/* Attach user data to the stream. */
+void sonicSetUserData(sonicStream stream, void* userData) {
+  stream->userData = userData;
+}
+
+/* Retrieve user data attached to the stream. */
+void* sonicGetUserData(sonicStream stream) { return stream->userData; }
+
+#ifdef SONIC_SPECTROGRAM
+
+/* Compute a spectrogram on the fly. */
+void sonicComputeSpectrogram(sonicStream stream) {
+  stream->spectrogram = sonicCreateSpectrogram(stream->sampleRate);
+  /* Force changeSpeed to be called to compute the spectrogram. */
+  sonicSetSpeed(stream, 2.0);
+}
+
+/* Get the spectrogram. */
+sonicSpectrogram sonicGetSpectrogram(sonicStream stream) {
+  return stream->spectrogram;
+}
+
+#endif
+
+/* Scale the samples by the factor. */
+static void scaleSamples(short* samples, int numSamples, float volume) {
+  /* This is 24-bit integer and 8-bit fraction fixed-point representation. */
+  int fixedPointVolume = volume * 256.0f;
+  int value;
+
+  while (numSamples--) {
+    value = (*samples * fixedPointVolume) >> 8;
+    if (value > 32767) {
+      value = 32767;
+    } else if (value < -32767) {
+      value = -32767;
+    }
+    *samples++ = value;
+  }
+}
+
+/* Get the speed of the stream. */
+float sonicGetSpeed(sonicStream stream) { return stream->speed; }
+
+/* Set the speed of the stream. */
+void sonicSetSpeed(sonicStream stream, float speed) {
+  stream->speed = CLAMP(speed, SONIC_MIN_SPEED, SONIC_MAX_SPEED);
+}
+
+/* Get the pitch of the stream. */
+float sonicGetPitch(sonicStream stream) { return stream->pitch; }
+
+/* Set the pitch of the stream. */
+void sonicSetPitch(sonicStream stream, float pitch) {
+  stream->pitch = CLAMP(pitch, SONIC_MIN_PITCH_SETTING, SONIC_MAX_PITCH_SETTING);
+}
+
+/* Get the rate of the stream. */
+float sonicGetRate(sonicStream stream) { return stream->rate; }
+
+/* Set the playback rate of the stream. This scales pitch and speed at the same
+   time. */
+void sonicSetRate(sonicStream stream, float rate) {
+  stream->rate = CLAMP(rate, SONIC_MIN_RATE, SONIC_MAX_RATE);
+
+  stream->oldRatePosition = 0;
+  stream->newRatePosition = 0;
+}
+
+/* DEPRECATED.  Get the vocal chord pitch setting. */
+int sonicGetChordPitch(sonicStream stream) { return 0; }
+
+/* DEPRECATED. Set the vocal chord mode for pitch computation.  Default is off.
+ */
+void sonicSetChordPitch(sonicStream stream, int useChordPitch) {}
+
+/* Get the quality setting. */
+int sonicGetQuality(sonicStream stream) { return stream->quality; }
+
+/* Set the "quality".  Default 0 is virtually as good as 1, but very much
+   faster. */
+void sonicSetQuality(sonicStream stream, int quality) {
+  stream->quality = quality != 0? 1 : 0;
+}
+
+/* Get the scaling factor of the stream. */
+float sonicGetVolume(sonicStream stream) { return stream->volume; }
+
+/* Set the scaling factor of the stream. */
+void sonicSetVolume(sonicStream stream, float volume) {
+  stream->volume = CLAMP(volume, SONIC_MIN_VOLUME, SONIC_MAX_VOLUME);
+}
+
+/* Free stream buffers. */
+static void freeStreamBuffers(sonicStream stream) {
+  if (stream->inputBuffer != NULL) {
+    sonicFree(stream->inputBuffer);
+  }
+  if (stream->outputBuffer != NULL) {
+    sonicFree(stream->outputBuffer);
+  }
+  if (stream->pitchBuffer != NULL) {
+    sonicFree(stream->pitchBuffer);
+  }
+  if (stream->downSampleBuffer != NULL) {
+    sonicFree(stream->downSampleBuffer);
+  }
+}
+
+/* Destroy the sonic stream. */
+void sonicDestroyStream(sonicStream stream) {
+#ifdef SONIC_SPECTROGRAM
+  if (stream->spectrogram != NULL) {
+    sonicDestroySpectrogram(stream->spectrogram);
+  }
+#endif /* SONIC_SPECTROGRAM */
+  freeStreamBuffers(stream);
+  sonicFree(stream);
+}
+
+/* Compute the number of samples to skip to down-sample the input. */
+static int computeSkip(sonicStream stream, int sampleRate) {
+  int skip = 1;
+  if (sampleRate > SONIC_AMDF_FREQ && stream->quality == 0) {
+    skip = sampleRate / SONIC_AMDF_FREQ;
+  }
+  return skip;
+}
+
+/* Allocate stream buffers. */
+static int allocateStreamBuffers(sonicStream stream, int sampleRate,
+                                 int numChannels) {
+  int minPeriod = sampleRate / SONIC_MAX_PITCH;
+  int maxPeriod = sampleRate / SONIC_MIN_PITCH;
+  int maxRequired = 2 * maxPeriod;
+
+  /* Allocate 25% more than needed so we hopefully won't grow. */
+  stream->inputBufferSize = maxRequired + (maxRequired >> 2);
+
+  stream->inputBuffer =
+      (short*)sonicCalloc(stream->inputBufferSize, sizeof(short) * numChannels);
+  if (stream->inputBuffer == NULL) {
+    sonicDestroyStream(stream);
+    return 0;
+  }
+  /* Allocate 25% more than needed so we hopefully won't grow. */
+  stream->outputBufferSize = maxRequired + (maxRequired >> 2);
+  stream->outputBuffer = (short*)sonicCalloc(stream->outputBufferSize,
+                                             sizeof(short) * numChannels);
+  if (stream->outputBuffer == NULL) {
+    sonicDestroyStream(stream);
+    return 0;
+  }
+  /* Allocate 25% more than needed so we hopefully won't grow. */
+  stream->pitchBufferSize = maxRequired + (maxRequired >> 2);
+  stream->pitchBuffer =
+      (short*)sonicCalloc(stream->pitchBufferSize, sizeof(short) * numChannels);
+  if (stream->pitchBuffer == NULL) {
+    sonicDestroyStream(stream);
+    return 0;
+  }
+  int downSampleBufferSize = maxRequired;
+  stream->downSampleBuffer =
+      (short*)sonicCalloc(downSampleBufferSize, sizeof(short));
+  if (stream->downSampleBuffer == NULL) {
+    sonicDestroyStream(stream);
+    return 0;
+  }
+  stream->sampleRate = sampleRate;
+  stream->samplePeriod = 1.0 / sampleRate;
+  stream->numChannels = numChannels;
+  stream->oldRatePosition = 0;
+  stream->newRatePosition = 0;
+  stream->minPeriod = minPeriod;
+  stream->maxPeriod = maxPeriod;
+  stream->maxRequired = maxRequired;
+  stream->prevPeriod = 0;
+  return 1;
+}
+
+/* Create a sonic stream.  Return NULL only if we are out of memory and cannot
+   allocate the stream. */
+sonicStream sonicCreateStream(int sampleRate, int numChannels) {
+  sonicStream stream =
+      (sonicStream)sonicCalloc(1, sizeof(struct sonicStreamStruct));
+
+  sampleRate = CLAMP(sampleRate, SONIC_MIN_SAMPLE_RATE, SONIC_MAX_SAMPLE_RATE);
+  numChannels = CLAMP(numChannels, SONIC_MIN_CHANNELS, SONIC_MAX_CHANNELS);
+  if (stream == NULL) {
+    return NULL;
+  }
+  if (!allocateStreamBuffers(stream, sampleRate, numChannels)) {
+    return NULL;
+  }
+  stream->speed = 1.0f;
+  stream->pitch = 1.0f;
+  stream->volume = 1.0f;
+  stream->rate = 1.0f;
+  stream->oldRatePosition = 0;
+  stream->newRatePosition = 0;
+  stream->quality = 0;
+  return stream;
+}
+
+/* Get the sample rate of the stream. */
+int sonicGetSampleRate(sonicStream stream) { return stream->sampleRate; }
+
+/* Set the sample rate of the stream.  This will cause samples buffered in the
+   stream to be lost. */
+void sonicSetSampleRate(sonicStream stream, int sampleRate) {
+  sampleRate = CLAMP(sampleRate, SONIC_MIN_SAMPLE_RATE, SONIC_MAX_SAMPLE_RATE);
+  freeStreamBuffers(stream);
+  allocateStreamBuffers(stream, sampleRate, stream->numChannels);
+}
+
+/* Get the number of channels. */
+int sonicGetNumChannels(sonicStream stream) { return stream->numChannels; }
+
+/* Set the num channels of the stream.  This will cause samples buffered in the
+   stream to be lost. */
+void sonicSetNumChannels(sonicStream stream, int numChannels) {
+  numChannels = CLAMP(numChannels, SONIC_MIN_CHANNELS, SONIC_MAX_CHANNELS);
+  freeStreamBuffers(stream);
+  allocateStreamBuffers(stream, stream->sampleRate, numChannels);
+}
+
+/* Enlarge the output buffer if needed. */
+static int enlargeOutputBufferIfNeeded(sonicStream stream, int numSamples) {
+  int outputBufferSize = stream->outputBufferSize;
+
+  if (stream->numOutputSamples + numSamples > outputBufferSize) {
+    stream->outputBufferSize += (outputBufferSize >> 1) + numSamples;
+    stream->outputBuffer = (short*)sonicRealloc(
+        stream->outputBuffer, outputBufferSize, stream->outputBufferSize,
+        sizeof(short) * stream->numChannels);
+    if (stream->outputBuffer == NULL) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+/* Enlarge the input buffer if needed. */
+static int enlargeInputBufferIfNeeded(sonicStream stream, int numSamples) {
+  int inputBufferSize = stream->inputBufferSize;
+
+  if (stream->numInputSamples + numSamples > inputBufferSize) {
+    stream->inputBufferSize += (inputBufferSize >> 1) + numSamples;
+    stream->inputBuffer = (short*)sonicRealloc(
+        stream->inputBuffer, inputBufferSize, stream->inputBufferSize,
+        sizeof(short) * stream->numChannels);
+    if (stream->inputBuffer == NULL) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+/* Update stream->numInputSamples, and update stream->inputPlayTime.  Call this
+   whenever adding samples to the input buffer, to keep track of total expected
+   input play time accounting. */
+static void updateNumInputSamples(sonicStream stream, int numSamples) {
+  float speed = stream->speed / stream->pitch;
+
+  stream->numInputSamples += numSamples;
+  stream->inputPlayTime += numSamples * stream->samplePeriod / speed;
+}
+
+/* Add the input samples to the input buffer. */
+static int addFloatSamplesToInputBuffer(sonicStream stream,
+                                        const float* samples, int numSamples) {
+  short* buffer;
+  int count = numSamples * stream->numChannels;
+
+  if (numSamples == 0) {
+    return 1;
+  }
+  if (!enlargeInputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  buffer = stream->inputBuffer + stream->numInputSamples * stream->numChannels;
+  while (count--) {
+    *buffer++ = (*samples++) * 32767.0f;
+  }
+  updateNumInputSamples(stream, numSamples);
+  return 1;
+}
+
+/* Add the input samples to the input buffer. */
+static int addShortSamplesToInputBuffer(sonicStream stream,
+                                        const short* samples, int numSamples) {
+  if (numSamples == 0) {
+    return 1;
+  }
+  if (!enlargeInputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  memcpy(stream->inputBuffer + stream->numInputSamples * stream->numChannels,
+         samples, numSamples * sizeof(short) * stream->numChannels);
+  updateNumInputSamples(stream, numSamples);
+  return 1;
+}
+
+/* Add the input samples to the input buffer. */
+static int addUnsignedCharSamplesToInputBuffer(sonicStream stream,
+                                               const unsigned char* samples,
+                                               int numSamples) {
+  short* buffer;
+  int count = numSamples * stream->numChannels;
+
+  if (numSamples == 0) {
+    return 1;
+  }
+  if (!enlargeInputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  buffer = stream->inputBuffer + stream->numInputSamples * stream->numChannels;
+  while (count--) {
+    *buffer++ = (*samples++ - 128) << 8;
+  }
+  updateNumInputSamples(stream, numSamples);
+  return 1;
+}
+
+/* Remove input samples that we have already processed. */
+static void removeInputSamples(sonicStream stream, int position) {
+  int remainingSamples = stream->numInputSamples - position;
+
+  if (remainingSamples > 0) {
+    memmove(stream->inputBuffer,
+            stream->inputBuffer + position * stream->numChannels,
+            remainingSamples * sizeof(short) * stream->numChannels);
+  }
+  /* If we play 3/4ths of the samples, then the expected play time of the
+     remaining samples is 1/4th of the original expected play time. */
+  stream->inputPlayTime =
+      (stream->inputPlayTime * remainingSamples) / stream->numInputSamples;
+  stream->numInputSamples = remainingSamples;
+}
+
+/* Copy from the input buffer to the output buffer, and remove the samples from
+   the input buffer. */
+static int copyInputToOutput(sonicStream stream, int numSamples) {
+  if (!enlargeOutputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  memcpy(stream->outputBuffer + stream->numOutputSamples * stream->numChannels,
+         stream->inputBuffer, numSamples * sizeof(short) * stream->numChannels);
+  stream->numOutputSamples += numSamples;
+  removeInputSamples(stream, numSamples);
+  return 1;
+}
+
+/* Copy from samples to the output buffer */
+static int copyToOutput(sonicStream stream, short* samples, int numSamples) {
+  if (!enlargeOutputBufferIfNeeded(stream, numSamples)) {
+    return 0;
+  }
+  memcpy(stream->outputBuffer + stream->numOutputSamples * stream->numChannels,
+         samples, numSamples * sizeof(short) * stream->numChannels);
+  stream->numOutputSamples += numSamples;
+  return 1;
+}
+
+/* Read data out of the stream.  Sometimes no data will be available, and zero
+   is returned, which is not an error condition. */
+int sonicReadFloatFromStream(sonicStream stream, float* samples,
+                             int maxSamples) {
+  int numSamples = stream->numOutputSamples;
+  int remainingSamples = 0;
+  short* buffer;
+  int count;
+
+  if (numSamples == 0) {
+    return 0;
+  }
+  if (numSamples > maxSamples) {
+    remainingSamples = numSamples - maxSamples;
+    numSamples = maxSamples;
+  }
+  buffer = stream->outputBuffer;
+  count = numSamples * stream->numChannels;
+  while (count--) {
+    *samples++ = (*buffer++) / 32767.0f;
+  }
+  if (remainingSamples > 0) {
+    memmove(stream->outputBuffer,
+            stream->outputBuffer + numSamples * stream->numChannels,
+            remainingSamples * sizeof(short) * stream->numChannels);
+  }
+  stream->numOutputSamples = remainingSamples;
+  return numSamples;
+}
+
+/* Read short data out of the stream.  Sometimes no data will be available, and
+   zero is returned, which is not an error condition. */
+int sonicReadShortFromStream(sonicStream stream, short* samples,
+                             int maxSamples) {
+  int numSamples = stream->numOutputSamples;
+  int remainingSamples = 0;
+
+  if (numSamples == 0) {
+    return 0;
+  }
+  if (numSamples > maxSamples) {
+    remainingSamples = numSamples - maxSamples;
+    numSamples = maxSamples;
+  }
+  memcpy(samples, stream->outputBuffer,
+         numSamples * sizeof(short) * stream->numChannels);
+  if (remainingSamples > 0) {
+    memmove(stream->outputBuffer,
+            stream->outputBuffer + numSamples * stream->numChannels,
+            remainingSamples * sizeof(short) * stream->numChannels);
+  }
+  stream->numOutputSamples = remainingSamples;
+  return numSamples;
+}
+
+/* Read unsigned char data out of the stream.  Sometimes no data will be
+   available, and zero is returned, which is not an error condition. */
+int sonicReadUnsignedCharFromStream(sonicStream stream, unsigned char* samples,
+                                    int maxSamples) {
+  int numSamples = stream->numOutputSamples;
+  int remainingSamples = 0;
+  short* buffer;
+  int count;
+
+  if (numSamples == 0) {
+    return 0;
+  }
+  if (numSamples > maxSamples) {
+    remainingSamples = numSamples - maxSamples;
+    numSamples = maxSamples;
+  }
+  buffer = stream->outputBuffer;
+  count = numSamples * stream->numChannels;
+  while (count--) {
+    *samples++ = (char)((*buffer++) >> 8) + 128;
+  }
+  if (remainingSamples > 0) {
+    memmove(stream->outputBuffer,
+            stream->outputBuffer + numSamples * stream->numChannels,
+            remainingSamples * sizeof(short) * stream->numChannels);
+  }
+  stream->numOutputSamples = remainingSamples;
+  return numSamples;
+}
+
+/* Force the sonic stream to generate output using whatever data it currently
+   has.  No extra delay will be added to the output, but flushing in the middle
+   of words could introduce distortion. */
+int sonicFlushStream(sonicStream stream) {
+  int maxRequired = stream->maxRequired;
+  int remainingSamples = stream->numInputSamples;
+  float speed = stream->speed / stream->pitch;
+  float rate = stream->rate * stream->pitch;
+  int expectedOutputSamples =
+      stream->numOutputSamples +
+      (int)((remainingSamples / speed + stream->numPitchSamples) / rate + 0.5f);
+
+  /* Add enough silence to flush both input and pitch buffers. */
+  if (!enlargeInputBufferIfNeeded(stream, remainingSamples + 2 * maxRequired)) {
+    return 0;
+  }
+  memset(stream->inputBuffer + remainingSamples * stream->numChannels, 0,
+         2 * maxRequired * sizeof(short) * stream->numChannels);
+  stream->numInputSamples += 2 * maxRequired;
+  if (!sonicWriteShortToStream(stream, NULL, 0)) {
+    return 0;
+  }
+  /* Throw away any extra samples we generated due to the silence we added */
+  if (stream->numOutputSamples > expectedOutputSamples) {
+    stream->numOutputSamples = expectedOutputSamples;
+  }
+  /* Empty input and pitch buffers */
+  stream->numInputSamples = 0;
+  stream->inputPlayTime = 0.0f;
+  stream->timeError = 0.0f;
+  stream->numPitchSamples = 0;
+  return 1;
+}
+
+/* Return the number of samples in the output buffer */
+int sonicSamplesAvailable(sonicStream stream) {
+  return stream->numOutputSamples;
+}
+
+/* If skip is greater than one, average skip samples together and write them to
+   the down-sample buffer.  If numChannels is greater than one, mix the channels
+   together as we down sample. */
+static void downSampleInput(sonicStream stream, short* samples, int skip) {
+  int numSamples = stream->maxRequired / skip;
+  int samplesPerValue = stream->numChannels * skip;
+  int i, j;
+  int value;
+  short* downSamples = stream->downSampleBuffer;
+
+  for (i = 0; i < numSamples; i++) {
+    value = 0;
+    for (j = 0; j < samplesPerValue; j++) {
+      value += *samples++;
+    }
+    value /= samplesPerValue;
+    *downSamples++ = value;
+  }
+}
+
+/* Find the best frequency match in the range, and given a sample skip multiple.
+   For now, just find the pitch of the first channel. */
+static int findPitchPeriodInRange(short* samples, int minPeriod, int maxPeriod,
+                                  int* retMinDiff, int* retMaxDiff) {
+  int period, bestPeriod = 0, worstPeriod = 255;
+  short* s;
+  short* p;
+  short sVal, pVal;
+  unsigned long diff, minDiff = 1, maxDiff = 0;
+  int i;
+
+  for (period = minPeriod; period <= maxPeriod; period++) {
+    diff = 0;
+    s = samples;
+    p = samples + period;
+    for (i = 0; i < period; i++) {
+      sVal = *s++;
+      pVal = *p++;
+      diff += sVal >= pVal ? (unsigned short)(sVal - pVal)
+                           : (unsigned short)(pVal - sVal);
+    }
+    /* Note that the highest number of samples we add into diff will be less
+       than 256, since we skip samples.  Thus, diff is a 24 bit number, and
+       we can safely multiply by numSamples without overflow */
+    if (bestPeriod == 0 || diff * bestPeriod < minDiff * period) {
+      minDiff = diff;
+      bestPeriod = period;
+    }
+    if (diff * worstPeriod > maxDiff * period) {
+      maxDiff = diff;
+      worstPeriod = period;
+    }
+  }
+  *retMinDiff = minDiff / bestPeriod;
+  *retMaxDiff = maxDiff / worstPeriod;
+  return bestPeriod;
+}
+
+/* At abrupt ends of voiced words, we can have pitch periods that are better
+   approximated by the previous pitch period estimate.  Try to detect this case.
+ */
+static int prevPeriodBetter(sonicStream stream, int minDiff, int maxDiff,
+                            int preferNewPeriod) {
+  if (minDiff == 0 || stream->prevPeriod == 0) {
+    return 0;
+  }
+  if (preferNewPeriod) {
+    if (maxDiff > minDiff * 3) {
+      /* Got a reasonable match this period */
+      return 0;
+    }
+    if (minDiff * 2 <= stream->prevMinDiff * 3) {
+      /* Mismatch is not that much greater this period */
+      return 0;
+    }
+  } else {
+    if (minDiff <= stream->prevMinDiff) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+/* Find the pitch period.  This is a critical step, and we may have to try
+   multiple ways to get a good answer.  This version uses Average Magnitude
+   Difference Function (AMDF).  To improve speed, we down sample by an integer
+   factor get in the 11KHz range, and then do it again with a narrower
+   frequency range without down sampling */
+static int findPitchPeriod(sonicStream stream, short* samples,
+                           int preferNewPeriod) {
+  int minPeriod = stream->minPeriod;
+  int maxPeriod = stream->maxPeriod;
+  int minDiff, maxDiff, retPeriod;
+  int skip = computeSkip(stream, stream->sampleRate);
+  int period;
+
+  if (stream->numChannels == 1 && skip == 1) {
+    period = findPitchPeriodInRange(samples, minPeriod, maxPeriod, &minDiff,
+                                    &maxDiff);
+  } else {
+    downSampleInput(stream, samples, skip);
+    period = findPitchPeriodInRange(stream->downSampleBuffer, minPeriod / skip,
+                                    maxPeriod / skip, &minDiff, &maxDiff);
+    if (skip != 1) {
+      period *= skip;
+      minPeriod = period - (skip << 2);
+      maxPeriod = period + (skip << 2);
+      if (minPeriod < stream->minPeriod) {
+        minPeriod = stream->minPeriod;
+      }
+      if (maxPeriod > stream->maxPeriod) {
+        maxPeriod = stream->maxPeriod;
+      }
+      if (stream->numChannels == 1) {
+        period = findPitchPeriodInRange(samples, minPeriod, maxPeriod, &minDiff,
+                                        &maxDiff);
+      } else {
+        downSampleInput(stream, samples, 1);
+        period = findPitchPeriodInRange(stream->downSampleBuffer, minPeriod,
+                                        maxPeriod, &minDiff, &maxDiff);
+      }
+    }
+  }
+  if (prevPeriodBetter(stream, minDiff, maxDiff, preferNewPeriod)) {
+    retPeriod = stream->prevPeriod;
+  } else {
+    retPeriod = period;
+  }
+  stream->prevMinDiff = minDiff;
+  stream->prevPeriod = period;
+  return retPeriod;
+}
+
+/* Overlap two sound segments, ramp the volume of one down, while ramping the
+   other one from zero up, and add them, storing the result at the output. */
+static void overlapAdd(int numSamples, int numChannels, short* out,
+                       short* rampDown, short* rampUp) {
+  short* o;
+  short* u;
+  short* d;
+  int i, t;
+
+  for (i = 0; i < numChannels; i++) {
+    o = out + i;
+    u = rampUp + i;
+    d = rampDown + i;
+    for (t = 0; t < numSamples; t++) {
+#ifdef SONIC_USE_SIN
+      float ratio = sin(t * M_PI / (2 * numSamples));
+      *o = *d * (1.0f - ratio) + *u * ratio;
+#else
+      *o = (*d * (numSamples - t) + *u * t) / numSamples;
+#endif
+      o += numChannels;
+      d += numChannels;
+      u += numChannels;
+    }
+  }
+}
+
+/* Just move the new samples in the output buffer to the pitch buffer */
+static int moveNewSamplesToPitchBuffer(sonicStream stream,
+                                       int originalNumOutputSamples) {
+  int numSamples = stream->numOutputSamples - originalNumOutputSamples;
+  int numChannels = stream->numChannels;
+  int pitchBufferSize = stream->pitchBufferSize;
+
+  if (stream->numPitchSamples + numSamples > pitchBufferSize) {
+    stream->pitchBufferSize += (pitchBufferSize >> 1) + numSamples;
+    stream->pitchBuffer = (short*)sonicRealloc(
+        stream->pitchBuffer, pitchBufferSize, stream->pitchBufferSize,
+        sizeof(short) * numChannels);
+  }
+  memcpy(stream->pitchBuffer + stream->numPitchSamples * numChannels,
+         stream->outputBuffer + originalNumOutputSamples * numChannels,
+         numSamples * sizeof(short) * numChannels);
+  stream->numOutputSamples = originalNumOutputSamples;
+  stream->numPitchSamples += numSamples;
+  return 1;
+}
+
+/* Remove processed samples from the pitch buffer. */
+static void removePitchSamples(sonicStream stream, int numSamples) {
+  int numChannels = stream->numChannels;
+  short* source = stream->pitchBuffer + numSamples * numChannels;
+
+  if (numSamples == 0) {
+    return;
+  }
+  if (numSamples != stream->numPitchSamples) {
+    memmove(
+        stream->pitchBuffer, source,
+        (stream->numPitchSamples - numSamples) * sizeof(short) * numChannels);
+  }
+  stream->numPitchSamples -= numSamples;
+}
+
+/* Approximate the sinc function times a Hann window from the sinc table. */
+static int findSincCoefficient(int i, int ratio, int width) {
+  int lobePoints = (SINC_TABLE_SIZE - 1) / SINC_FILTER_POINTS;
+  int left = i * lobePoints + (ratio * lobePoints) / width;
+  int right = left + 1;
+  int position = i * lobePoints * width + ratio * lobePoints - left * width;
+  int leftVal = sincTable[left];
+  int rightVal = sincTable[right];
+
+  return ((leftVal * (width - position) + rightVal * position) << 1) / width;
+}
+
+/* Return 1 if value >= 0, else -1.  This represents the sign of value. */
+static int getSign(int value) { return value >= 0 ? 1 : -1; }
+
+/* Interpolate the new output sample. */
+static short interpolate(sonicStream stream, short* in, int oldSampleRate,
+                         int newSampleRate) {
+  /* Compute N-point sinc FIR-filter here.  Clip rather than overflow. */
+  int i;
+  int total = 0;
+  int position = stream->newRatePosition * oldSampleRate;
+  int leftPosition = stream->oldRatePosition * newSampleRate;
+  int rightPosition = (stream->oldRatePosition + 1) * newSampleRate;
+  int ratio = rightPosition - position - 1;
+  int width = rightPosition - leftPosition;
+  int weight, value;
+  int oldSign;
+  int overflowCount = 0;
+
+  for (i = 0; i < SINC_FILTER_POINTS; i++) {
+    weight = findSincCoefficient(i, ratio, width);
+    value = in[i * stream->numChannels] * weight;
+    oldSign = getSign(total);
+    total += value;
+    if (oldSign != getSign(total) && getSign(value) == oldSign) {
+      /* We must have overflowed.  This can happen with a sinc filter. */
+      overflowCount += oldSign;
+    }
+  }
+  /* It is better to clip than to wrap if there was a overflow. */
+  if (overflowCount > 0) {
+    return SHRT_MAX;
+  } else if (overflowCount < 0) {
+    return SHRT_MIN;
+  }
+  return total >> 16;
+}
+
+/* Change the rate.  Interpolate with a sinc FIR filter using a Hann window. */
+static int adjustRate(sonicStream stream, float rate,
+                      int originalNumOutputSamples) {
+  int newSampleRate = stream->sampleRate / rate;
+  int oldSampleRate = stream->sampleRate;
+  int numChannels = stream->numChannels;
+  int position;
+  short *in, *out;
+  int i;
+  int N = SINC_FILTER_POINTS;
+
+  /* Set these values to help with the integer math */
+  while (newSampleRate > (1 << 14) || oldSampleRate > (1 << 14)) {
+    newSampleRate >>= 1;
+    oldSampleRate >>= 1;
+  }
+  if (stream->numOutputSamples == originalNumOutputSamples) {
+    return 1;
+  }
+  if (!moveNewSamplesToPitchBuffer(stream, originalNumOutputSamples)) {
+    return 0;
+  }
+  /* Leave at least N pitch sample in the buffer */
+  for (position = 0; position < stream->numPitchSamples - N; position++) {
+    while ((stream->oldRatePosition + 1) * newSampleRate >
+           stream->newRatePosition * oldSampleRate) {
+      if (!enlargeOutputBufferIfNeeded(stream, 1)) {
+        return 0;
+      }
+      out = stream->outputBuffer + stream->numOutputSamples * numChannels;
+      in = stream->pitchBuffer + position * numChannels;
+      for (i = 0; i < numChannels; i++) {
+        *out++ = interpolate(stream, in, oldSampleRate, newSampleRate);
+        in++;
+      }
+      stream->newRatePosition++;
+      stream->numOutputSamples++;
+    }
+    stream->oldRatePosition++;
+    if (stream->oldRatePosition == oldSampleRate) {
+      stream->oldRatePosition = 0;
+      stream->newRatePosition = 0;
+    }
+  }
+  removePitchSamples(stream, position);
+  return 1;
+}
+
+/* Skip over a pitch period.  Return the number of output samples. */
+static int skipPitchPeriod(sonicStream stream, short* samples, float speed,
+                           int period) {
+  long newSamples;
+  int numChannels = stream->numChannels;
+
+  if (speed >= 2.0f) {
+    /* For speeds >= 2.0, we skip over a portion of each pitch period rather
+       than dropping whole pitch periods. */
+    newSamples = period / (speed - 1.0f);
+  } else {
+    newSamples = period;
+  }
+  if (!enlargeOutputBufferIfNeeded(stream, newSamples)) {
+    return 0;
+  }
+  overlapAdd(newSamples, numChannels,
+             stream->outputBuffer + stream->numOutputSamples * numChannels,
+             samples, samples + period * numChannels);
+  stream->numOutputSamples += newSamples;
+  return newSamples;
+}
+
+/* Insert a pitch period, and determine how much input to copy directly. */
+static int insertPitchPeriod(sonicStream stream, short* samples, float speed,
+                             int period) {
+  long newSamples;
+  short* out;
+  int numChannels = stream->numChannels;
+
+  if (speed <= 0.5f) {
+    newSamples = period * speed / (1.0f - speed);
+  } else {
+    newSamples = period;
+  }
+  if (!enlargeOutputBufferIfNeeded(stream, period + newSamples)) {
+    return 0;
+  }
+  out = stream->outputBuffer + stream->numOutputSamples * numChannels;
+  memcpy(out, samples, period * sizeof(short) * numChannels);
+  out =
+      stream->outputBuffer + (stream->numOutputSamples + period) * numChannels;
+  overlapAdd(newSamples, numChannels, out, samples + period * numChannels,
+             samples);
+  stream->numOutputSamples += period + newSamples;
+  return newSamples;
+}
+
+/* PICOLA copies input to output until the total output samples == consumed
+   input samples * speed. */
+static int copyUnmodifiedSamples(sonicStream stream, short* samples,
+                                 float speed, int position, int* newSamples) {
+  int availableSamples = stream->numInputSamples - position;
+  float inputToCopyFloat =
+      1 - stream->timeError * speed / (stream->samplePeriod * (speed - 1.0));
+
+  *newSamples = inputToCopyFloat > availableSamples ? availableSamples
+                                                    : (int)inputToCopyFloat;
+  if (!copyToOutput(stream, samples, *newSamples)) {
+    return 0;
+  }
+  stream->timeError +=
+      *newSamples * stream->samplePeriod * (speed - 1.0) / speed;
+  return 1;
+}
+
+/* Resample as many pitch periods as we have buffered on the input.  Return 0 if
+   we fail to resize an input or output buffer. */
+static int changeSpeed(sonicStream stream, float speed) {
+  short* samples;
+  int numSamples = stream->numInputSamples;
+  int position = 0, period, newSamples;
+  int maxRequired = stream->maxRequired;
+
+  if (stream->numInputSamples < maxRequired) {
+    return 1;
+  }
+  do {
+    samples = stream->inputBuffer + position * stream->numChannels;
+    if ((speed > 1.0f && speed < 2.0f && stream->timeError < 0.0f) ||
+        (speed < 1.0f && speed > 0.5f && stream->timeError > 0.0f)) {
+      /* Deal with the case where PICOLA is still copying input samples to
+         output unmodified, */
+      if (!copyUnmodifiedSamples(stream, samples, speed, position,
+                                 &newSamples)) {
+        return 0;
+      }
+      position += newSamples;
+    } else {
+      /* We are in the remaining cases, either inserting/removing a pitch period
+         for speed < 2.0X, or a portion of one for speed >= 2.0X. */
+      period = findPitchPeriod(stream, samples, 1);
+#ifdef SONIC_SPECTROGRAM
+      if (stream->spectrogram != NULL) {
+        sonicAddPitchPeriodToSpectrogram(stream->spectrogram, samples, period,
+                                         stream->numChannels);
+        newSamples = period;
+        position += period;
+      } else
+#endif /* SONIC_SPECTROGRAM */
+        if (speed > 1.0) {
+          newSamples = skipPitchPeriod(stream, samples, speed, period);
+          position += period + newSamples;
+          if (speed < 2.0) {
+            stream->timeError += newSamples * stream->samplePeriod -
+                                 (period + newSamples) * stream->inputPlayTime /
+                                     stream->numInputSamples;
+          }
+        } else {
+          newSamples = insertPitchPeriod(stream, samples, speed, period);
+          position += newSamples;
+          if (speed > 0.5) {
+            stream->timeError +=
+                (period + newSamples) * stream->samplePeriod -
+                newSamples * stream->inputPlayTime / stream->numInputSamples;
+          }
+        }
+      if (newSamples == 0) {
+        return 0; /* Failed to resize output buffer */
+      }
+    }
+  } while (position + maxRequired <= numSamples);
+  removeInputSamples(stream, position);
+  return 1;
+}
+
+/* Resample as many pitch periods as we have buffered on the input.  Return 0 if
+   we fail to resize an input or output buffer.  Also scale the output by the
+   volume. */
+static int processStreamInput(sonicStream stream) {
+  int originalNumOutputSamples = stream->numOutputSamples;
+  float rate = stream->rate * stream->pitch;
+  float localSpeed;
+
+  if (stream->numInputSamples == 0) {
+    return 1;
+  }
+  localSpeed =
+      stream->numInputSamples * stream->samplePeriod / stream->inputPlayTime;
+  if (localSpeed > 1.00001 || localSpeed < 0.99999) {
+    changeSpeed(stream, localSpeed);
+  } else {
+    if (!copyInputToOutput(stream, stream->numInputSamples)) {
+      return 0;
+    }
+  }
+  if (rate != 1.0f) {
+    if (!adjustRate(stream, rate, originalNumOutputSamples)) {
+      return 0;
+    }
+  }
+  if (stream->volume != 1.0f) {
+    /* Adjust output volume. */
+    scaleSamples(
+        stream->outputBuffer + originalNumOutputSamples * stream->numChannels,
+        (stream->numOutputSamples - originalNumOutputSamples) *
+            stream->numChannels,
+        stream->volume);
+  }
+  return 1;
+}
+
+/* Write floating point data to the input buffer and process it. */
+int sonicWriteFloatToStream(sonicStream stream, const float* samples,
+                            int numSamples) {
+  if (!addFloatSamplesToInputBuffer(stream, samples, numSamples)) {
+    return 0;
+  }
+  return processStreamInput(stream);
+}
+
+/* Simple wrapper around sonicWriteFloatToStream that does the short to float
+   conversion for you. */
+int sonicWriteShortToStream(sonicStream stream, const short* samples,
+                            int numSamples) {
+  if (!addShortSamplesToInputBuffer(stream, samples, numSamples)) {
+    return 0;
+  }
+  return processStreamInput(stream);
+}
+
+/* Simple wrapper around sonicWriteFloatToStream that does the unsigned char to
+   float conversion for you. */
+int sonicWriteUnsignedCharToStream(sonicStream stream,
+                                   const unsigned char* samples,
+                                   int numSamples) {
+  if (!addUnsignedCharSamplesToInputBuffer(stream, samples, numSamples)) {
+    return 0;
+  }
+  return processStreamInput(stream);
+}
+
+/* This is a non-stream oriented interface to just change the speed of a sound
+ * sample */
+int sonicChangeFloatSpeed(float* samples, int numSamples, float speed,
+                          float pitch, float rate, float volume,
+                          int useChordPitch, int sampleRate, int numChannels) {
+  sonicStream stream = sonicCreateStream(sampleRate, numChannels);
+
+  sonicSetSpeed(stream, speed);
+  sonicSetPitch(stream, pitch);
+  sonicSetRate(stream, rate);
+  sonicSetVolume(stream, volume);
+  sonicWriteFloatToStream(stream, samples, numSamples);
+  sonicFlushStream(stream);
+  numSamples = sonicSamplesAvailable(stream);
+  sonicReadFloatFromStream(stream, samples, numSamples);
+  sonicDestroyStream(stream);
+  return numSamples;
+}
+
+/* This is a non-stream oriented interface to just change the speed of a sound
+ * sample */
+int sonicChangeShortSpeed(short* samples, int numSamples, float speed,
+                          float pitch, float rate, float volume,
+                          int useChordPitch, int sampleRate, int numChannels) {
+  sonicStream stream = sonicCreateStream(sampleRate, numChannels);
+
+  sonicSetSpeed(stream, speed);
+  sonicSetPitch(stream, pitch);
+  sonicSetRate(stream, rate);
+  sonicSetVolume(stream, volume);
+  sonicWriteShortToStream(stream, samples, numSamples);
+  sonicFlushStream(stream);
+  numSamples = sonicSamplesAvailable(stream);
+  sonicReadShortFromStream(stream, samples, numSamples);
+  sonicDestroyStream(stream);
+  return numSamples;
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/sonic.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/sonic.h
@@ -1,0 +1,304 @@
+#ifndef SONIC_H_
+#define SONIC_H_
+
+/* Sonic library
+   Copyright 2010
+   Bill Cox
+   This file is part of the Sonic Library.
+
+   This file is licensed under the Apache 2.0 license.
+*/
+
+/*
+The Sonic Library implements a new algorithm invented by Bill Cox for the
+specific purpose of speeding up speech by high factors at high quality.  It
+generates smooth speech at speed up factors as high as 6X, possibly more.  It is
+also capable of slowing down speech, and generates high quality results
+regardless of the speed up or slow down factor.  For speeding up speech by 2X or
+more, the following equation is used:
+
+    newSamples = period/(speed - 1.0)
+    scale = 1.0/newSamples;
+
+where period is the current pitch period, determined using AMDF or any other
+pitch estimator, and speed is the speedup factor.  If the current position in
+the input stream is pointed to by "samples", and the current output stream
+position is pointed to by "out", then newSamples number of samples can be
+generated with:
+
+    out[t] = (samples[t]*(newSamples - t) + samples[t + period]*t)/newSamples;
+
+where t = 0 to newSamples - 1.
+
+For speed factors < 2X, the PICOLA algorithm is used.  The above
+algorithm is first used to double the speed of one pitch period.  Then, enough
+input is directly copied from the input to the output to achieve the desired
+speed up factor, where 1.0 < speed < 2.0.  The amount of data copied is derived:
+
+    speed = (2*period + length)/(period + length)
+    speed*length + speed*period = 2*period + length
+    length(speed - 1) = 2*period - speed*period
+    length = period*(2 - speed)/(speed - 1)
+
+For slowing down speech where 0.5 < speed < 1.0, a pitch period is inserted into
+the output twice, and length of input is copied from the input to the output
+until the output desired speed is reached.  The length of data copied is:
+
+    length = period*(speed - 0.5)/(1 - speed)
+
+For slow down factors below 0.5, no data is copied, and an algorithm
+similar to high speed factors is used.
+*/
+
+/* Uncomment this to use sin-wav based overlap add which in theory can improve
+   sound quality slightly, at the expense of lots of floating point math. */
+/* #define SONIC_USE_SIN */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef SONIC_INTERNAL
+/* The following #define's are used to change the names of the routines defined
+ * here so that a new library (i.e. speedy) can reuse these names, and then call
+ * the original names.  We do this for two reasons: 1) we don't want to change
+ * the original API, and 2) we want to add a shim, using the original names and
+ * still call these routines.
+ *
+ * Original users of this API and the libsonic library need to do nothing.  The
+ * original behavior remains.
+ *
+ * A new user that add some additional functionality above this library (a shim)
+ * should #define SONIC_INTERNAL before including this file, undefine all these
+ * symbols and call the sonicIntXXX functions directly.
+ */
+#define sonicCreateStream sonicIntCreateStream
+#define sonicDestroyStream sonicIntDestroyStream
+#define sonicWriteFloatToStream sonicIntWriteFloatToStream
+#define sonicWriteShortToStream sonicIntWriteShortToStream
+#define sonicWriteUnsignedCharToStream sonicIntWriteUnsignedCharToStream
+#define sonicReadFloatFromStream sonicIntReadFloatFromStream
+#define sonicReadShortFromStream sonicIntReadShortFromStream
+#define sonicReadUnsignedCharFromStream sonicIntReadUnsignedCharFromStream
+#define sonicFlushStream sonicIntFlushStream
+#define sonicSamplesAvailable sonicIntSamplesAvailable
+#define sonicGetSpeed sonicIntGetSpeed
+#define sonicSetSpeed sonicIntSetSpeed
+#define sonicGetPitch sonicIntGetPitch
+#define sonicSetPitch sonicIntSetPitch
+#define sonicGetRate sonicIntGetRate
+#define sonicSetRate sonicIntSetRate
+#define sonicGetVolume sonicIntGetVolume
+#define sonicSetVolume sonicIntSetVolume
+#define sonicGetQuality sonicIntGetQuality
+#define sonicSetQuality sonicIntSetQuality
+#define sonicGetSampleRate sonicIntGetSampleRate
+#define sonicSetSampleRate sonicIntSetSampleRate
+#define sonicGetNumChannels sonicIntGetNumChannels
+#define sonicGetUserData sonicIntGetUserData
+#define sonicSetUserData sonicIntSetUserData
+#define sonicSetNumChannels sonicIntSetNumChannels
+#define sonicChangeFloatSpeed sonicIntChangeFloatSpeed
+#define sonicChangeShortSpeed sonicIntChangeShortSpeed
+#define sonicEnableNonlinearSpeedup sonicIntEnableNonlinearSpeedup
+#define sonicSetDurationFeedbackStrength sonicIntSetDurationFeedbackStrength
+#define sonicComputeSpectrogram sonicIntComputeSpectrogram
+#define sonicGetSpectrogram sonicIntGetSpectrogram
+
+#endif /* SONIC_INTERNAL */
+
+/* This specifies the range of voice pitches we try to match.
+   Note that if we go lower than 65, we could overflow in findPitchInRange */
+#ifndef SONIC_MIN_PITCH
+#define SONIC_MIN_PITCH 65
+#endif  /* SONIC_MIN_PITCH */
+#ifndef SONIC_MAX_PITCH
+#define SONIC_MAX_PITCH 400
+#endif  /* SONIC_MAX_PITCH */
+
+/* The following values are used to clamp inputs such as speed to sane values.
+ */
+#define SONIC_MIN_VOLUME 0.01f
+#define SONIC_MAX_VOLUME 100.0f
+#define SONIC_MIN_SPEED 0.05f
+#define SONIC_MAX_SPEED 20.0f
+#define SONIC_MIN_PITCH_SETTING 0.05f
+#define SONIC_MAX_PITCH_SETTING 20.0f
+#define SONIC_MIN_RATE 0.05f
+#define SONIC_MAX_RATE 20.0f
+#define SONIC_MIN_SAMPLE_RATE 1000
+#define SONIC_MAX_SAMPLE_RATE 500000
+#define SONIC_MIN_CHANNELS 1
+#define SONIC_MAX_CHANNELS 32
+
+/* These are used to down-sample some inputs to improve speed */
+#define SONIC_AMDF_FREQ 4000
+
+struct sonicStreamStruct;
+typedef struct sonicStreamStruct* sonicStream;
+
+/* For all of the following functions, numChannels is multiplied by numSamples
+   to determine the actual number of values read or returned. */
+
+/* Create a sonic stream.  Return NULL only if we are out of memory and cannot
+  allocate the stream. Set numChannels to 1 for mono, and 2 for stereo. */
+sonicStream sonicCreateStream(int sampleRate, int numChannels);
+/* Destroy the sonic stream. */
+void sonicDestroyStream(sonicStream stream);
+/* Attach user data to the stream. */
+void sonicSetUserData(sonicStream stream, void *userData);
+/* Retrieve user data attached to the stream. */
+void *sonicGetUserData(sonicStream stream);
+/* Use this to write floating point data to be speed up or down into the stream.
+   Values must be between -1 and 1.  Return 0 if memory realloc failed,
+   otherwise 1 */
+int sonicWriteFloatToStream(sonicStream stream, const float* samples, int numSamples);
+/* Use this to write 16-bit data to be speed up or down into the stream.
+   Return 0 if memory realloc failed, otherwise 1 */
+int sonicWriteShortToStream(sonicStream stream, const short* samples, int numSamples);
+/* Use this to write 8-bit unsigned data to be speed up or down into the stream.
+   Return 0 if memory realloc failed, otherwise 1 */
+int sonicWriteUnsignedCharToStream(sonicStream stream, const unsigned char* samples,
+                                   int numSamples);
+/* Use this to read floating point data out of the stream.  Sometimes no data
+   will be available, and zero is returned, which is not an error condition. */
+int sonicReadFloatFromStream(sonicStream stream, float* samples,
+                             int maxSamples);
+/* Use this to read 16-bit data out of the stream.  Sometimes no data will
+   be available, and zero is returned, which is not an error condition. */
+int sonicReadShortFromStream(sonicStream stream, short* samples,
+                             int maxSamples);
+/* Use this to read 8-bit unsigned data out of the stream.  Sometimes no data
+   will be available, and zero is returned, which is not an error condition. */
+int sonicReadUnsignedCharFromStream(sonicStream stream, unsigned char* samples,
+                                    int maxSamples);
+/* Force the sonic stream to generate output using whatever data it currently
+   has.  No extra delay will be added to the output, but flushing in the middle
+   of words could introduce distortion. */
+int sonicFlushStream(sonicStream stream);
+/* Return the number of samples in the output buffer */
+int sonicSamplesAvailable(sonicStream stream);
+/* Get the speed of the stream. */
+float sonicGetSpeed(sonicStream stream);
+/* Set the speed of the stream. */
+void sonicSetSpeed(sonicStream stream, float speed);
+/* Get the pitch of the stream. */
+float sonicGetPitch(sonicStream stream);
+/* Set the pitch of the stream. */
+void sonicSetPitch(sonicStream stream, float pitch);
+/* Get the rate of the stream. */
+float sonicGetRate(sonicStream stream);
+/* Set the rate of the stream. */
+void sonicSetRate(sonicStream stream, float rate);
+/* Get the scaling factor of the stream. */
+float sonicGetVolume(sonicStream stream);
+/* Set the scaling factor of the stream. */
+void sonicSetVolume(sonicStream stream, float volume);
+/* Chord pitch is DEPRECATED.  AFAIK, it was never used by anyone.  These
+   functions still exist to avoid breaking existing code. */
+/* Get the chord pitch setting. */
+int sonicGetChordPitch(sonicStream stream);
+/* Set chord pitch mode on or off.  Default is off.  See the documentation
+   page for a description of this feature. */
+void sonicSetChordPitch(sonicStream stream, int useChordPitch);
+/* Get the quality setting. */
+int sonicGetQuality(sonicStream stream);
+/* Set the "quality".  Default 0 is virtually as good as 1, but very much
+ * faster. */
+void sonicSetQuality(sonicStream stream, int quality);
+/* Get the sample rate of the stream. */
+int sonicGetSampleRate(sonicStream stream);
+/* Set the sample rate of the stream.  This will drop any samples that have not
+ * been read. */
+void sonicSetSampleRate(sonicStream stream, int sampleRate);
+/* Get the number of channels. */
+int sonicGetNumChannels(sonicStream stream);
+/* Set the number of channels.  This will drop any samples that have not been
+ * read. */
+void sonicSetNumChannels(sonicStream stream, int numChannels);
+/* This is a non-stream oriented interface to just change the speed of a sound
+   sample.  It works in-place on the sample array, so there must be at least
+   speed*numSamples available space in the array. Returns the new number of
+   samples. */
+int sonicChangeFloatSpeed(float* samples, int numSamples, float speed,
+                          float pitch, float rate, float volume,
+                          int useChordPitch, int sampleRate, int numChannels);
+/* This is a non-stream oriented interface to just change the speed of a sound
+   sample.  It works in-place on the sample array, so there must be at least
+   speed*numSamples available space in the array. Returns the new number of
+   samples. */
+int sonicChangeShortSpeed(short* samples, int numSamples, float speed,
+                          float pitch, float rate, float volume,
+                          int useChordPitch, int sampleRate, int numChannels);
+
+#ifdef SONIC_SPECTROGRAM
+/*
+This code generates high quality spectrograms from sound samples, using
+Time-Aliased-FFTs as described at:
+
+    https://github.com/waywardgeek/spectrogram
+
+Basically, two adjacent pitch periods are overlap-added to create a sound
+sample that accurately represents the speech sound at that moment in time.
+This set of samples is converted to a spetral line using an FFT, and the result
+is saved as a single spectral line at that moment in time.  The resulting
+spectral lines vary in resolution (it is equal to the number of samples in the
+pitch period), and the spacing of spectral lines also varies (proportional to
+the numver of samples in the pitch period).
+
+To generate a bitmap, linear interpolation is used to render the grayscale
+value at any particular point in time and frequency.
+*/
+
+#define SONIC_MAX_SPECTRUM_FREQ 5000
+
+struct sonicSpectrogramStruct;
+struct sonicBitmapStruct;
+typedef struct sonicSpectrogramStruct* sonicSpectrogram;
+typedef struct sonicBitmapStruct* sonicBitmap;
+
+/* sonicBitmap objects represent spectrograms as grayscale bitmaps where each
+   pixel is from 0 (black) to 255 (white).  Bitmaps are rows*cols in size.
+   Rows are indexed top to bottom and columns are indexed left to right */
+struct sonicBitmapStruct {
+  unsigned char* data;
+  int numRows;
+  int numCols;
+};
+
+/* Enable coomputation of a spectrogram on the fly. */
+void sonicComputeSpectrogram(sonicStream stream);
+
+/* Get the spectrogram. */
+sonicSpectrogram sonicGetSpectrogram(sonicStream stream);
+
+/* Create an empty spectrogram. Called automatically if sonicComputeSpectrogram
+   has been called. */
+sonicSpectrogram sonicCreateSpectrogram(int sampleRate);
+
+/* Destroy the spectrotram.  This is called automatically when calling
+   sonicDestroyStream. */
+void sonicDestroySpectrogram(sonicSpectrogram spectrogram);
+
+/* Convert the spectrogram to a bitmap. Caller must destroy bitmap when done. */
+sonicBitmap sonicConvertSpectrogramToBitmap(sonicSpectrogram spectrogram,
+                                            int numRows, int numCols);
+
+/* Destroy a bitmap returned by sonicConvertSpectrogramToBitmap. */
+void sonicDestroyBitmap(sonicBitmap bitmap);
+
+int sonicWritePGM(sonicBitmap bitmap, char* fileName);
+
+/* Add two pitch periods worth of samples to the spectrogram.  There must be
+   2*period samples.  Time should advance one pitch period for each call to
+   this function. */
+void sonicAddPitchPeriodToSpectrogram(sonicSpectrogram spectrogram,
+                                      short* samples, int numSamples,
+                                      int numChannels);
+#endif  /* SONIC_SPECTROGRAM */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* SONIC_H_ */

--- a/Packages/PlaybackDSP/Sources/PlaybackDSP/TimeStretchStream.swift
+++ b/Packages/PlaybackDSP/Sources/PlaybackDSP/TimeStretchStream.swift
@@ -1,0 +1,45 @@
+import CPlaybackDSP
+import Foundation
+
+/// Stateful mono Float32 stretching. Keep one instance for a continuous source;
+/// create a new instance after seeking or changing speed. Call only serially.
+public final class TimeStretchStream {
+    public static let engineName = "Sonic"
+    private let handle: UnsafeMutableRawPointer
+    private var isFinished = false
+
+    public enum Failure: Error {
+        case invalidConfiguration
+        case invalidSamples
+        case processingFailed
+        case alreadyFinished
+    }
+
+    public init(sampleRate: Double, rate: Double) throws {
+        guard let handle = sayit_stretch_create(sampleRate, rate) else {
+            throw Failure.invalidConfiguration
+        }
+        self.handle = handle
+    }
+
+    deinit { sayit_stretch_destroy(handle) }
+
+    /// Finalization drains lookahead and trims padding to round(inputFrames / rate).
+    /// At 1×, samples pass through unchanged.
+    public func process(_ samples: [Float], final: Bool = false) throws -> [Float] {
+        guard !isFinished else { throw Failure.alreadyFinished }
+        guard samples.count <= Int(Int32.max), samples.allSatisfy(\.isFinite) else {
+            throw Failure.invalidSamples
+        }
+        var count: Int32 = 0
+        let result = samples.withUnsafeBufferPointer {
+            sayit_stretch_process(handle, $0.baseAddress, Int32($0.count), final ? 1 : 0, &count)
+        }
+        guard count >= 0 else { throw Failure.processingFailed }
+        isFinished = final
+        guard count > 0, let result else { return [] }
+        let output = Array(UnsafeBufferPointer(start: result, count: Int(count)))
+        guard output.allSatisfy(\.isFinite) else { throw Failure.processingFailed }
+        return output
+    }
+}

--- a/Packages/PlaybackDSP/Sources/PlaybackDSPRender/main.swift
+++ b/Packages/PlaybackDSP/Sources/PlaybackDSPRender/main.swift
@@ -1,0 +1,65 @@
+@preconcurrency import AVFoundation
+import Foundation
+import PlaybackDSP
+
+// Offline listening fixtures use exactly the same streaming wrapper as playback.
+// Usage: swift run -c release --package-path Packages/PlaybackDSP PlaybackDSPRender input.wav output-directory
+@main
+struct RenderComparison {
+    static func main() throws {
+        guard CommandLine.arguments.count == 3 else {
+            print("Usage: PlaybackDSPRender input-audio output-directory")
+            return
+        }
+        let source = URL(fileURLWithPath: CommandLine.arguments[1])
+        let destination = URL(fileURLWithPath: CommandLine.arguments[2], isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        let input = try AVAudioFile(forReading: source, commonFormat: .pcmFormatFloat32, interleaved: false)
+        let sampleRate = input.processingFormat.sampleRate
+        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: input.processingFormat, frameCapacity: 4096),
+              let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1) else {
+            throw TimeStretchStream.Failure.invalidConfiguration
+        }
+        print("engine,rate,input_frames,output_frames,processing_seconds")
+        for rate in [0.5, 0.75, 1.0, 1.25, 1.5, 2.0] {
+            let url = destination.appendingPathComponent("speed-\(rate).wav")
+            guard !FileManager.default.fileExists(atPath: url.path) else {
+                throw CocoaError(.fileWriteFileExists)
+            }
+            let output = try AVAudioFile(forWriting: url, settings: format.settings)
+            let stream = try TimeStretchStream(sampleRate: sampleRate, rate: rate)
+            var outputFrames = 0
+            var processingSeconds = 0.0
+            input.framePosition = 0
+            func write(_ samples: [Float], final: Bool = false) throws {
+                let start = ContinuousClock.now
+                let stretched = try stream.process(samples, final: final)
+                let elapsed = start.duration(to: .now).components
+                processingSeconds += Double(elapsed.seconds) + Double(elapsed.attoseconds) / 1e18
+                guard !stretched.isEmpty else { return }
+                guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(stretched.count)),
+                      let channel = buffer.floatChannelData?[0] else {
+                    throw TimeStretchStream.Failure.processingFailed
+                }
+                buffer.frameLength = AVAudioFrameCount(stretched.count)
+                for index in stretched.indices { channel[index] = stretched[index] }
+                try output.write(from: buffer)
+                outputFrames += stretched.count
+            }
+            while input.framePosition < input.length {
+                try input.read(into: inputBuffer)
+                guard let channels = inputBuffer.floatChannelData, inputBuffer.frameLength > 0 else {
+                    throw TimeStretchStream.Failure.invalidSamples
+                }
+                let channelCount = Int(input.processingFormat.channelCount)
+                var mono = [Float](repeating: 0, count: Int(inputBuffer.frameLength))
+                for channel in 0..<channelCount {
+                    for frame in mono.indices { mono[frame] += channels[channel][frame] / Float(channelCount) }
+                }
+                try write(mono)
+            }
+            try write([], final: true)
+            print("\(TimeStretchStream.engineName),\(rate),\(input.length),\(outputFrames),\(processingSeconds)")
+        }
+    }
+}

--- a/Packages/PlaybackDSP/Tests/PlaybackDSPTests/TimeStretchTests.swift
+++ b/Packages/PlaybackDSP/Tests/PlaybackDSPTests/TimeStretchTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import PlaybackDSP
+
+@Suite("Pitch-preserving playback DSP")
+struct TimeStretchTests {
+    static let rates = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+
+    static func tone(sampleRate: Double, duration: Double = 3) -> [Float] {
+        (0..<Int(sampleRate * duration)).map { frame in
+            let time = Double(frame) / sampleRate
+            let envelope = min(1, time / 0.02, (duration - time) / 0.02)
+            return Float(0.25 * envelope * sin(2 * .pi * 220 * time))
+        }
+    }
+
+    @Test("All speeds preserve pitch, duration and level", arguments: rates, [24_000.0, 44_100.0, 48_000.0])
+    func pitchAndDuration(rate: Double, sampleRate: Double) throws {
+        let input = Self.tone(sampleRate: sampleRate)
+        let stream = try TimeStretchStream(sampleRate: sampleRate, rate: rate)
+        var output: [Float] = []
+        // Irregular chunks exercise cumulative rounding and continuous state.
+        for start in stride(from: 0, to: input.count, by: 997) {
+            output += try stream.process(Array(input[start..<min(start + 997, input.count)]))
+        }
+        output += try stream.process([], final: true)
+        #expect(output.count == Int((Double(input.count) / rate).rounded()))
+        #expect(output.allSatisfy { $0.isFinite })
+        let middle = Array(output[Int(sampleRate / 4)..<(output.count - Int(sampleRate / 4))])
+        let rms = sqrt(middle.reduce(0.0) { $0 + Double($1 * $1) } / Double(middle.count))
+        let crossings = zip(middle, middle.dropFirst()).filter { $0 <= 0 && $1 > 0 }.count
+        let frequency = Double(crossings) * sampleRate / Double(middle.count)
+        #expect(abs(frequency - 220) < 3)
+        #expect(rms > 0.10 && rms < 0.25)
+        #expect((output.map { abs($0) }.max() ?? 0) < 0.5)
+        if rate == 1 { #expect(output == input) }
+    }
+
+    @Test("Short clips drain their tail at every speed", arguments: rates)
+    func shortTail(rate: Double) throws {
+        for count in [1, 37, 240, 2400] {
+            let stream = try TimeStretchStream(sampleRate: 24_000, rate: rate)
+            let output = try stream.process([Float](repeating: 0.1, count: count), final: true)
+            #expect(output.count == Int((Double(count) / rate).rounded()))
+            #expect(output.allSatisfy { $0.isFinite })
+        }
+    }
+
+    @Test("Invalid inputs fail and finalized streams cannot be reused")
+    func invalidInputs() throws {
+        for rate in [0, -1, 3, Double.nan, Double.infinity] {
+            #expect(throws: TimeStretchStream.Failure.self) {
+                try TimeStretchStream(sampleRate: 24_000, rate: rate)
+            }
+        }
+        #expect(throws: TimeStretchStream.Failure.self) {
+            try TimeStretchStream(sampleRate: 0, rate: 1)
+        }
+        let stream = try TimeStretchStream(sampleRate: 24_000, rate: 1.5)
+        #expect(throws: TimeStretchStream.Failure.self) { try stream.process([.nan]) }
+        #expect(try stream.process([], final: true).isEmpty)
+        #expect(throws: TimeStretchStream.Failure.self) { try stream.process([0]) }
+    }
+
+    @Test("New streams after seek or speed change do not carry old audio")
+    func resetIsolation() throws {
+        let first = try TimeStretchStream(sampleRate: 24_000, rate: 2)
+        _ = try first.process(Self.tone(sampleRate: 24_000))
+        let second = try TimeStretchStream(sampleRate: 24_000, rate: 0.5)
+        let silence = try second.process([Float](repeating: 0, count: 24_000), final: true)
+        #expect(silence.allSatisfy { abs($0) < 0.0001 })
+    }
+}

--- a/SayIt.xcodeproj/project.pbxproj
+++ b/SayIt.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		2F13AD95B66B59D9BEFAB69D /* VoiceProfileRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48CC76FCF104B6EA0CCFFC3 /* VoiceProfileRecord.swift */; };
 		2F98443BCC6A9CE666AFF7D2 /* SayItCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E5B162BA286FB4707D990A4 /* SayItCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		30F806119784A3EA06D08732 /* APITokenCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AADDFBAF6765A7A9E46F6F /* APITokenCreation.swift */; };
+		31CB6C9597C1FD2312EB3DE6 /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */; };
 		32FC4CC7ADAA06A627E07AD0 /* HTTPEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEAC3BEEF3A43EBD6DCF107 /* HTTPEventStreamTests.swift */; };
 		35C5858DED5258F9813091A5 /* SynthesisError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF73CF550608FF1F4C96C1B /* SynthesisError.swift */; };
 		360339154AB4814D00BBCB3B /* TokenCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62B45AACA98296E67663E5A /* TokenCreationSheet.swift */; };
@@ -126,7 +127,7 @@
 		3E69D945BB53BFBF82FCAA9D /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68391B4A83D06AD4C1FFAA0 /* OnboardingView.swift */; };
 		3F22D38886E6E44E0156F0F7 /* VoiceDiscoveryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AD71761AE179BEA6A20967 /* VoiceDiscoveryRequest.swift */; };
 		40F3797F2C6B54BD494E8C74 /* APITokenDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8697FFA4EB481A4A7FB1A3A /* APITokenDigestTests.swift */; };
-		419CB00AB6F80C7F4A3F46BC /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */; };
+		419CB00AB6F80C7F4A3F46BC /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 71DDF93755CA3F43B4C3D31B /* MLXAudioCore */; };
 		41DE1A049C2D3BFE630D7177 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 12D3C7903194A06085F4C99C /* Atomics */; };
 		4251B261B2659D5CB44E474C /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C074F8772DC89E43CE2A267 /* DesignTokens.swift */; };
 		435E896B82A959E7FDFB0403 /* SayItApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CEBAFD3BF5D864C5BD06D /* SayItApplication.swift */; };
@@ -176,6 +177,7 @@
 		560101541C1F3A848FE2B02F /* SayItSelectionAgentMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E19E0A44E938CCC17DEF7EE /* SayItSelectionAgentMain.swift */; };
 		560D74E1A13F3E50F535D55F /* MenuFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504A1CDB257EFB01D742FAE6 /* MenuFooterView.swift */; };
 		560E27275E9D1815E261F41E /* TimeInterval+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7392C8CFFBB121658EBD9597 /* TimeInterval+Formatting.swift */; };
+		56D2AEA8E65D228BBC9509CF /* TimeStretchPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */; };
 		56ECCB4BAC727F46AA2408EF /* VoiceCloneRequirements.swift in Sources */ = {isa = PBXBuildFile; fileRef = E052AB297B6730E47BF28A4D /* VoiceCloneRequirements.swift */; };
 		56F431F50DFF88F2785B215B /* SpeechTitleGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF89D0850C4A3A612A71C738 /* SpeechTitleGeneratorTests.swift */; };
 		57F882F8230C74C9C260774F /* UpdateOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DD06F06BB2F0F12013A199 /* UpdateOffer.swift */; };
@@ -208,7 +210,7 @@
 		660B9287719F72B11783D3C1 /* ResumeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = C159E47E305909312F3675A5 /* ResumeCommand.swift */; };
 		662931D02D9303078BB8AE62 /* VoiceTuningSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61809FAC6AB3B4223A714878 /* VoiceTuningSpace.swift */; };
 		673810EDC217C5CD2640A55A /* PlaybackRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6517CAB9846FFD0FD879B897 /* PlaybackRate.swift */; };
-		690DD7FC6DABD5D8A65B7A48 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 71DDF93755CA3F43B4C3D31B /* MLXAudioCore */; };
+		690DD7FC6DABD5D8A65B7A48 /* PlaybackDSP in Frameworks */ = {isa = PBXBuildFile; productRef = 7D5589CFD718091E8391DB68 /* PlaybackDSP */; };
 		69CE3A628AAE1587B7976D71 /* VoiceStudioSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AEFBFB440C0388E52C0DEC /* VoiceStudioSnapshot.swift */; };
 		6B2A2003079910D0A146A378 /* SayItHTTPServer+PlaybackRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC29C1C1131C5748DA67D61 /* SayItHTTPServer+PlaybackRoutes.swift */; };
 		6B8EA518D4DB7702985F43FA /* RegisteredServiceStartup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB5BBA9182ED3B21E5A1465 /* RegisteredServiceStartup.swift */; };
@@ -946,6 +948,7 @@
 		456A6147E5C1F299C5F70B42 /* AccessibilityAncestorSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAncestorSearch.swift; sourceTree = "<group>"; };
 		45838FA1413995858EC9E5C3 /* StatusHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusHeaderView.swift; sourceTree = "<group>"; };
 		45FA49ACF4B53BA6833BADA6 /* SKILL.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SKILL.md; sourceTree = "<group>"; };
+		4616A529E899E2F12ACCA917 /* PlaybackDSP */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PlaybackDSP; path = Packages/PlaybackDSP; sourceTree = SOURCE_ROOT; };
 		46A2C77FAF415C25A265B262 /* HTTPSubmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPSubmission.swift; sourceTree = "<group>"; };
 		46C4FDBB3A3112F47070537F /* APITokenPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenPreset.swift; sourceTree = "<group>"; };
 		4704665E76548BC4B54EAAE2 /* VoiceCloneRequirementsSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCloneRequirementsSnapshot.swift; sourceTree = "<group>"; };
@@ -1132,6 +1135,7 @@
 		B825339FFDAD336D58CA0052 /* SpeechChunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechChunk.swift; sourceTree = "<group>"; };
 		B9BFBF98DB02E32E3E824EF6 /* BackendPrimitiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPrimitiveTests.swift; sourceTree = "<group>"; };
 		BA18E0AFEFF10C13815F3D6D /* APITokenScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenScope.swift; sourceTree = "<group>"; };
+		BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeStretchPlaybackTests.swift; sourceTree = "<group>"; };
 		BB95F4768AD968BE1C4CBCD1 /* SayItStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItStyles.swift; sourceTree = "<group>"; };
 		BD2C197A18B385CC45949276 /* DiagnosticEvent+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiagnosticEvent+Snapshot.swift"; sourceTree = "<group>"; };
 		BE4174D1D4EB7E48D19724DA /* SelectionCaptureFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionCaptureFlow.swift; sourceTree = "<group>"; };
@@ -1280,10 +1284,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				690DD7FC6DABD5D8A65B7A48 /* PlaybackDSP in Frameworks */,
 				0922BE8F5F7353F975466383 /* SayItCore.framework in Frameworks */,
 				89AD3D4D8907B9BD8BC76B7F /* SayItProtocol.framework in Frameworks */,
-				690DD7FC6DABD5D8A65B7A48 /* MLXAudioCore in Frameworks */,
-				419CB00AB6F80C7F4A3F46BC /* MLXAudioTTS in Frameworks */,
+				419CB00AB6F80C7F4A3F46BC /* MLXAudioCore in Frameworks */,
+				31CB6C9597C1FD2312EB3DE6 /* MLXAudioTTS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1935,6 +1940,7 @@
 			isa = PBXGroup;
 			children = (
 				D5368688F97DCA95208246D6 /* Fixtures */,
+				E6A9ADAA62A15BD6C74D2CEF /* Packages */,
 				04D76396770A2F14616CD133 /* Resources */,
 				4835E83DFC07A19B7BC7DEF9 /* Resources */,
 				180CF2F43C8748887CC1F6A5 /* SayIt */,
@@ -2164,6 +2170,14 @@
 			path = Tests/SayItUpdateTests;
 			sourceTree = "<group>";
 		};
+		E6A9ADAA62A15BD6C74D2CEF /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				4616A529E899E2F12ACCA917 /* PlaybackDSP */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
 		EA01701396BB7A5E45BFB811 /* Diagnostics */ = {
 			isa = PBXGroup;
 			children = (
@@ -2261,6 +2275,7 @@
 				C66497ED594E15E3EF2CF5FD /* SpeechQueuePolicyTests.swift */,
 				DC8FE48DDB4640E0887AC670 /* SynthesisActorTests.swift */,
 				40828984E8B5F3F75C795F92 /* SynthesisOperationLifecycleTests.swift */,
+				BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */,
 				9E44B62D54EF87F46363D70C /* VoiceProfileStoreTests.swift */,
 				9842DB392263544D975DAA5F /* VoiceTuningPolicyTests.swift */,
 			);
@@ -2353,6 +2368,7 @@
 			);
 			name = SayItBackend;
 			packageProductDependencies = (
+				7D5589CFD718091E8391DB68 /* PlaybackDSP */,
 				71DDF93755CA3F43B4C3D31B /* MLXAudioCore */,
 				A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */,
 			);
@@ -2731,6 +2747,7 @@
 				C93AA06F3A6E248872ED93BC /* XCRemoteSwiftPackageReference "swift-collections" */,
 				2E71412ABA0D3631AC8F7E2B /* XCRemoteSwiftPackageReference "swift-nio" */,
 				8FA3A87EEEF8E0DC0F7CA93B /* XCRemoteSwiftPackageReference "Yams" */,
+				84D82FD5D4C643C189B34542 /* XCLocalSwiftPackageReference "Packages/PlaybackDSP" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 932443B985F40D816A0FD3B7 /* Products */;
@@ -3317,6 +3334,7 @@
 				F88A3CF15CA4053F7D587898 /* SpeechQueuePolicyTests.swift in Sources */,
 				BD7E756DBD67FF169CDD68C2 /* SynthesisActorTests.swift in Sources */,
 				97FFD241C34F9894CF4E8B9E /* SynthesisOperationLifecycleTests.swift in Sources */,
+				56D2AEA8E65D228BBC9509CF /* TimeStretchPlaybackTests.swift in Sources */,
 				04EDE873EF293B5BAFCD4C49 /* VoiceProfileStoreTests.swift in Sources */,
 				2D698A1F3469FA1866B99A24 /* VoiceTuningPolicyTests.swift in Sources */,
 			);
@@ -4486,6 +4504,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		84D82FD5D4C643C189B34542 /* XCLocalSwiftPackageReference "Packages/PlaybackDSP" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/PlaybackDSP;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		0FB0C4A704F0962960BDE609 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -4588,6 +4613,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = EDE9B52C93821E68A0BAF348 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */;
 			productName = MLXAudioCore;
+		};
+		7D5589CFD718091E8391DB68 /* PlaybackDSP */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PlaybackDSP;
 		};
 		966CEFC1C422D50A7DA22CD1 /* DequeModule */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Sources/SayItBackend/Playback/PlaybackController.swift
+++ b/Sources/SayItBackend/Playback/PlaybackController.swift
@@ -3,6 +3,7 @@
 import Foundation
 @preconcurrency import MediaPlayer
 import Observation
+import PlaybackDSP
 import SayItCore
 import SayItProtocol
 
@@ -10,7 +11,7 @@ import SayItProtocol
 @Observable
 final class PlaybackController: BackendPlaybackControlling {
     static let modelSwitchFadeDuration: Duration = .milliseconds(24)
-    static let highQualityTimePitchOverlap: Float = 32
+    static let timeStretchEngineName = TimeStretchStream.engineName
     static let schedulingHorizon: TimeInterval = 12
     static let schedulingChunkDuration: TimeInterval = 2
     static let fileReadFrameCount = 65_536
@@ -23,7 +24,11 @@ final class PlaybackController: BackendPlaybackControlling {
 
     private let engine = AVAudioEngine()
     private let player = AVAudioPlayerNode()
-    private let timePitch = AVAudioUnitTimePitch()
+    private var timeStretch: TimeStretchStream?
+    private var processingIsComplete = false
+    private var pendingSourceFrames: Int64 = 0
+    private var scheduledOutputFrames: Int64 = 0
+    private var renderRate: Double = 1
     private let timeline = TimelineDriver()
     private var audioConfigurationTask: Task<Void, Never>?
     private var audioConfigurationRecoveryTask: Task<Void, Never>?
@@ -97,7 +102,19 @@ final class PlaybackController: BackendPlaybackControlling {
     }
     var rate: Double = 1 {
         didSet {
-            timePitch.rate = Float(rate)
+            guard rate != oldValue else { return }
+            let wasPlaying = state == .playing
+            let anchor = currentPlaybackTime()
+            do {
+                if hasStoredAudio {
+                    try rescheduleAudio(from: anchor)
+                    elapsed = anchor
+                    lastStablePlaybackTime = anchor
+                    if wasPlaying { try startPlayback() }
+                }
+            } catch {
+                reportFailure(error, shouldResume: wasPlaying)
+            }
             scheduleCompletionWatchdog()
             updateNowPlaying()
         }
@@ -126,10 +143,6 @@ final class PlaybackController: BackendPlaybackControlling {
 
     init() {
         engine.attach(player)
-        engine.attach(timePitch)
-        timePitch.rate = Float(rate)
-        timePitch.pitch = 0
-        timePitch.overlap = Self.highQualityTimePitchOverlap
         configureRemoteCommands()
         monitorAudioConfiguration()
     }
@@ -345,6 +358,12 @@ final class PlaybackController: BackendPlaybackControlling {
     func finishBuffering() {
         synthesisIsComplete = true
         estimatedDuration = generatedDuration
+        do {
+            try scheduleAvailableAudio()
+        } catch {
+            reportFailure(error)
+            return
+        }
         if state == .buffering {
             play()
         } else {
@@ -492,16 +511,7 @@ final class PlaybackController: BackendPlaybackControlling {
         engine.stop()
         player.stop()
         engine.disconnectNodeOutput(player)
-        engine.disconnectNodeOutput(timePitch)
-        engine.connect(player, to: timePitch, format: format)
-        engine.connect(
-            timePitch,
-            to: engine.mainMixerNode,
-            format: format
-        )
-        timePitch.rate = Float(rate)
-        timePitch.pitch = 0
-        timePitch.overlap = Self.highQualityTimePitchOverlap
+        engine.connect(player, to: engine.mainMixerNode, format: format)
         engine.prepare()
         configuredSampleRate = format.sampleRate
         try ensureEngineRunning()
@@ -601,6 +611,7 @@ final class PlaybackController: BackendPlaybackControlling {
     ) {
         let generation = scheduleGeneration
         scheduledBufferCount += 1
+        scheduledOutputFrames += Int64(buffer.frameLength)
         player.scheduleBuffer(
             buffer,
             completionCallbackType: .dataPlayedBack
@@ -636,6 +647,11 @@ final class PlaybackController: BackendPlaybackControlling {
         completionWatchdogTask = nil
         scheduleGeneration &+= 1
         scheduledBufferCount = 0
+        scheduledOutputFrames = 0
+        pendingSourceFrames = 0
+        timeStretch = nil
+        processingIsComplete = false
+        renderRate = rate
         if var frameScheduler {
             frameScheduler.reset(startingAt: frameScheduler.nextFrame)
             self.frameScheduler = frameScheduler
@@ -658,38 +674,54 @@ final class PlaybackController: BackendPlaybackControlling {
     }
 
     private func scheduleAvailableAudio() throws {
-        guard let pcmStore, var frameScheduler else { return }
-        while let range = frameScheduler.nextRange(
-            availableFrameCount: pcmStore.frameCount
-        ) {
-            var samples = try pcmStore.readFrames(
+        guard let pcmStore, var frameScheduler, !processingIsComplete else { return }
+        if timeStretch == nil {
+            renderRate = rate
+            timeStretch = try TimeStretchStream(sampleRate: sampleRate, rate: renderRate)
+        }
+        guard let timeStretch else { return }
+        while let range = frameScheduler.nextRange(availableFrameCount: pcmStore.frameCount) {
+            let samples = try pcmStore.readFrames(
                 startingAt: range.lowerBound,
                 count: Int(range.count)
             )
             guard samples.count == range.count else {
                 throw CocoaError(.fileReadCorruptFile)
             }
-            if shouldFadeInNextScheduledBuffer {
-                samples = PCMTransitionRamp.fadeInHead(
-                    samples,
-                    frameCount: transitionFrameCount
-                )
-                shouldFadeInNextScheduledBuffer = false
-            }
-            let buffer = try makeBuffer(
-                samples: samples,
-                sampleRate: sampleRate
-            )
-            if configuredSampleRate == nil {
-                try prepareAudioGraph(for: buffer.format)
-            } else {
-                try ensureEngineRunning()
-            }
-            try validatePlayerFormat(for: buffer)
-            schedule(buffer, sourceFrameCount: Int64(range.count))
+            let output = try timeStretch.process(samples)
+            pendingSourceFrames += Int64(range.count)
             frameScheduler.didSchedule(range)
+            try scheduleProcessedAudio(output)
+        }
+        if synthesisIsComplete, frameScheduler.nextFrame == pcmStore.frameCount {
+            let tail = try timeStretch.process([], final: true)
+            try scheduleProcessedAudio(tail)
+            // A unity-rate stream has no delayed output to attach this accounting to.
+            if pendingSourceFrames > 0 {
+                frameScheduler.didComplete(frameCount: pendingSourceFrames)
+                pendingSourceFrames = 0
+            }
+            processingIsComplete = true
         }
         self.frameScheduler = frameScheduler
+    }
+
+    private func scheduleProcessedAudio(_ output: [Float]) throws {
+        guard !output.isEmpty else { return }
+        var samples = output
+        if shouldFadeInNextScheduledBuffer {
+            samples = PCMTransitionRamp.fadeInHead(samples, frameCount: transitionFrameCount)
+            shouldFadeInNextScheduledBuffer = false
+        }
+        let buffer = try makeBuffer(samples: samples, sampleRate: sampleRate)
+        if configuredSampleRate == nil {
+            try prepareAudioGraph(for: buffer.format)
+        } else {
+            try ensureEngineRunning()
+        }
+        try validatePlayerFormat(for: buffer)
+        schedule(buffer, sourceFrameCount: pendingSourceFrames)
+        pendingSourceFrames = 0
     }
 
     private func currentPlaybackTime() -> TimeInterval {
@@ -701,7 +733,8 @@ final class PlaybackController: BackendPlaybackControlling {
         }
         return min(
             scheduleOffset
-                + Double(playerTime.sampleTime) / playerTime.sampleRate,
+                + Double(min(playerTime.sampleTime, scheduledOutputFrames))
+                    / playerTime.sampleRate * renderRate,
             generatedDuration
         )
     }
@@ -722,7 +755,7 @@ final class PlaybackController: BackendPlaybackControlling {
               scheduledBufferCount == 0 else {
             return
         }
-        if synthesisIsComplete {
+        if synthesisIsComplete, processingIsComplete {
             completePlayback()
         } else if state == .playing {
             enterBufferingState()
@@ -789,10 +822,14 @@ final class PlaybackController: BackendPlaybackControlling {
     }
 
     private func enterBufferingState() {
-        elapsed = generatedDuration
+        // Restart from the audible source position, including the processor's
+        // held-back lookahead, when progressive synthesis catches up.
+        elapsed = currentPlaybackTime()
         lastStablePlaybackTime = elapsed
         invalidateScheduledAudio()
-        scheduleOffset = elapsed
+        let frame = Int64((elapsed * sampleRate).rounded(.down))
+        frameScheduler?.reset(startingAt: frame)
+        scheduleOffset = Double(frame) / sampleRate
         state = .buffering
         updateNowPlaying()
     }

--- a/Tests/SayItBackendTests/BackendProjectionTests.swift
+++ b/Tests/SayItBackendTests/BackendProjectionTests.swift
@@ -97,6 +97,6 @@ struct BackendProjectionTests {
         #expect(PlaybackController.preferredStartBufferDuration(for: 0.5) == 1.2)
         #expect(PlaybackController.preferredStartBufferDuration(for: 1) == 1.2)
         #expect(PlaybackController.preferredStartBufferDuration(for: 2) == 2.4)
-        #expect(PlaybackController.highQualityTimePitchOverlap == 32)
+        #expect(PlaybackController.timeStretchEngineName == "Sonic")
     }
 }

--- a/Tests/SayItBackendTests/TimeStretchPlaybackTests.swift
+++ b/Tests/SayItBackendTests/TimeStretchPlaybackTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import SayItCore
+import SayItProtocol
+import Testing
+@testable import SayItBackend
+
+// Uses the real output graph, muted. Opt in on a Mac with an audio output device.
+@Suite("Time-stretched playback integration", .serialized,
+       .enabled(if: ProcessInfo.processInfo.environment["SAYIT_PLAYBACK_INTEGRATION"] == "1"))
+@MainActor
+struct TimeStretchPlaybackTests {
+    private func enqueue(_ playback: PlaybackController, id: UUID, duration: Double, index: Int = 0) throws {
+        let samples = (0..<Int(24_000 * duration)).map {
+            Float(0.1 * sin(2 * .pi * 220 * Double($0) / 24_000))
+        }
+        try playback.enqueue(AudioChunk(requestID: id, index: index, samples: samples,
+                                        sampleRate: 24_000, startsParagraph: false))
+    }
+
+    private func waitUntilFinished(_ playback: PlaybackController, timeout: Double) async throws {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while playback.state != .finished && playback.state != .failed && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(playback.state == .finished)
+        #expect(playback.failureMessage == nil)
+    }
+
+    @Test("Real output graph finishes at the requested speed", arguments: [0.5, 0.75, 1.0, 1.25, 1.5, 2.0])
+    func duration(rate: Double) async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = rate
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP integration fixture", estimatedDuration: 1, modelID: nil)
+        try enqueue(playback, id: id, duration: 1)
+        let start = ContinuousClock.now
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 1 / rate + 2)
+        let wall = start.duration(to: .now)
+        #expect(wall > .seconds(1 / rate - 0.2))
+        #expect(wall < .seconds(1 / rate + 0.75))
+        #expect(abs(playback.elapsed - 1) < 0.001)
+    }
+
+    @Test("Speed changes, paused seeks and replay preserve source position")
+    func controls() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 0.5
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP control fixture", estimatedDuration: 2, modelID: nil)
+        try enqueue(playback, id: id, duration: 2)
+        playback.finishBuffering()
+        try await Task.sleep(for: .milliseconds(300))
+        let before = playback.elapsed
+        playback.rate = 2
+        #expect(playback.state == .playing)
+        #expect(abs(playback.elapsed - before) < 0.15)
+        playback.pause()
+        #expect(playback.state == .paused)
+        playback.rate = 0.75
+        #expect(playback.state == .paused)
+        playback.seek(to: 1.5)
+        #expect(abs(playback.elapsed - 1.5) < 0.001)
+        playback.play()
+        try await waitUntilFinished(playback, timeout: 2)
+        playback.rate = 2
+        playback.play()
+        try await waitUntilFinished(playback, timeout: 3)
+    }
+
+    @Test("Progressive underruns retain the delayed audio and completion tail")
+    func progressive() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 1.5
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP progressive fixture", estimatedDuration: 1, modelID: nil)
+        try enqueue(playback, id: id, duration: 0.5)
+        playback.play()
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(playback.state == .buffering)
+        #expect(playback.elapsed < playback.generatedDuration)
+        try enqueue(playback, id: id, duration: 0.5, index: 1)
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 2)
+        #expect(abs(playback.elapsed - 1) < 0.001)
+    }
+
+    @Test("Long playback replenishes the scheduling horizon")
+    func schedulingHorizon() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 2
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP horizon fixture", estimatedDuration: 13, modelID: nil)
+        try enqueue(playback, id: id, duration: 13)
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 9)
+        #expect(abs(playback.elapsed - 13) < 0.001)
+    }
+}

--- a/Tests/SayItPlaybackTests/AudioArchiveTests.swift
+++ b/Tests/SayItPlaybackTests/AudioArchiveTests.swift
@@ -8,7 +8,7 @@ struct AudioArchiveTests {
     @Test("Playback uses high quality time stretching")
     @MainActor
     func playbackUsesHighQualityTimeStretching() {
-        #expect(PlaybackController.highQualityTimePitchOverlap == 32)
+        #expect(PlaybackController.timeStretchEngineName == "Sonic")
         #expect(
             PlaybackController.preferredStartBufferDuration(for: 1) == 1.2
         )

--- a/project.yml
+++ b/project.yml
@@ -8,6 +8,8 @@ options:
   groupSortPosition: top
 
 packages:
+  PlaybackDSP:
+    path: Packages/PlaybackDSP
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     exactVersion: 2.9.6
@@ -105,6 +107,8 @@ targets:
     sources:
       - path: Sources/SayItBackend
     dependencies:
+      - package: PlaybackDSP
+        product: PlaybackDSP
       - target: SayItCore
       - target: SayItProtocol
       - package: MLXAudio


### PR DESCRIPTION
Compare pitch-preserving playback using Sonic's quality mode instead of AVAudioUnitTimePitch. This is an independent listening experiment based on main, alternative to #25; these engine branches should not be merged together.

The existing 0.5–2× controls drive one continuous native Sonic stream. Original audio and exports remain unchanged, and 1× bypasses processing exactly. Live speed changes reschedule from the audible source position. Pending output, final lookahead, cumulative sample rounding, progressive underruns, and source-time tracking are handled explicitly.

The Apache-2.0 upstream sources are pinned and vendored. Sonic internally converts floats to 16-bit PCM; the wrapper clamps non-unity input before conversion to avoid overflow. That precision tradeoff is documented as part of the quality comparison. No runtime library installation is required.

Validation:
- DSP tests passed at six speeds (0.5, 0.75, 1, 1.25, 1.5, 2×) and three sample rates (24, 44.1, 48 kHz), checking duration, pitch, level, finite samples, short tails and reset isolation.
- Muted real-output integration tests passed for every speed, live rate changes, paused seeks, replay, progressive underruns, and playback beyond the scheduling horizon.
- Full existing package suite: 358 tests passed, using the app's compiled MLX Metal library.
- Local app build, signing verification, package linkage, updater and catalog checks passed. Existing upstream MLX dependency warnings remain.
- The offline renderer produced six speech WAVs with the expected sample counts. Listening quality remains for manual assessment.

Run `swift test --package-path Packages/PlaybackDSP -c release` for DSP tests, or set `SAYIT_PLAYBACK_INTEGRATION=1` when running `TimeStretchPlaybackTests` on a Mac with audio output. The `PlaybackDSPRender` tool renders a saved source file at every comparison speed; usage is in `Packages/PlaybackDSP/README.md`.

For listening, keep native Speaking Pace at Natural and compare identical text/voice or saved audio. Assess metallic artifacts, consonants, voice warmth and low-level noise, particularly at 0.5× and 2×. Run only one local comparison app at a time because variants share the local app identity and settings.
