### PR TITLE
Compare Rubber Band R3 pitch-preserving playback

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .executable(name: "SayIt", targets: ["SayIt"])
     ],
     dependencies: [
+        .package(path: "Packages/PlaybackDSP"),
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.6"),
         .package(
             url: "https://github.com/Blaizzy/mlx-audio-swift.git",
@@ -71,6 +72,7 @@ let package = Package(
         .target(
             name: "SayItBackend",
             dependencies: [
+                .product(name: "PlaybackDSP", package: "PlaybackDSP"),
                 "SayItCore",
                 "SayItProtocol",
                 .product(name: "MLXAudioCore", package: "mlx-audio-swift"),

--- a/Packages/PlaybackDSP/COMPARISON-LICENSE.md
+++ b/Packages/PlaybackDSP/COMPARISON-LICENSE.md
@@ -1,0 +1,14 @@
+# License of this experimental combined build
+
+This branch links Rubber Band Library, licensed under GNU GPL version 2 or (at
+your option) any later version. This experimental combined application uses the
+GPL version 3 option, compatible with the project's Apache-2.0 dependencies.
+The GPLv3 text is included in `COPYING.GPL-3.0`. The original Rubber Band notice
+and license are preserved at `Sources/CPlaybackDSP/vendor/COPYING`, along with
+its corresponding source. The pre-existing Say It source retains its MIT license.
+
+This branch is an isolated evaluation alternative, not a dependency change proposed
+for automatic inclusion in the MIT distribution. Rubber Band also offers a
+commercial license: https://breakfastquay.com/rubberband/license.html
+
+Preserve the included source and notices when sharing this experimental build.

--- a/Packages/PlaybackDSP/COPYING.GPL-3.0
+++ b/Packages/PlaybackDSP/COPYING.GPL-3.0
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/Packages/PlaybackDSP/Package.swift
+++ b/Packages/PlaybackDSP/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "PlaybackDSP",
+    platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "PlaybackDSP", targets: ["PlaybackDSP"]),
+        .executable(name: "PlaybackDSPRender", targets: ["PlaybackDSPRender"])
+    ],
+    targets: [
+        .target(
+            name: "CPlaybackDSP",
+            exclude: ["vendor"],
+            sources: ["TimeStretch.cpp", "RubberBandBuild.cpp"],
+            publicHeadersPath: "include",
+            cxxSettings: [.headerSearchPath("vendor")],
+            linkerSettings: [.linkedFramework("Accelerate")]
+        ),
+        .target(name: "PlaybackDSP", dependencies: ["CPlaybackDSP"]),
+        .testTarget(name: "PlaybackDSPTests", dependencies: ["PlaybackDSP"]),
+        .executableTarget(name: "PlaybackDSPRender", dependencies: ["PlaybackDSP"])
+    ],
+    cxxLanguageStandard: .cxx17
+)

--- a/Packages/PlaybackDSP/README.md
+++ b/Packages/PlaybackDSP/README.md
@@ -1,0 +1,27 @@
+# Rubber Band R3 playback comparison
+
+This experimental branch replaces Apple's playback time stretcher with Rubber
+Band 4.0.0's R3 Finer engine, using real-time mode, standard windows, and unchanged
+pitch. Playback speed remains 0.5–2×. At 1× the original PCM bypasses processing.
+One continuous processor spans scheduling chunks. Startup padding and delay use
+the library's own reported values, variable output counts are buffered, and the
+final tail is drained and trimmed to the cumulative target duration. Source audio
+and exports stay original.
+
+Vendored unmodified sources: breakfastquay/rubberband at `1d95888` (v4.0.0).
+The upstream single-file build uses Apple Accelerate and the bundled resampler;
+no runtime library installation is needed. See `COMPARISON-LICENSE.md` for the
+GPL terms of this experimental combined build and the vendor's commercial option.
+
+Run `swift test --package-path Packages/PlaybackDSP -c release` for DSP tests, then
+`./Scripts/build-app.sh` for the local app. Compare the same voice/text and keep
+native Speaking Pace at Natural. Test 0.5, 0.75, 1, 1.25, 1.5 and 2×, including
+mid-sentence rate changes, pause/resume, seek, progressive generation, and replay.
+This is a listening experiment, not a claim of perceptual superiority.
+
+To render a saved speech file at every comparison speed, run
+`swift run -c release --package-path Packages/PlaybackDSP PlaybackDSPRender input.wav output-directory`.
+Use a fresh output directory for each engine. CSV output reports sample counts
+and DSP processing time; the six WAV files can be compared directly. No audio or
+measurements are uploaded. Only run one comparison app at a time; the variants
+share the local app identity and settings.

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/RubberBandBuild.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/RubberBandBuild.cpp
@@ -1,0 +1,2 @@
+// Upstream's single translation unit selects Accelerate and its bundled resampler.
+#include "vendor/single/RubberBandSingle.cpp"

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/TimeStretch.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/TimeStretch.cpp
@@ -1,0 +1,100 @@
+#include "TimeStretch.h"
+#include "vendor/rubberband/RubberBandStretcher.h"
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+using Stretcher = RubberBand::RubberBandStretcher;
+struct Stream {
+    Stretcher stretch;
+    double rate;
+    int64_t inputFrames = 0, deliveredFrames = 0;
+    size_t skip = 0;
+    bool finished = false;
+    std::vector<float> pending, output;
+    static constexpr int blockSize = 4096;
+
+    Stream(double sampleRate, double rate)
+        : stretch(size_t(sampleRate), 1,
+                  Stretcher::OptionProcessRealTime | Stretcher::OptionEngineFiner
+                  | Stretcher::OptionChannelsTogether | Stretcher::OptionThreadingNever,
+                  1.0 / rate, 1.0), rate(rate) {
+        if (stretch.getEngineVersion() != 3) throw std::runtime_error("R3 engine unavailable");
+        stretch.setMaxProcessSize(blockSize);
+        if (rate != 1) {
+            skip = stretch.getStartDelay();
+            std::vector<float> padding(stretch.getPreferredStartPad(), 0);
+            write(padding.data(), int(padding.size()), false);
+        }
+    }
+
+    void drain() {
+        int available;
+        while ((available = stretch.available()) > 0) {
+            std::vector<float> block(available);
+            float *channels[] = {block.data()};
+            auto count = stretch.retrieve(channels, available);
+            if (count == 0) throw std::runtime_error("Incomplete read");
+            auto drop = std::min(skip, count);
+            skip -= drop;
+            pending.insert(pending.end(), block.begin() + drop, block.begin() + count);
+        }
+    }
+
+    void write(const float *input, int count, bool final) {
+        for (int start = 0; start < count; start += blockSize) {
+            int size = std::min(blockSize, count - start);
+            const float *channels[] = {input + start};
+            stretch.process(channels, size, final && start + size == count);
+            drain();
+        }
+        if (count == 0 && final) {
+            const float zero = 0;
+            const float *channels[] = {&zero};
+            stretch.process(channels, 0, true);
+            drain();
+        }
+    }
+
+    void process(const float *input, int count, bool final) {
+        if (finished) throw std::runtime_error("Stream already finalized");
+        output.clear();
+        inputFrames += count;
+        auto expected = std::llround(inputFrames / rate);
+        if (rate == 1) {
+            if (count) output.assign(input, input + count);
+            deliveredFrames += count;
+        } else {
+            write(input, count, final);
+            // Rubber Band's local ratio is adaptive: buffer extra output rather
+            // than assuming a fixed input/output count for each processing call.
+            auto keep = std::min<int64_t>(pending.size(), expected - deliveredFrames);
+            output.assign(pending.begin(), pending.begin() + keep);
+            pending.erase(pending.begin(), pending.begin() + keep);
+            deliveredFrames += keep;
+            if (final && deliveredFrames != expected) throw std::runtime_error("Incomplete tail");
+        }
+        finished = final;
+    }
+};
+}
+extern "C" void *sayit_stretch_create(double sampleRate, double rate) {
+    if (!std::isfinite(sampleRate) || sampleRate < 8000 || sampleRate > 192000
+        || !std::isfinite(rate) || rate < 0.5 || rate > 2) return nullptr;
+    try { return new Stream(sampleRate, rate); } catch (...) { return nullptr; }
+}
+extern "C" void sayit_stretch_destroy(void *handle) { delete static_cast<Stream *>(handle); }
+extern "C" const float *sayit_stretch_process(void *handle, const float *input, int count,
+                                             int final, int *outputCount) {
+    *outputCount = -1;
+    if (!handle || count < 0 || (count && !input)) return nullptr;
+    try {
+        auto &stream = *static_cast<Stream *>(handle);
+        stream.process(input, count, final != 0);
+        *outputCount = int(stream.output.size());
+        return stream.output.data();
+    } catch (...) { return nullptr; }
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/include/TimeStretch.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/include/TimeStretch.h
@@ -1,0 +1,15 @@
+#ifndef SAYIT_TIME_STRETCH_H
+#define SAYIT_TIME_STRETCH_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Each handle belongs to one serial processing context. No audio callback work.
+void *sayit_stretch_create(double sample_rate, double playback_rate);
+void sayit_stretch_destroy(void *handle);
+// Output is owned by handle until the next call. A negative count signals failure.
+const float *sayit_stretch_process(void *handle, const float *input, int count,
+                                  int final, int *output_count);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/COPYING
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/COPYING
@@ -1,0 +1,561 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                          675 Mass Ave, Cambridge, MA 02139, USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/rubberband/RubberBandLiveShifter.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/rubberband/RubberBandLiveShifter.h
@@ -1,0 +1,353 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Live Pitch Shifter obtained by agreement with the
+    copyright holders, you may redistribute and/or modify it under the
+    terms described in that licence.
+
+    If you wish to distribute code using Rubber Band Live under terms
+    other than those of the GNU General Public License, you must
+    obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_LIVE_SHIFTER_H
+#define RUBBERBAND_LIVE_SHIFTER_H
+
+#define RUBBERBAND_VERSION "4.0.0"
+#define RUBBERBAND_API_MAJOR_VERSION 3
+#define RUBBERBAND_API_MINOR_VERSION 0
+
+#undef RUBBERBAND_LIVE_DLLEXPORT
+#ifdef _MSC_VER
+#define RUBBERBAND_LIVE_DLLEXPORT __declspec(dllexport)
+#else
+#define RUBBERBAND_LIVE_DLLEXPORT
+#endif
+
+#include <vector>
+#include <map>
+#include <string>
+#include <memory>
+#include <cstddef>
+
+namespace RubberBand
+{
+
+/**
+ * ### Summary
+ * 
+ * RubberBand::RubberBandLiveShifter is an interface to the Rubber
+ * Band Library designed for applications that need to perform
+ * pitch-shifting only, without time-stretching, and to do so in a
+ * straightforward block-by-block process with the shortest available
+ * processing delay. For the more general interface, see
+ * RubberBand::RubberBandStretcher.
+ *
+ * RubberBandLiveShifter has a much simpler API than
+ * RubberBandStretcher. Its process function, called
+ * RubberBandLiveShifter::shift(), accepts a fixed number of sample
+ * frames on each call and always returns exactly the same number of
+ * sample frames. This is in contrast to the
+ * process/available/retrieve call sequence that RubberBandStretcher
+ * requires as a result of its variable output rate.
+ *
+ * The number of frames accepted by and returned from
+ * RubberBandLiveShifter::shift() are not under the caller's control:
+ * they must always be exactly the number given by
+ * RubberBandLiveShifter::getBlockSize(). But this number is fixed for
+ * the lifetime of the shifter, so it only needs to be queried once
+ * after construction and then fixed-size buffers may be used.
+ *
+ * Using RubberBandLiveShifter also gives a shorter processing delay
+ * than a typical buffering setup using RubberBandStretcher, making it
+ * a useful choice for some streamed or live situations. However, it
+ * is still not a low-latency effect, with a delay of 50ms or more
+ * between input and output signals depending on configuration. (The
+ * actual value may be queried via
+ * RubberBandLiveShifter::getStartDelay().) The shifter is real-time
+ * safe in the sense of avoiding allocation, locking, or blocking
+ * operations in the processing path.
+ *
+ * ### Thread safety
+ * 
+ * Multiple instances of RubberBandLiveShifter may be created and used
+ * in separate threads concurrently.  However, for any single instance
+ * of RubberBandLiveShifter, you may not call
+ * RubberBandLiveShifter::shift() more than once concurrently, and you
+ * may not change the pitch scaling ratio using
+ * RubberBandLiveShifter::setPitchScale() while a
+ * RubberBandLiveShifter::shift() call is being executed. Changing the
+ * ratio is real-time safe, so when the pitch ratio is time-varying,
+ * it is normal to update the ratio before each shift call.
+ */
+class RUBBERBAND_LIVE_DLLEXPORT
+RubberBandLiveShifter
+{
+public:
+    enum Option {
+        OptionWindowShort          = 0x00000000,
+        OptionWindowMedium         = 0x00100000,
+
+        OptionFormantShifted       = 0x00000000,
+        OptionFormantPreserved     = 0x01000000,
+
+        OptionChannelsApart        = 0x00000000,
+        OptionChannelsTogether     = 0x10000000
+
+        // n.b. Options is int, so we must stop before 0x80000000
+    };
+
+    /**
+     * A bitwise OR of values from the RubberBandLiveShifter::Option
+     * enum.
+     */
+    typedef int Options;
+
+    enum PresetOption {
+        DefaultOptions = 0x00000000
+    };
+
+    /**
+     * Interface for log callbacks that may optionally be provided to
+     * the shifter on construction.
+     *
+     * If a Logger is provided, the shifter will call one of these
+     * functions instead of sending output to \c cerr when there is
+     * something to report. This allows debug output to be diverted to
+     * an application's logging facilities, and/or handled in an
+     * RT-safe way. See setDebugLevel() for details about how and when
+     * RubberBandLiveShifter reports something in this way.
+     *
+     * The message text passed to each of these log functions is a
+     * C-style string with no particular guaranteed lifespan. If you
+     * need to retain it, copy it before returning. Do not free it.
+     *
+     * @see setDebugLevel
+     * @see setDefaultDebugLevel
+     */
+    struct Logger {
+        /// Receive a log message with no numeric values.
+        virtual void log(const char *) = 0;
+
+        /// Receive a log message and one accompanying numeric value.
+        virtual void log(const char *, double) = 0;
+
+        /// Receive a log message and two accompanying numeric values.
+        virtual void log(const char *, double, double) = 0;
+        
+        virtual ~Logger() { }
+    };
+    
+    /**
+     * Construct a pitch shifter object to run at the given sample
+     * rate, with the given number of channels.
+     */
+    RubberBandLiveShifter(size_t sampleRate, size_t channels,
+                          Options options);
+
+    /**
+     * Construct a pitch shifter object with a custom debug
+     * logger. This may be useful for debugging if the default logger
+     * output (which simply goes to \c cerr) is not visible in the
+     * runtime environment, or if the application has a standard or
+     * more realtime-appropriate logging mechanism.
+     *
+     * See the documentation for the other constructor above for
+     * details of the arguments other than the logger.
+     *
+     * Note that although the supplied logger gets to decide what to
+     * do with log messages, the separately-set debug level (see
+     * setDebugLevel() and setDefaultDebugLevel()) still determines
+     * whether any given debug message is sent to the logger in the
+     * first place.
+     */
+    RubberBandLiveShifter(size_t sampleRate, size_t channels,
+                          std::shared_ptr<Logger> logger,
+                          Options options);
+    
+    ~RubberBandLiveShifter();
+
+    /**
+     * Reset the shifter's internal buffers.  The shifter should
+     * subsequently behave as if it had just been constructed
+     * (although retaining the current pitch ratio).
+     */
+    void reset();
+
+    /**
+     * Set the pitch scaling ratio for the shifter.  This is the ratio
+     * of target frequency to source frequency.  For example, a ratio
+     * of 2.0 would shift up by one octave; 0.5 down by one octave; or
+     * 1.0 leave the pitch unaffected.
+     *
+     * To put this in musical terms, a pitch scaling ratio
+     * corresponding to a shift of S equal-tempered semitones (where S
+     * is positive for an upwards shift and negative for downwards) is
+     * pow(2.0, S / 12.0).
+     *
+     * This function may be called at any time, so long as it is not
+     * called concurrently with shift().  You should either call this
+     * function from the same thread as shift(), or provide your own
+     * mutex or similar mechanism to ensure that setPitchScale and
+     * shift() cannot be run at once (there is no internal mutex for
+     * this purpose).
+     */
+    void setPitchScale(double scale);
+
+    /**
+     * Set a pitch scale for the vocal formant envelope separately
+     * from the overall pitch scale.  This is a ratio of target
+     * frequency to source frequency.  For example, a ratio of 2.0
+     * would shift the formant envelope up by one octave; 0.5 down by
+     * one octave; or 1.0 leave the formant unaffected.
+     *
+     * By default this is set to the special value of 0.0, which
+     * causes the scale to be calculated automatically. It will be
+     * treated as 1.0 / the pitch scale if OptionFormantPreserved is
+     * specified, or 1.0 for OptionFormantShifted.
+     *
+     * Conversely, if this is set to a value other than the default
+     * 0.0, formant shifting will happen regardless of the state of
+     * the OptionFormantPreserved/OptionFormantShifted option.
+     *
+     * This function is provided for special effects only. You do not
+     * need to call it for ordinary pitch shifting, with or without
+     * formant preservation - just specify or omit the
+     * OptionFormantPreserved option as appropriate. Use this function
+     * only if you want to shift formants by a distance other than
+     * that of the overall pitch shift.
+     */
+    void setFormantScale(double scale);
+
+    /**
+     * Return the last pitch scaling ratio value that was set (either
+     * on construction or with setPitchScale()).
+     */
+    double getPitchScale() const;
+
+    /**
+     * Return the last formant scaling ratio that was set with
+     * setFormantScale, or 0.0 if the default automatic scaling is in
+     * effect.
+     */     
+    double getFormantScale() const;
+    
+    /**
+     * Return the output delay of the shifter.  This is the number of
+     * audio samples that one should discard at the start of the
+     * output, in order to ensure that the resulting audio has the
+     * expected time alignment with the input.
+     *
+     * Ensure you have set the pitch scale to its proper starting
+     * value before calling getStartDelay().
+     */
+    size_t getStartDelay() const;
+    
+    /**
+     * Return the number of channels this shifter was constructed
+     * with.
+     */
+    size_t getChannelCount() const;
+
+    /**
+     * Change an OptionFormant configuration setting.  This may be
+     * called at any time in any mode.
+     *
+     * Note that if running multi-threaded in Offline mode, the change
+     * may not take effect immediately if processing is already under
+     * way when this function is called.
+     */
+    void setFormantOption(Options options);
+
+    /**
+     * Query the number of sample frames that must be passed to, and
+     * will be returned by, each shift() call. This value is fixed for
+     * the lifetime of the shifter.
+     *
+     * Note that the blocksize refers to the number of audio sample
+     * frames, which may be multi-channel, not the number of
+     * individual samples.
+     */
+    size_t getBlockSize() const;
+    
+    /**
+     * Pitch-shift a single block of sample frames. The number of
+     * sample frames (samples per channel) processed per call is
+     * constant.
+     *
+     * "input" should point to de-interleaved audio data with one
+     * float array per channel, with each array containing n samples
+     * where n is the value returned by getBlockSize().
+     * 
+     * "output" should point to a float array per channel, with each
+     * array having enough room to store n samples where n is the value
+     * returned by getBlockSize().
+     *
+     * The input and output must be separate arrays; they cannot alias
+     * one another or overlap.
+     *
+     * Sample values are conventionally expected to be in the range
+     * -1.0f to +1.0f.
+     */
+    void shift(const float *const *input, float *const *output);
+
+    /**
+     * Set the level of debug output.  The supported values are:
+     *
+     * 0. Report errors only.
+     * 
+     * 1. Report some information on construction and ratio
+     * change. Nothing is reported during normal processing unless
+     * something changes.
+     * 
+     * 2. Report a significant amount of information about ongoing
+     * calculations during normal processing.
+     *
+     * The default is whatever has been set using
+     * setDefaultDebugLevel(), or 0 if that function has not been
+     * called.
+     *
+     * All output goes to \c cerr unless a custom
+     * RubberBandLiveShifter::Logger has been provided on
+     * construction. Because writing to \c cerr is not RT-safe, only
+     * debug level 0 is RT-safe in normal use by default. Debug levels
+     * 0 and 1 use only C-string constants as debug messages, so they
+     * are RT-safe if your custom logger is RT-safe. Levels 2 and 3
+     * are not guaranteed to be RT-safe in any conditions as they may
+     * construct messages by allocation.
+     *
+     * @see Logger
+     * @see setDefaultDebugLevel
+     */
+    void setDebugLevel(int level);
+
+    /**
+     * Set the default level of debug output for subsequently
+     * constructed shifters.
+     *
+     * @see setDebugLevel
+     */
+    static void setDefaultDebugLevel(int level);
+
+protected:
+    class Impl;
+    Impl *m_d;
+
+    RubberBandLiveShifter(const RubberBandLiveShifter &) =delete;
+    RubberBandLiveShifter &operator=(const RubberBandLiveShifter &) =delete;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/rubberband/RubberBandStretcher.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/rubberband/RubberBandStretcher.h
@@ -1,0 +1,1099 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_STRETCHER_H
+#define RUBBERBAND_STRETCHER_H
+    
+#define RUBBERBAND_VERSION "4.0.0"
+#define RUBBERBAND_API_MAJOR_VERSION 3
+#define RUBBERBAND_API_MINOR_VERSION 0
+
+#undef RUBBERBAND_DLLEXPORT
+#ifdef _MSC_VER
+#ifndef RUBBERBAND_STATIC
+#define RUBBERBAND_DLLEXPORT __declspec(dllexport)
+#else
+#define RUBBERBAND_DLLEXPORT
+#endif
+#else
+#define RUBBERBAND_DLLEXPORT
+#endif
+
+#include <vector>
+#include <map>
+#include <string>
+#include <memory>
+#include <cstddef>
+
+namespace RubberBand
+{
+
+/**
+ * @mainpage RubberBand
+ *
+ * ### Summary
+ * 
+ * The primary Rubber Band Library API is contained in the class
+ * RubberBand::RubberBandStretcher. This class can perform both pitch
+ * shifting and time stretching and supports every feature of the
+ * library. A simpler, more limited API that supports only
+ * pitch-shifting can be found in RubberBand::RubberBandLiveShifter.
+ *
+ * RubberBandStretcher supports two processing modes, offline and
+ * real-time, and two processing "engines", known as the R2 or Faster
+ * engine and the R3 or Finer engine. The choices of processing mode
+ * and engine are fixed on construction: see the constructor
+ * RubberBandStretcher::RubberBandStretcher. The two engines work
+ * identically in API terms, and both of them support both offline and
+ * real-time modes as described below.
+ *
+ * ### Offline mode
+ *
+ * In offline mode, you must provide the audio block-by-block in
+ * two passes. In the first pass, call RubberBandStretcher::study() on
+ * each block; in the second pass, call RubberBandStretcher::process()
+ * on each block and receive the output via
+ * RubberBandStretcher::retrieve().
+ *
+ * In offline mode, the time and pitch ratios are fixed as soon as the
+ * study pass has begun and cannot be changed afterwards. (But see
+ * RubberBandStretcher::setKeyFrameMap() for a way to do pre-planned
+ * variable time stretching in offline mode.) Offline mode also
+ * performs padding and delay compensation so that the stretched
+ * result has an exact start and duration.
+ *
+ * ### Real-time mode
+ *
+ * In \b real-time mode, there is no study pass, just a single
+ * streaming pass in which the audio is passed to
+ * RubberBandStretcher::process() and output received via
+ * RubberBandStretcher::retrieve().
+ *
+ * In real-time mode you can change the time and pitch ratios at any
+ * time.
+ *
+ * You may need to perform signal padding and delay compensation in
+ * real-time mode; see RubberBandStretcher::getPreferredStartPad() and
+ * RubberBandStretcher::getStartDelay() for details.
+ *
+ * Rubber Band Library is RT-safe when used in real-time mode with
+ * "normal" processing parameters. That is, it performs no allocation,
+ * locking, or blocking operations after initialisation during normal
+ * use, even when the time and pitch ratios change. There are certain
+ * exceptions that include error states and extremely rapid changes
+ * between extreme ratios, as well as the case in which more frames
+ * are passed to RubberBandStretcher::process() than the values
+ * returned by RubberBandStretcher::getSamplesRequired() or set using
+ * RubberBandStretcher::setMaxProcessSize(), when buffer reallocation
+ * may occur. See the latter function's documentation for
+ * details. Note that offline mode is never RT-safe.
+ *
+ * ### Thread safety
+ * 
+ * Multiple instances of RubberBandStretcher may be created and used
+ * in separate threads concurrently.  However, for any single instance
+ * of RubberBandStretcher, you may not call
+ * RubberBandStretcher::process() more than once concurrently, and you
+ * may not change the time or pitch ratio while a
+ * RubberBandStretcher::process() call is being executed (if the
+ * stretcher was created in "real-time mode"; in "offline mode" you
+ * can't change the ratios during use anyway).
+ * 
+ * So you can run RubberBandStretcher::process() in its own thread if
+ * you like, but if you want to change ratios dynamically from a
+ * different thread, you will need some form of mutex in your code.
+ * Changing the time or pitch ratio is real-time safe except in
+ * extreme circumstances, so for most applications that may change
+ * these dynamically it probably makes most sense to do so from the
+ * same thread as calls RubberBandStretcher::process(), even if that
+ * is a real-time thread.
+ */
+class RUBBERBAND_DLLEXPORT
+RubberBandStretcher
+{
+public:
+    /**
+     * Processing options for the timestretcher.  The preferred
+     * options should normally be set in the constructor, as a bitwise
+     * OR of the option flags.  The default value (DefaultOptions) is
+     * intended to give good results in most situations.
+     *
+     * 1. Flags prefixed \c OptionProcess determine how the timestretcher
+     * will be invoked.  These options may not be changed after
+     * construction.
+     * 
+     *   \li \c OptionProcessOffline - Run the stretcher in offline
+     *   mode.  In this mode the input data needs to be provided
+     *   twice, once to study(), which calculates a stretch profile
+     *   for the audio, and once to process(), which stretches it.
+     *
+     *   \li \c OptionProcessRealTime - Run the stretcher in real-time
+     *   mode.  In this mode only process() should be called, and the
+     *   stretcher adjusts dynamically in response to the input audio.
+     * 
+     * The Process setting is likely to depend on your architecture:
+     * non-real-time operation on seekable files: Offline; real-time
+     * or streaming operation: RealTime.
+     *
+     * 2. Flags prefixed \c OptionEngine select the core Rubber Band
+     * processing engine to be used. These options may not be changed
+     * after construction.
+     *
+     *   \li \c OptionEngineFaster - Use the Rubber Band Library R2
+     *   (Faster) engine. This is the engine implemented in Rubber
+     *   Band Library v1.x and v2.x, and it remains the default in
+     *   newer versions. It uses substantially less CPU than the R3
+     *   engine and there are still many situations in which it is
+     *   likely to be the more appropriate choice.
+     *
+     *   \li \c OptionEngineFiner - Use the Rubber Band Library R3
+     *   (Finer) engine. This engine was introduced in Rubber Band
+     *   Library v3.0. It produces higher-quality results than the R2
+     *   engine for most material, especially complex mixes, vocals
+     *   and other sounds that have soft onsets and smooth pitch
+     *   changes, and music with substantial bass content. However, it
+     *   uses much more CPU power than the R2 engine.
+     *
+     *   Important note: Consider calling getEngineVersion() after
+     *   construction to make sure the engine you requested is
+     *   active. That's not because engine selection can fail, but
+     *   because Rubber Band Library ignores any unknown options
+     *   supplied on construction - so a program that requests the R3
+     *   engine but ends up linked against an older version of the
+     *   library (prior to v3.0) will silently use the R2 engine
+     *   instead. Calling the v3.0 function getEngineVersion() will
+     *   ensure a link failure in this situation instead, and supply a
+     *   reassuring run-time check.
+     *
+     * 3. Flags prefixed \c OptionTransients control the component
+     * frequency phase-reset mechanism in the R2 engine, that may be
+     * used at transient points to provide clarity and realism to
+     * percussion and other significant transient sounds. These
+     * options have no effect when using the R3 engine.  These options
+     * may be changed after construction when running in real-time
+     * mode, but not when running in offline mode.
+     * 
+     *   \li \c OptionTransientsCrisp - Reset component phases at the
+     *   peak of each transient (the start of a significant note or
+     *   percussive event).  This, the default setting, usually
+     *   results in a clear-sounding output; but it is not always
+     *   consistent, and may cause interruptions in stable sounds
+     *   present at the same time as transient events.  The
+     *   OptionDetector flags (below) can be used to tune this to some
+     *   extent.
+     *
+     *   \li \c OptionTransientsMixed - Reset component phases at the
+     *   peak of each transient, outside a frequency range typical of
+     *   musical fundamental frequencies.  The results may be more
+     *   regular for mixed stable and percussive notes than
+     *   \c OptionTransientsCrisp, but with a "phasier" sound.  The
+     *   balance may sound very good for certain types of music and
+     *   fairly bad for others.
+     *
+     *   \li \c OptionTransientsSmooth - Do not reset component phases
+     *   at any point.  The results will be smoother and more regular
+     *   but may be less clear than with either of the other
+     *   transients flags.
+     *
+     * 4. Flags prefixed \c OptionDetector control the type of
+     * transient detector used in the R2 engine.  These options have
+     * no effect when using the R3 engine.  These options may be
+     * changed after construction when running in real-time mode, but
+     * not when running in offline mode.
+     *
+     *   \li \c OptionDetectorCompound - Use a general-purpose
+     *   transient detector which is likely to be good for most
+     *   situations.  This is the default.
+     *
+     *   \li \c OptionDetectorPercussive - Detect percussive
+     *   transients.  Note that this was the default and only option
+     *   in Rubber Band versions prior to 1.5.
+     *
+     *   \li \c OptionDetectorSoft - Use an onset detector with less
+     *   of a bias toward percussive transients.  This may give better
+     *   results with certain material (e.g. relatively monophonic
+     *   piano music).
+     *
+     * 5. Flags prefixed \c OptionPhase control the adjustment of
+     * component frequency phases in the R2 engine from one analysis
+     * window to the next during non-transient segments.  These
+     * options have no effect when using the R3 engine. These options
+     * may be changed at any time.
+     *
+     *   \li \c OptionPhaseLaminar - Adjust phases when stretching in
+     *   such a way as to try to retain the continuity of phase
+     *   relationships between adjacent frequency bins whose phases
+     *   are behaving in similar ways.  This, the default setting,
+     *   should give good results in most situations.
+     *
+     *   \li \c OptionPhaseIndependent - Adjust the phase in each
+     *   frequency bin independently from its neighbours.  This
+     *   usually results in a slightly softer, phasier sound.
+     *
+     * 6. Flags prefixed \c OptionThreading control the threading
+     * model of the stretcher.  These options may not be changed after
+     * construction.
+     *
+     *   \li \c OptionThreadingAuto - Permit the stretcher to
+     *   determine its own threading model.  In the R2 engine this
+     *   means using one processing thread per audio channel in
+     *   offline mode if the stretcher is able to determine that more
+     *   than one CPU is available, and one thread only in realtime
+     *   mode.  The R3 engine does not currently have a multi-threaded
+     *   mode, but if one is introduced in future, this option may use
+     *   it. This is the default.
+     *
+     *   \li \c OptionThreadingNever - Never use more than one thread.
+     *  
+     *   \li \c OptionThreadingAlways - Use multiple threads in any
+     *   situation where \c OptionThreadingAuto would do so, except omit
+     *   the check for multiple CPUs and instead assume it to be true.
+     *
+     * 7. Flags prefixed \c OptionWindow influence the window size for
+     * FFT processing. In the R2 engine these affect the resulting
+     * sound quality but have relatively little effect on processing
+     * speed. With the R3 engine they can dramatically affect
+     * processing speed as well as output quality. These options may
+     * not be changed after construction.
+     *
+     *   \li \c OptionWindowStandard - Use the default window size.
+     *   The actual size will vary depending on other parameters.
+     *   This option is expected to produce better results than the
+     *   other window options in most situations. In the R3 engine
+     *   this causes the engine's full multi-resolution processing
+     *   scheme to be used.
+     *
+     *   \li \c OptionWindowShort - Use a shorter window. This has
+     *   different effects with R2 and R3 engines.
+     *
+     *   With the R2 engine it may result in crisper sound for audio
+     *   that depends strongly on its timing qualities, but is likely
+     *   to sound worse in other ways and will have similar
+     *   efficiency.
+     *
+     *   With the R3 engine, it causes the engine to be restricted to
+     *   a single window size, resulting in both dramatically faster
+     *   processing and lower delay than OptionWindowStandard, but at
+     *   the expense of some sound quality. It may still sound better
+     *   for non-percussive material than the R2 engine.
+     *
+     *   With both engines it reduces the start delay somewhat (see
+     *   RubberBandStretcher::getStartDelay) which may be useful for
+     *   real-time handling.
+     *
+     *   \li \c OptionWindowLong - Use a longer window. With the R2
+     *   engine this is likely to result in a smoother sound at the
+     *   expense of clarity and timing. The R3 engine currently
+     *   ignores this option, treating it like OptionWindowStandard.
+     *
+     * 8. Flags prefixed \c OptionSmoothing control the use of
+     * window-presum FFT and time-domain smoothing in the R2
+     * engine. These options have no effect when using the R3 engine.
+     * These options may not be changed after construction.
+     *
+     *   \li \c OptionSmoothingOff - Do not use time-domain smoothing.
+     *   This is the default.
+     *
+     *   \li \c OptionSmoothingOn - Use time-domain smoothing.  This
+     *   will result in a softer sound with some audible artifacts
+     *   around sharp transients, but it may be appropriate for longer
+     *   stretches of some instruments and can mix well with
+     *   OptionWindowShort.
+     *
+     * 9. Flags prefixed \c OptionFormant control the handling of
+     * formant shape (spectral envelope) when pitch-shifting. These
+     * options affect both the R2 and R3 engines.  These options may
+     * be changed at any time.
+     *
+     *   \li \c OptionFormantShifted - Apply no special formant
+     *   processing.  The spectral envelope will be pitch shifted as
+     *   normal.  This is the default.
+     *
+     *   \li \c OptionFormantPreserved - Preserve the spectral
+     *   envelope of the unshifted signal.  This permits shifting the
+     *   note frequency without so substantially affecting the
+     *   perceived pitch profile of the voice or instrument.
+     *
+     * 10. Flags prefixed \c OptionPitch control the method used for
+     * pitch shifting. These options affect only realtime mode. In
+     * offline mode the method is not adjustable. In the R2 engine
+     * these options may be changed at any time; in the R3 engine they
+     * may be set only on construction.
+     *
+     *   \li \c OptionPitchHighSpeed - Favour CPU cost over sound
+     *   quality. This is the default. Use this when time-stretching
+     *   only, or for fixed pitch shifts where CPU usage is of
+     *   concern. Do not use this for arbitrarily time-varying pitch
+     *   shifts (see OptionPitchHighConsistency below).
+     *
+     *   \li \c OptionPitchHighQuality - Favour sound quality over CPU
+     *   cost. Use this for fixed pitch shifts where sound quality is
+     *   of most concern. Do not use this for arbitrarily time-varying
+     *   pitch shifts (see OptionPitchHighConsistency below).
+
+     *   \li \c OptionPitchHighConsistency - Use a method that
+     *   supports dynamic pitch changes without discontinuities,
+     *   including when crossing the 1.0 pitch scale. This may cost
+     *   more in CPU than the default, especially when the pitch scale
+     *   is exactly 1.0. You should use this option whenever you wish
+     *   to support dynamically changing pitch shift during
+     *   processing.
+     *
+     * 11. Flags prefixed \c OptionChannels control the method used
+     * for processing two-channel stereo audio. These options may not
+     * be changed after construction.
+     *
+     *   \li \c OptionChannelsApart - Channels are handled for maximum
+     *   individual fidelity, at the expense of synchronisation. In
+     *   the R3 engine, this means frequency-bin synchronisation is
+     *   maintained more closely for lower-frequency content than
+     *   higher.  In R2, it means the stereo channels are processed
+     *   individually and only synchronised at transients.  In both
+     *   engines this gives the highest quality for the individual
+     *   channels but a more diffuse stereo image, an unnatural
+     *   increase in "width", and generally a loss of mono
+     *   compatibility (i.e. mono mixes from stereo can sound phasy).
+     *   This option is the default.
+     *
+     *   \li \c OptionChannelsTogether - Channels are handled for
+     *   higher synchronisation at some expense of individual
+     *   fidelity. In particular, a stretcher processing two channels
+     *   will treat its input as a stereo pair and aim to maximise
+     *   clarity at the centre and preserve mono compatibility.  This
+     *   gives relatively less stereo space and width than the
+     *   default, as well as slightly lower fidelity for individual
+     *   channel content, but the results may be more appropriate for
+     *   many situations making use of stereo mixes.
+     *
+     * Finally, flags prefixed \c OptionStretch are obsolete flags
+     * provided for backward compatibility only. They are ignored by
+     * the stretcher.
+     */
+    enum Option {
+
+        OptionProcessOffline       = 0x00000000,
+        OptionProcessRealTime      = 0x00000001,
+
+        OptionStretchElastic       = 0x00000000, // obsolete
+        OptionStretchPrecise       = 0x00000010, // obsolete
+    
+        OptionTransientsCrisp      = 0x00000000,
+        OptionTransientsMixed      = 0x00000100,
+        OptionTransientsSmooth     = 0x00000200,
+
+        OptionDetectorCompound     = 0x00000000,
+        OptionDetectorPercussive   = 0x00000400,
+        OptionDetectorSoft         = 0x00000800,
+
+        OptionPhaseLaminar         = 0x00000000,
+        OptionPhaseIndependent     = 0x00002000,
+    
+        OptionThreadingAuto        = 0x00000000,
+        OptionThreadingNever       = 0x00010000,
+        OptionThreadingAlways      = 0x00020000,
+
+        OptionWindowStandard       = 0x00000000,
+        OptionWindowShort          = 0x00100000,
+        OptionWindowLong           = 0x00200000,
+
+        OptionSmoothingOff         = 0x00000000,
+        OptionSmoothingOn          = 0x00800000,
+
+        OptionFormantShifted       = 0x00000000,
+        OptionFormantPreserved     = 0x01000000,
+
+        OptionPitchHighSpeed       = 0x00000000,
+        OptionPitchHighQuality     = 0x02000000,
+        OptionPitchHighConsistency = 0x04000000,
+
+        OptionChannelsApart        = 0x00000000,
+        OptionChannelsTogether     = 0x10000000,
+
+        OptionEngineFaster         = 0x00000000,
+        OptionEngineFiner          = 0x20000000
+
+        // n.b. Options is int, so we must stop before 0x80000000
+    };
+
+    /**
+     * A bitwise OR of values from the RubberBandStretcher::Option
+     * enum.
+     */
+    typedef int Options;
+
+    enum PresetOption {
+        DefaultOptions             = 0x00000000,
+        PercussiveOptions          = 0x00102000
+    };
+
+    /**
+     * Interface for log callbacks that may optionally be provided to
+     * the stretcher on construction.
+     *
+     * If a Logger is provided, the stretcher will call one of these
+     * functions instead of sending output to \c cerr when there is
+     * something to report. This allows debug output to be diverted to
+     * an application's logging facilities, and/or handled in an
+     * RT-safe way. See setDebugLevel() for details about how and when
+     * RubberBandStretcher reports something in this way.
+     *
+     * The message text passed to each of these log functions is a
+     * C-style string with no particular guaranteed lifespan. If you
+     * need to retain it, copy it before returning. Do not free it.
+     *
+     * @see setDebugLevel
+     * @see setDefaultDebugLevel
+     */
+    struct Logger {
+        /// Receive a log message with no numeric values.
+        virtual void log(const char *) = 0;
+
+        /// Receive a log message and one accompanying numeric value.
+        virtual void log(const char *, double) = 0;
+
+        /// Receive a log message and two accompanying numeric values.
+        virtual void log(const char *, double, double) = 0;
+        
+        virtual ~Logger() { }
+    };
+    
+    /**
+     * Construct a time and pitch stretcher object to run at the given
+     * sample rate, with the given number of channels.
+     *
+     * Both of the stretcher engines provide their best balance of
+     * quality with efficiency at sample rates of 44100 or 48000 Hz.
+     * Other rates may be used, and the stretcher should produce
+     * sensible output with any rate from 8000 to 192000 Hz, but you
+     * are advised to use 44100 or 48000 where practical. Do not use
+     * rates below 8000 or above 192000 Hz.
+     *
+     * Initial time and pitch scaling ratios and other processing
+     * options may be provided. In particular, the behaviour of the
+     * stretcher depends strongly on whether offline or real-time mode
+     * is selected on construction (via OptionProcessOffline or
+     * OptionProcessRealTime option - offline is the default).
+     * 
+     * In offline mode, you must provide the audio block-by-block in
+     * two passes: in the first pass calling study(), in the second
+     * pass calling process() and receiving the output via
+     * retrieve(). In real-time mode, there is no study pass, just a
+     * single streaming pass in which the audio is passed to process()
+     * and output received via retrieve().
+     *
+     * In real-time mode you can change the time and pitch ratios at
+     * any time, but in offline mode they are fixed and cannot be
+     * changed after the study pass has begun. (However, see
+     * setKeyFrameMap() for a way to do pre-planned variable time
+     * stretching in offline mode.)
+     *
+     * See the option documentation above for more details.
+     */
+    RubberBandStretcher(size_t sampleRate,
+                        size_t channels,
+                        Options options = DefaultOptions,
+                        double initialTimeRatio = 1.0,
+                        double initialPitchScale = 1.0);
+
+    /**
+     * Construct a time and pitch stretcher object with a custom debug
+     * logger. This may be useful for debugging if the default logger
+     * output (which simply goes to \c cerr) is not visible in the
+     * runtime environment, or if the application has a standard or
+     * more realtime-appropriate logging mechanism.
+     *
+     * See the documentation for the other constructor above for
+     * details of the arguments other than the logger.
+     *
+     * Note that although the supplied logger gets to decide what to
+     * do with log messages, the separately-set debug level (see
+     * setDebugLevel() and setDefaultDebugLevel()) still determines
+     * whether any given debug message is sent to the logger in the
+     * first place.
+     */
+    RubberBandStretcher(size_t sampleRate,
+                        size_t channels,
+                        std::shared_ptr<Logger> logger,
+                        Options options = DefaultOptions,
+                        double initialTimeRatio = 1.0,
+                        double initialPitchScale = 1.0);
+    
+    ~RubberBandStretcher();
+
+    /**
+     * Reset the stretcher's internal buffers.  The stretcher should
+     * subsequently behave as if it had just been constructed
+     * (although retaining the current time and pitch ratio).
+     */
+    void reset();
+
+    /**
+     * Return the active internal engine version, according to the \c
+     * OptionEngine flag supplied on construction. This will return 2
+     * for the R2 (Faster) engine or 3 for the R3 (Finer) engine.
+     *
+     * This function was added in Rubber Band Library v3.0.
+     */
+    int getEngineVersion() const;
+    
+    /**
+     * Set the time ratio for the stretcher.  This is the ratio of
+     * stretched to unstretched duration -- not tempo.  For example, a
+     * ratio of 2.0 would make the audio twice as long (i.e. halve the
+     * tempo); 0.5 would make it half as long (i.e. double the tempo);
+     * 1.0 would leave the duration unaffected.
+     *
+     * If the stretcher was constructed in Offline mode, the time
+     * ratio is fixed throughout operation; this function may be
+     * called any number of times between construction (or a call to
+     * reset()) and the first call to study() or process(), but may
+     * not be called after study() or process() has been called.
+     *
+     * If the stretcher was constructed in RealTime mode, the time
+     * ratio may be varied during operation; this function may be
+     * called at any time, so long as it is not called concurrently
+     * with process().  You should either call this function from the
+     * same thread as process(), or provide your own mutex or similar
+     * mechanism to ensure that setTimeRatio and process() cannot be
+     * run at once (there is no internal mutex for this purpose).
+     */
+    void setTimeRatio(double ratio);
+
+    /**
+     * Set the pitch scaling ratio for the stretcher.  This is the
+     * ratio of target frequency to source frequency.  For example, a
+     * ratio of 2.0 would shift up by one octave; 0.5 down by one
+     * octave; or 1.0 leave the pitch unaffected.
+     *
+     * To put this in musical terms, a pitch scaling ratio
+     * corresponding to a shift of S equal-tempered semitones (where S
+     * is positive for an upwards shift and negative for downwards) is
+     * pow(2.0, S / 12.0).
+     *
+     * If the stretcher was constructed in Offline mode, the pitch
+     * scaling ratio is fixed throughout operation; this function may
+     * be called any number of times between construction (or a call
+     * to reset()) and the first call to study() or process(), but may
+     * not be called after study() or process() has been called.
+     *
+     * If the stretcher was constructed in RealTime mode, the pitch
+     * scaling ratio may be varied during operation; this function may
+     * be called at any time, so long as it is not called concurrently
+     * with process().  You should either call this function from the
+     * same thread as process(), or provide your own mutex or similar
+     * mechanism to ensure that setPitchScale and process() cannot be
+     * run at once (there is no internal mutex for this purpose).
+     */
+    void setPitchScale(double scale);
+
+    /**
+     * Set a pitch scale for the vocal formant envelope separately
+     * from the overall pitch scale.  This is a ratio of target
+     * frequency to source frequency.  For example, a ratio of 2.0
+     * would shift the formant envelope up by one octave; 0.5 down by
+     * one octave; or 1.0 leave the formant unaffected.
+     *
+     * By default this is set to the special value of 0.0, which
+     * causes the scale to be calculated automatically. It will be
+     * treated as 1.0 / the pitch scale if OptionFormantPreserved is
+     * specified, or 1.0 for OptionFormantShifted.
+     *
+     * Conversely, if this is set to a value other than the default
+     * 0.0, formant shifting will happen regardless of the state of
+     * the OptionFormantPreserved/OptionFormantShifted option.
+     *
+     * This function is provided for special effects only. You do not
+     * need to call it for ordinary pitch shifting, with or without
+     * formant preservation - just specify or omit the
+     * OptionFormantPreserved option as appropriate. Use this function
+     * only if you want to shift formants by a distance other than
+     * that of the overall pitch shift.
+     * 
+     * This function is supported only in the R3 (OptionEngineFiner)
+     * engine. It has no effect in R2 (OptionEngineFaster).
+     *
+     * This function was added in Rubber Band Library v3.0.
+     */
+    void setFormantScale(double scale);
+    
+    /**
+     * Return the last time ratio value that was set (either on
+     * construction or with setTimeRatio()).
+     */
+    double getTimeRatio() const;
+
+    /**
+     * Return the last pitch scaling ratio value that was set (either
+     * on construction or with setPitchScale()).
+     */
+    double getPitchScale() const;
+
+    /**
+     * Return the last formant scaling ratio that was set with
+     * setFormantScale, or 0.0 if the default automatic scaling is in
+     * effect.
+     * 
+     * This function is supported only in the R3 (OptionEngineFiner)
+     * engine. It always returns 0.0 in R2 (OptionEngineFaster).
+     *
+     * This function was added in Rubber Band Library v3.0.
+     */     
+    double getFormantScale() const;
+
+    /**
+     * In RealTime mode (unlike in Offline mode) the stretcher
+     * performs no automatic padding or delay/latency compensation at
+     * the start of the signal. This permits applications to have
+     * their own custom requirements, but it also means that by
+     * default some samples will be lost or attenuated at the start of
+     * the output and the correct linear relationship between input
+     * and output sample counts may be lost.
+     *
+     * Most applications using RealTime mode should solve this by
+     * calling getPreferredStartPad() and supplying the returned
+     * number of (silent) samples at the start of their input, before
+     * their first "true" process() call; and then also calling
+     * getStartDelay() and trimming the returned number of samples
+     * from the start of their stretcher's output.
+     *
+     * Ensure you have set the time and pitch scale factors to their
+     * proper starting values before calling getRequiredStartPad() or
+     * getStartDelay().
+     *
+     * In Offline mode, padding and delay compensation are handled
+     * internally and both functions always return zero.
+     *
+     * This function was added in Rubber Band Library v3.0.
+     *
+     * @see getStartDelay
+     */
+    size_t getPreferredStartPad() const;
+    
+    /**
+     * Return the output delay of the stretcher.  This is the number
+     * of audio samples that one should discard at the start of the
+     * output, after padding the start of the input with
+     * getPreferredStartPad(), in order to ensure that the resulting
+     * audio has the expected time alignment with the input.
+     *
+     * Ensure you have set the time and pitch scale factors to their
+     * proper starting values before calling getPreferredStartPad() or
+     * getStartDelay().
+     *
+     * In Offline mode, padding and delay compensation are handled
+     * internally and both functions always return zero.
+     * 
+     * This function was added in Rubber Band Library v3.0. Previously
+     * it was called getLatency(). It was renamed to avoid confusion
+     * with the number of samples needed at input to cause a block of
+     * processing to handle (returned by getSamplesRequired()) which
+     * is also sometimes referred to as latency.
+     *
+     * @see getPreferredStartPad
+     */
+    size_t getStartDelay() const;
+
+    /**
+     * Return the start delay of the stretcher. This is a deprecated
+     * alias for getStartDelay().
+     *
+     * @deprecated
+     */
+    size_t getLatency() const;
+    
+    /**
+     * Return the number of channels this stretcher was constructed
+     * with.
+     */
+    size_t getChannelCount() const;
+
+    /**
+     * Change an OptionTransients configuration setting. This may be
+     * called at any time in RealTime mode.  It may not be called in
+     * Offline mode (for which the transients option is fixed on
+     * construction). This has no effect when using the R3 engine.
+     */
+    void setTransientsOption(Options options);
+
+    /**
+     * Change an OptionDetector configuration setting.  This may be
+     * called at any time in RealTime mode.  It may not be called in
+     * Offline mode (for which the detector option is fixed on
+     * construction). This has no effect when using the R3 engine.
+     */
+    void setDetectorOption(Options options);
+
+    /**
+     * Change an OptionPhase configuration setting.  This may be
+     * called at any time in any mode. This has no effect when using
+     * the R3 engine.
+     *
+     * Note that if running multi-threaded in Offline mode, the change
+     * may not take effect immediately if processing is already under
+     * way when this function is called.
+     */
+    void setPhaseOption(Options options);
+
+    /**
+     * Change an OptionFormant configuration setting.  This may be
+     * called at any time in any mode.
+     *
+     * Note that if running multi-threaded in Offline mode, the change
+     * may not take effect immediately if processing is already under
+     * way when this function is called.
+     */
+    void setFormantOption(Options options);
+
+    /**
+     * Change an OptionPitch configuration setting.  This may be
+     * called at any time in RealTime mode.  It may not be called in
+     * Offline mode (for which the pitch option is fixed on
+     * construction). This has no effect when using the R3 engine.
+     */
+    void setPitchOption(Options options);
+
+    /**
+     * Tell the stretcher exactly how many input sample frames it will
+     * receive.  This is only useful in Offline mode, when it allows
+     * the stretcher to ensure that the number of output samples is
+     * exactly correct.  In RealTime mode no such guarantee is
+     * possible and this value is ignored.
+     *
+     * Note that the value of "samples" refers to the number of audio
+     * sample frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     */
+    void setExpectedInputDuration(size_t samples);
+
+    /**
+     * Tell the stretcher the maximum number of sample frames that you
+     * will ever be passing in to a single process() call.  If you
+     * don't call this, the stretcher will assume that you are calling
+     * getSamplesRequired() at each cycle and are never passing more
+     * samples than are suggested by that function.
+     *
+     * If your application has some external constraint that means you
+     * prefer a fixed block size, then your normal mode of operation
+     * would be to provide that block size to this function; to loop
+     * calling process() with that size of block; after each call to
+     * process(), test whether output has been generated by calling
+     * available(); and, if so, call retrieve() to obtain it.  See
+     * getSamplesRequired() for a more suitable operating mode for
+     * applications without such external constraints.
+     *
+     * This function may not be called after the first call to study()
+     * or process().
+     *
+     * Note that this value is only relevant to process(), not to
+     * study() (to which you may pass any number of samples at a time,
+     * and from which there is no output).
+     *
+     * Despite the existence of this call and its use of a size_t
+     * argument, there is an internal limit to the maximum process
+     * buffer size that can be requested. Call getProcessSizeLimit()
+     * to query that limit. The Rubber Band API is essentially
+     * block-based and is not designed to process an entire signal
+     * within a single process cycle.
+     *
+     * Note that the value of "samples" refers to the number of audio
+     * sample frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     */
+    void setMaxProcessSize(size_t samples);
+
+    /**
+     * Obtain the overall maximum supported process buffer size in
+     * sample frames, which is also the maximum acceptable value to
+     * pass to setMaxProcessSize(). This value is fixed across
+     * instances and configurations. As of Rubber Band v3.3 it is
+     * always 524288 (or 2^19), but in principle it may change in
+     * future releases.
+     *
+     * This function was added in Rubber Band Library v3.3.
+     */
+    size_t getProcessSizeLimit() const;
+    
+    /**
+     * Ask the stretcher how many audio sample frames should be
+     * provided as input in order to ensure that some more output
+     * becomes available.
+     * 
+     * If your application has no particular constraint on processing
+     * block size and you are able to provide any block size as input
+     * for each cycle, then your normal mode of operation would be to
+     * loop querying this function; providing that number of samples
+     * to process(); and reading the output (repeatedly if necessary)
+     * using available() and retrieve().  See setMaxProcessSize() for
+     * a more suitable operating mode for applications that do have
+     * external block size constraints.
+     *
+     * Note that this value is only relevant to process(), not to
+     * study() (to which you may pass any number of samples at a time,
+     * and from which there is no output).
+     *
+     * Note that the return value refers to the number of audio sample
+     * frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     *
+     * @see getStartDelay
+     */
+     size_t getSamplesRequired() const;
+
+    /**
+     * Provide a set of mappings from "before" to "after" sample
+     * numbers so as to enforce a particular stretch profile.  The
+     * argument is a map from audio sample frame number in the source
+     * material, to the corresponding sample frame number in the
+     * stretched output.  The mapping should be for key frames only,
+     * with a "reasonable" gap between mapped samples.
+     *
+     * This function cannot be used in RealTime mode.
+     *
+     * This function may not be called after the first call to
+     * process().  It should be called after the time and pitch ratios
+     * have been set; the results of changing the time and pitch
+     * ratios after calling this function are undefined.  Calling
+     * reset() will clear this mapping.
+     *
+     * The key frame map only affects points within the material; it
+     * does not determine the overall stretch ratio (that is, the
+     * ratio between the output material's duration and the source
+     * material's duration).  You need to provide this ratio
+     * separately to setTimeRatio(), otherwise the results may be
+     * truncated or extended in unexpected ways regardless of the
+     * extent of the frame numbers found in the key frame map.
+     */
+    void setKeyFrameMap(const std::map<size_t, size_t> &);
+    
+    /**
+     * Provide a block of "samples" sample frames for the stretcher to
+     * study and calculate a stretch profile from.
+     *
+     * This is only meaningful in Offline mode, and is required if
+     * running in that mode.  You should pass the entire input through
+     * study() before any process() calls are made, as a sequence of
+     * blocks in individual study() calls, or as a single large block.
+     *
+     * "input" should point to de-interleaved audio data with one
+     * float array per channel. Sample values are conventionally
+     * expected to be in the range -1.0f to +1.0f.  "samples" supplies
+     * the number of audio sample frames available in "input". If
+     * "samples" is zero, "input" may be NULL.
+     *
+     * Note that the value of "samples" refers to the number of audio
+     * sample frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     * 
+     * Set "final" to true if this is the last block of data that will
+     * be provided to study() before the first process() call.
+     */
+    void study(const float *const *input, size_t samples, bool final);
+
+    /**
+     * Provide a block of "samples" sample frames for processing.
+     * See also getSamplesRequired() and setMaxProcessSize().
+     *
+     * "input" should point to de-interleaved audio data with one
+     * float array per channel. Sample values are conventionally
+     * expected to be in the range -1.0f to +1.0f.  "samples" supplies
+     * the number of audio sample frames available in "input".
+     *
+     * Note that the value of "samples" refers to the number of audio
+     * sample frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     *
+     * Set "final" to true if this is the last block of input data.
+     */
+    void process(const float *const *input, size_t samples, bool final);
+
+    /**
+     * Ask the stretcher how many audio sample frames of output data
+     * are available for reading (via retrieve()).
+     * 
+     * This function returns 0 if no frames are available: this
+     * usually means more input data needs to be provided, but if the
+     * stretcher is running in threaded mode it may just mean that not
+     * enough data has yet been processed.  Call getSamplesRequired()
+     * to discover whether more input is needed.
+     *
+     * Note that the return value refers to the number of audio sample
+     * frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     *
+     * This function returns -1 if all data has been fully processed
+     * and all output read, and the stretch process is now finished.
+     */
+    int available() const;
+
+    /**
+     * Obtain some processed output data from the stretcher.  Up to
+     * "samples" samples will be stored in each of the output arrays
+     * (one per channel for de-interleaved audio data) pointed to by
+     * "output".  The number of sample frames available to be
+     * retrieved can be queried beforehand with a call to available().
+     * The return value is the actual number of sample frames
+     * retrieved.
+     *
+     * Note that the value of "samples" and the return value refer to
+     * the number of audio sample frames, which may be multi-channel,
+     * not the number of individual samples. (For example, one second
+     * of stereo audio sampled at 44100Hz yields a value of 44100
+     * sample frames, not 88200.)  This rule applies throughout the
+     * Rubber Band API.
+     */
+    size_t retrieve(float *const *output, size_t samples) const;
+
+    /**
+     * Return the value of internal frequency cutoff value n.
+     *
+     * This function is not for general use and is supported only with
+     * the R2 engine.
+     */
+    float getFrequencyCutoff(int n) const;
+
+    /** 
+     * Set the value of internal frequency cutoff n to f Hz.
+     *
+     * This function is not for general use and is supported only with
+     * the R2 engine.
+     */
+    void setFrequencyCutoff(int n, float f);
+    
+    /**
+     * Retrieve the value of the internal input block increment value.
+     *
+     * This function is provided for diagnostic purposes only and is
+     * supported only with the R2 engine.
+     */
+    size_t getInputIncrement() const;
+
+    /**
+     * In offline mode, retrieve the sequence of internal block
+     * increments for output, for the entire audio data, provided the
+     * stretch profile has been calculated.  In realtime mode,
+     * retrieve any output increments that have accumulated since the
+     * last call to getOutputIncrements, to a limit of 16.
+     *
+     * This function is provided for diagnostic purposes only and is
+     * supported only with the R2 engine.
+     */
+    std::vector<int> getOutputIncrements() const;
+
+    /**
+     * In offline mode, retrieve the sequence of internal phase reset
+     * detection function values, for the entire audio data, provided
+     * the stretch profile has been calculated.  In realtime mode,
+     * retrieve any phase reset points that have accumulated since the
+     * last call to getPhaseResetCurve, to a limit of 16.
+     *
+     * This function is provided for diagnostic purposes only and is
+     * supported only with the R2 engine.
+     */
+    std::vector<float> getPhaseResetCurve() const;
+
+    /**
+     * In offline mode, retrieve the sequence of internal frames for
+     * which exact timing has been sought, for the entire audio data,
+     * provided the stretch profile has been calculated.  In realtime
+     * mode, return an empty sequence.
+     *
+     * This function is provided for diagnostic purposes only and is
+     * supported only with the R2 engine.
+     */
+    std::vector<int> getExactTimePoints() const;
+
+    /**
+     * Force the stretcher to calculate a stretch profile.  Normally
+     * this happens automatically for the first process() call in
+     * offline mode.
+     *
+     * This function is provided for diagnostic purposes only and is
+     * supported only with the R2 engine.
+     */
+    void calculateStretch();
+
+    /**
+     * Set the level of debug output.  The supported values are:
+     *
+     * 0. Report errors only.
+     * 
+     * 1. Report some information on construction and ratio
+     * change. Nothing is reported during normal processing unless
+     * something changes.
+     * 
+     * 2. Report a significant amount of information about ongoing
+     * stretch calculations during normal processing.
+     * 
+     * 3. Report a large amount of information and also (in the R2
+     * engine) add audible ticks to the output at phase reset
+     * points. This is seldom useful.
+     *
+     * The default is whatever has been set using
+     * setDefaultDebugLevel(), or 0 if that function has not been
+     * called.
+     *
+     * All output goes to \c cerr unless a custom
+     * RubberBandStretcher::Logger has been provided on
+     * construction. Because writing to \c cerr is not RT-safe, only
+     * debug level 0 is RT-safe in normal use by default. Debug levels
+     * 0 and 1 use only C-string constants as debug messages, so they
+     * are RT-safe if your custom logger is RT-safe. Levels 2 and 3
+     * are not guaranteed to be RT-safe in any conditions as they may
+     * construct messages by allocation.
+     *
+     * @see Logger
+     * @see setDefaultDebugLevel
+     */
+    void setDebugLevel(int level);
+
+    /**
+     * Set the default level of debug output for subsequently
+     * constructed stretchers.
+     *
+     * @see setDebugLevel
+     */
+    static void setDefaultDebugLevel(int level);
+
+protected:
+    class Impl;
+    Impl *m_d;
+
+    RubberBandStretcher(const RubberBandStretcher &) =delete;
+    RubberBandStretcher &operator=(const RubberBandStretcher &) =delete;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/rubberband/rubberband-c.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/rubberband/rubberband-c.h
@@ -1,0 +1,216 @@
+
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_C_API_H
+#define RUBBERBAND_C_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+#define RUBBERBAND_VERSION "4.0.0"
+#define RUBBERBAND_API_MAJOR_VERSION 3
+#define RUBBERBAND_API_MINOR_VERSION 0
+
+#undef RB_EXTERN
+#ifdef _MSC_VER
+#ifndef RUBBERBAND_STATIC
+#define RB_EXTERN extern __declspec(dllexport)
+#else
+#define RB_EXTERN extern
+#endif
+#else
+#define RB_EXTERN extern
+#endif
+
+/**
+ * This is a C-linkage interface to the Rubber Band time stretcher.
+ * 
+ * This is a wrapper interface: the primary interface is in C++ and is
+ * defined and documented in RubberBandStretcher.h and
+ * RubberBandLiveShifter.h.  The library itself is implemented in C++,
+ * and requires C++ standard library support even when using the
+ * C-linkage API.
+ *
+ * Please see RubberBandStretcher.h and RubberBandLiveShifter.h for
+ * documentation.
+ *
+ * If you are writing to the C++ API, do not include this header.
+ */
+
+enum RubberBandOption {
+
+    RubberBandOptionProcessOffline       = 0x00000000,
+    RubberBandOptionProcessRealTime      = 0x00000001,
+
+    RubberBandOptionStretchElastic       = 0x00000000, // obsolete
+    RubberBandOptionStretchPrecise       = 0x00000010, // obsolete
+    
+    RubberBandOptionTransientsCrisp      = 0x00000000,
+    RubberBandOptionTransientsMixed      = 0x00000100,
+    RubberBandOptionTransientsSmooth     = 0x00000200,
+
+    RubberBandOptionDetectorCompound     = 0x00000000,
+    RubberBandOptionDetectorPercussive   = 0x00000400,
+    RubberBandOptionDetectorSoft         = 0x00000800,
+
+    RubberBandOptionPhaseLaminar         = 0x00000000,
+    RubberBandOptionPhaseIndependent     = 0x00002000,
+    
+    RubberBandOptionThreadingAuto        = 0x00000000,
+    RubberBandOptionThreadingNever       = 0x00010000,
+    RubberBandOptionThreadingAlways      = 0x00020000,
+
+    RubberBandOptionWindowStandard       = 0x00000000,
+    RubberBandOptionWindowShort          = 0x00100000,
+    RubberBandOptionWindowLong           = 0x00200000,
+
+    RubberBandOptionSmoothingOff         = 0x00000000,
+    RubberBandOptionSmoothingOn          = 0x00800000,
+
+    RubberBandOptionFormantShifted       = 0x00000000,
+    RubberBandOptionFormantPreserved     = 0x01000000,
+
+    RubberBandOptionPitchHighSpeed       = 0x00000000,
+    RubberBandOptionPitchHighQuality     = 0x02000000,
+    RubberBandOptionPitchHighConsistency = 0x04000000,
+
+    RubberBandOptionChannelsApart        = 0x00000000,
+    RubberBandOptionChannelsTogether     = 0x10000000,
+
+    RubberBandOptionEngineFaster         = 0x00000000,
+    RubberBandOptionEngineFiner          = 0x20000000
+};
+
+typedef int RubberBandOptions;
+
+struct RubberBandState_;
+typedef struct RubberBandState_ *RubberBandState;
+
+RB_EXTERN RubberBandState rubberband_new(unsigned int sampleRate,
+                                         unsigned int channels,
+                                         RubberBandOptions options,
+                                         double initialTimeRatio,
+                                         double initialPitchScale);
+
+RB_EXTERN void rubberband_delete(RubberBandState);
+
+RB_EXTERN void rubberband_reset(RubberBandState);
+
+RB_EXTERN int rubberband_get_engine_version(RubberBandState);
+    
+RB_EXTERN void rubberband_set_time_ratio(RubberBandState, double ratio);
+RB_EXTERN void rubberband_set_pitch_scale(RubberBandState, double scale);
+
+RB_EXTERN double rubberband_get_time_ratio(const RubberBandState);
+RB_EXTERN double rubberband_get_pitch_scale(const RubberBandState);
+
+RB_EXTERN void rubberband_set_formant_scale(RubberBandState, double scale);
+RB_EXTERN double rubberband_get_formant_scale(const RubberBandState);
+
+RB_EXTERN unsigned int rubberband_get_preferred_start_pad(const RubberBandState);
+RB_EXTERN unsigned int rubberband_get_start_delay(const RubberBandState);
+RB_EXTERN unsigned int rubberband_get_latency(const RubberBandState);
+
+RB_EXTERN void rubberband_set_transients_option(RubberBandState, RubberBandOptions options);
+RB_EXTERN void rubberband_set_detector_option(RubberBandState, RubberBandOptions options);
+RB_EXTERN void rubberband_set_phase_option(RubberBandState, RubberBandOptions options);
+RB_EXTERN void rubberband_set_formant_option(RubberBandState, RubberBandOptions options);
+RB_EXTERN void rubberband_set_pitch_option(RubberBandState, RubberBandOptions options);
+
+RB_EXTERN void rubberband_set_expected_input_duration(RubberBandState, unsigned int samples);
+
+RB_EXTERN unsigned int rubberband_get_samples_required(const RubberBandState);
+
+RB_EXTERN void rubberband_set_max_process_size(RubberBandState, unsigned int samples);
+RB_EXTERN unsigned int rubberband_get_process_size_limit(RubberBandState);
+    
+RB_EXTERN void rubberband_set_key_frame_map(RubberBandState, unsigned int keyframecount, unsigned int *from, unsigned int *to);
+
+RB_EXTERN void rubberband_study(RubberBandState, const float *const *input, unsigned int samples, int final);
+RB_EXTERN void rubberband_process(RubberBandState, const float *const *input, unsigned int samples, int final);
+
+RB_EXTERN int rubberband_available(const RubberBandState);
+RB_EXTERN unsigned int rubberband_retrieve(const RubberBandState, float *const *output, unsigned int samples);
+
+RB_EXTERN unsigned int rubberband_get_channel_count(const RubberBandState);
+
+RB_EXTERN void rubberband_calculate_stretch(RubberBandState);
+
+RB_EXTERN void rubberband_set_debug_level(RubberBandState, int level);
+RB_EXTERN void rubberband_set_default_debug_level(int level);
+
+
+enum RubberBandLiveOption {
+
+    RubberBandLiveOptionWindowShort      = 0x00000000,
+    RubberBandLiveOptionWindowMedium     = 0x00100000,
+
+    RubberBandLiveOptionFormantShifted   = 0x00000000,
+    RubberBandLiveOptionFormantPreserved = 0x01000000,
+
+    RubberBandLiveOptionChannelsApart    = 0x00000000,
+    RubberBandLiveOptionChannelsTogether = 0x10000000
+};
+
+typedef int RubberBandLiveOptions;
+
+struct RubberBandLiveState_;
+typedef struct RubberBandLiveState_ *RubberBandLiveState;
+
+RB_EXTERN RubberBandLiveState rubberband_live_new(unsigned int sampleRate,
+                                                  unsigned int channels,
+                                                  RubberBandOptions options);
+
+RB_EXTERN void rubberband_live_delete(RubberBandLiveState);
+
+RB_EXTERN void rubberband_live_reset(RubberBandLiveState);
+
+RB_EXTERN void rubberband_live_set_pitch_scale(RubberBandLiveState, double scale);
+RB_EXTERN double rubberband_live_get_pitch_scale(const RubberBandLiveState);
+
+RB_EXTERN void rubberband_live_set_formant_scale(RubberBandLiveState, double scale);
+RB_EXTERN double rubberband_live_get_formant_scale(const RubberBandLiveState);
+
+RB_EXTERN unsigned int rubberband_live_get_start_delay(const RubberBandLiveState);
+
+RB_EXTERN void rubberband_live_set_formant_option(RubberBandLiveState, RubberBandOptions options);
+
+RB_EXTERN unsigned int rubberband_live_get_block_size(RubberBandLiveState);
+
+RB_EXTERN void rubberband_live_shift(RubberBandLiveState, const float *const *input, float *const *output);
+
+RB_EXTERN unsigned int rubberband_live_get_channel_count(const RubberBandLiveState);
+
+RB_EXTERN void rubberband_live_set_debug_level(RubberBandLiveState, int level);
+RB_EXTERN void rubberband_live_set_default_debug_level(int level);
+
+    
+#ifdef __cplusplus
+}
+#endif
+
+#undef RB_EXTERN
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/single/RubberBandSingle.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/single/RubberBandSingle.cpp
@@ -1,0 +1,88 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+/*
+    RubberBandSingle.cpp
+ 
+    This is a single-file compilation unit for Rubber Band Library.
+  
+    To use the library in your project without building it separately,
+    include in your code either rubberband/RubberBandStretcher.h
+    and/or rubberband/RubberBandLiveShifter.h for use in C++, or
+    rubberband/rubberband-c.h if you need the C interface, then add
+    this single C++ source file to your build.
+ 
+    Don't move this file into your source tree - keep it in the same
+    place relative to the other Rubber Band code, so that the relative
+    include paths work, and just add it to your list of build files.
+  
+    This produces a build using the built-in FFT and resampler
+    implementations, except on Apple platforms, where the vDSP FFT is
+    used (and where you will need the Accelerate framework when
+    linking). It should work correctly on any supported platform, but
+    may not be the fastest configuration available. For further
+    customisation, consider using the full build system to make a
+    standalone library.
+*/
+
+#ifndef ALREADY_CONFIGURED
+
+#define USE_BQRESAMPLER 1
+
+#define NO_TIMING 1
+#define NO_THREADING 1
+#define NO_THREAD_CHECKS 1
+
+#if defined(__APPLE__)
+#define HAVE_VDSP 1
+#else
+#define USE_BUILTIN_FFT 1
+#endif
+
+#endif
+
+#include "../src/faster/AudioCurveCalculator.cpp"
+#include "../src/faster/CompoundAudioCurve.cpp"
+#include "../src/faster/HighFrequencyAudioCurve.cpp"
+#include "../src/faster/SilentAudioCurve.cpp"
+#include "../src/faster/PercussiveAudioCurve.cpp"
+#include "../src/common/Log.cpp"
+#include "../src/common/Profiler.cpp"
+#include "../src/common/FFT.cpp"
+#include "../src/common/Resampler.cpp"
+#include "../src/common/BQResampler.cpp"
+#include "../src/common/Allocators.cpp"
+#include "../src/common/StretchCalculator.cpp"
+#include "../src/common/sysutils.cpp"
+#include "../src/common/mathmisc.cpp"
+#include "../src/common/Thread.cpp"
+#include "../src/faster/StretcherChannelData.cpp"
+#include "../src/faster/R2Stretcher.cpp"
+#include "../src/faster/StretcherProcess.cpp"
+#include "../src/finer/R3Stretcher.cpp"
+#include "../src/finer/R3LiveShifter.cpp"
+
+#include "../src/RubberBandStretcher.cpp"
+#include "../src/RubberBandLiveShifter.cpp"
+#include "../src/rubberband-c.cpp"
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/RubberBandLiveShifter.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/RubberBandLiveShifter.cpp
@@ -1,0 +1,273 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Live Pitch Shifter obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Live Pitch Shifter
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "../rubberband/RubberBandLiveShifter.h"
+#include "finer/R3LiveShifter.h"
+
+#include <iostream>
+
+namespace RubberBand {
+
+class RubberBandLiveShifter::Impl
+{
+    R3LiveShifter *m_s;
+
+    class CerrLogger : public RubberBandLiveShifter::Logger {
+    public:
+        void log(const char *message) override {
+            std::cerr << "RubberBandLive: " << message << "\n";
+        }
+        void log(const char *message, double arg0) override {
+            auto prec = std::cerr.precision();
+            std::cerr.precision(10);
+            std::cerr << "RubberBandLive: " << message << ": " << arg0 << "\n";
+            std::cerr.precision(prec);
+        }
+        void log(const char *message, double arg0, double arg1) override {
+            auto prec = std::cerr.precision();
+            std::cerr.precision(10);
+            std::cerr << "RubberBandLive: " << message
+                      << ": (" << arg0 << ", " << arg1 << ")" << "\n";
+            std::cerr.precision(prec);
+        }
+    };
+    
+    Log makeRBLog(std::shared_ptr<RubberBandLiveShifter::Logger> logger) {
+        if (logger) {
+            return Log(
+                [=](const char *message) {
+                    logger->log(message);
+                },
+                [=](const char *message, double arg0) {
+                    logger->log(message, arg0);
+                },
+                [=](const char *message, double arg0, double arg1) {
+                    logger->log(message, arg0, arg1);
+                }
+                );
+        } else {
+            return makeRBLog(std::shared_ptr<RubberBandLiveShifter::Logger>
+                             (new CerrLogger()));
+        }
+    }
+
+public:
+    Impl(size_t sampleRate, size_t channels,
+         std::shared_ptr<RubberBandLiveShifter::Logger> logger,
+         RubberBandLiveShifter::Options options) :
+        m_s (new R3LiveShifter
+             (R3LiveShifter::Parameters(double(sampleRate), channels,
+                                        options),
+              makeRBLog(logger)))
+    {
+    }
+
+    ~Impl()
+    {
+        delete m_s;
+    }
+
+    void reset()
+    {
+        m_s->reset();
+    }
+
+    RTENTRY__
+    void
+    setPitchScale(double scale)
+    {
+        m_s->setPitchScale(scale);
+    }
+
+    RTENTRY__
+    void
+    setFormantScale(double scale)
+    {
+        m_s->setFormantScale(scale);
+    }
+
+    RTENTRY__
+    double
+    getPitchScale() const
+    {
+        return m_s->getPitchScale();
+    }
+
+    RTENTRY__
+    double
+    getFormantScale() const
+    {
+        return m_s->getFormantScale();
+    }
+
+    RTENTRY__
+    void
+    setFormantOption(RubberBandLiveShifter::Options options)
+    {
+        m_s->setFormantOption(options);
+    }
+    
+    RTENTRY__
+    size_t
+    getStartDelay() const
+    {
+        return m_s->getStartDelay();
+    }
+
+    RTENTRY__
+    size_t
+    getBlockSize() const
+    {
+        return m_s->getBlockSize();
+    }
+
+    RTENTRY__
+    void
+    shift(const float *const *input, float *const *output)
+    {
+        m_s->shift(input, output);
+    }
+
+    RTENTRY__
+    size_t
+    getChannelCount() const
+    {
+        return m_s->getChannelCount();
+    }
+
+    void
+    setDebugLevel(int level)
+    {
+        m_s->setDebugLevel(level);
+    }
+
+    static void
+    setDefaultDebugLevel(int level)
+    {
+        Log::setDefaultDebugLevel(level);
+    }
+};
+
+RubberBandLiveShifter::RubberBandLiveShifter(size_t sampleRate,
+                                             size_t channels,
+                                             Options options) :
+    m_d(new Impl(sampleRate, channels, nullptr, options))
+{
+}
+
+RubberBandLiveShifter::RubberBandLiveShifter(size_t sampleRate,
+                                             size_t channels,
+                                             std::shared_ptr<Logger> logger,
+                                             Options options) :
+    m_d(new Impl(sampleRate, channels, logger, options))
+{
+}
+
+RubberBandLiveShifter::~RubberBandLiveShifter()
+{
+    delete m_d;
+}
+
+void
+RubberBandLiveShifter::reset()
+{
+    m_d->reset();
+}
+
+RTENTRY__
+void
+RubberBandLiveShifter::setPitchScale(double scale)
+{
+    m_d->setPitchScale(scale);
+}
+
+RTENTRY__
+void
+RubberBandLiveShifter::setFormantScale(double scale)
+{
+    m_d->setFormantScale(scale);
+}
+
+RTENTRY__
+double
+RubberBandLiveShifter::getPitchScale() const
+{
+    return m_d->getPitchScale();
+}
+
+RTENTRY__
+double
+RubberBandLiveShifter::getFormantScale() const
+{
+    return m_d->getFormantScale();
+}
+
+RTENTRY__
+size_t
+RubberBandLiveShifter::getStartDelay() const
+{
+    return m_d->getStartDelay();
+}
+
+RTENTRY__
+void
+RubberBandLiveShifter::setFormantOption(Options options)
+{
+    m_d->setFormantOption(options);
+}
+
+RTENTRY__
+size_t
+RubberBandLiveShifter::getBlockSize() const
+{
+    return m_d->getBlockSize();
+}
+
+RTENTRY__
+void
+RubberBandLiveShifter::shift(const float *const *input, float *const *output)
+{
+    m_d->shift(input, output);
+}
+
+RTENTRY__
+size_t
+RubberBandLiveShifter::getChannelCount() const
+{
+    return m_d->getChannelCount();
+}
+
+void
+RubberBandLiveShifter::setDebugLevel(int level)
+{
+    m_d->setDebugLevel(level);
+}
+
+void
+RubberBandLiveShifter::setDefaultDebugLevel(int level)
+{
+    Impl::setDefaultDebugLevel(level);
+}
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/RubberBandStretcher.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/RubberBandStretcher.cpp
@@ -1,0 +1,612 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "faster/R2Stretcher.h"
+#include "finer/R3Stretcher.h"
+
+#include <iostream>
+
+namespace RubberBand {
+
+class RubberBandStretcher::Impl
+{
+    R2Stretcher *m_r2;
+    R3Stretcher *m_r3;
+
+    class CerrLogger : public RubberBandStretcher::Logger {
+    public:
+        void log(const char *message) override {
+            std::cerr << "RubberBand: " << message << "\n";
+        }
+        void log(const char *message, double arg0) override {
+            auto prec = std::cerr.precision();
+            std::cerr.precision(10);
+            std::cerr << "RubberBand: " << message << ": " << arg0 << "\n";
+            std::cerr.precision(prec);
+        }
+        void log(const char *message, double arg0, double arg1) override {
+            auto prec = std::cerr.precision();
+            std::cerr.precision(10);
+            std::cerr << "RubberBand: " << message
+                      << ": (" << arg0 << ", " << arg1 << ")" << "\n";
+            std::cerr.precision(prec);
+        }
+    };
+
+    Log makeRBLog(std::shared_ptr<RubberBandStretcher::Logger> logger) {
+        if (logger) {
+            return Log(
+                [=](const char *message) {
+                    logger->log(message);
+                },
+                [=](const char *message, double arg0) {
+                    logger->log(message, arg0);
+                },
+                [=](const char *message, double arg0, double arg1) {
+                    logger->log(message, arg0, arg1);
+                }
+                );
+        } else {
+            return makeRBLog(std::shared_ptr<RubberBandStretcher::Logger>
+                             (new CerrLogger()));
+        }
+    }
+
+public:
+    Impl(size_t sampleRate, size_t channels, Options options,
+         std::shared_ptr<RubberBandStretcher::Logger> logger,
+         double initialTimeRatio, double initialPitchScale) :
+        m_r2 (!(options & OptionEngineFiner) ?
+              new R2Stretcher(sampleRate, channels, options,
+                              initialTimeRatio, initialPitchScale,
+                              makeRBLog(logger))
+              : nullptr),
+        m_r3 ((options & OptionEngineFiner) ?
+              new R3Stretcher(R3Stretcher::Parameters
+                              (double(sampleRate), channels, options),
+                              initialTimeRatio, initialPitchScale,
+                              makeRBLog(logger))
+              : nullptr)
+    {
+    }
+
+    ~Impl()
+    {
+        delete m_r2;
+        delete m_r3;
+    }
+
+    int getEngineVersion() const
+    {
+        if (m_r3) return 3;
+        else return 2;
+    }
+    
+    void reset()
+    {
+        if (m_r2) m_r2->reset();
+        else m_r3->reset();
+    }
+
+    RTENTRY__
+    void
+    setTimeRatio(double ratio)
+    {
+        if (m_r2) m_r2->setTimeRatio(ratio);
+        else m_r3->setTimeRatio(ratio);
+    }
+
+    RTENTRY__
+    void
+    setPitchScale(double scale)
+    {
+        if (m_r2) m_r2->setPitchScale(scale);
+        else m_r3->setPitchScale(scale);
+    }
+
+    RTENTRY__
+    void
+    setFormantScale(double scale)
+    {
+        //!!!
+        if (m_r3) m_r3->setFormantScale(scale);
+    }
+
+    RTENTRY__
+    double
+    getTimeRatio() const
+    {
+        if (m_r2) return m_r2->getTimeRatio();
+        else return m_r3->getTimeRatio();
+    }
+
+    RTENTRY__
+    double
+    getPitchScale() const
+    {
+        if (m_r2) return m_r2->getPitchScale();
+        else return m_r3->getPitchScale();
+    }
+
+    RTENTRY__
+    double
+    getFormantScale() const
+    {
+        //!!!
+        if (m_r2) return 0.0;
+        else return m_r3->getFormantScale();
+    }
+
+    RTENTRY__
+    size_t
+    getPreferredStartPad() const
+    {
+        if (m_r2) return m_r2->getPreferredStartPad();
+        else return m_r3->getPreferredStartPad();
+    }
+
+    RTENTRY__
+    size_t
+    getStartDelay() const
+    {
+        if (m_r2) return m_r2->getStartDelay();
+        else return m_r3->getStartDelay();
+    }
+
+//!!! review all these
+
+    RTENTRY__
+    void
+    setTransientsOption(Options options) 
+    {
+        if (m_r2) m_r2->setTransientsOption(options);
+    }
+
+    RTENTRY__
+    void
+    setDetectorOption(Options options) 
+    {
+        if (m_r2) m_r2->setDetectorOption(options);
+    }
+
+    RTENTRY__
+    void
+    setPhaseOption(Options options) 
+    {
+        if (m_r2) m_r2->setPhaseOption(options);
+    }
+
+    RTENTRY__
+    void
+    setFormantOption(Options options)
+    {
+        if (m_r2) m_r2->setFormantOption(options);
+        else if (m_r3) m_r3->setFormantOption(options);
+    }
+
+    RTENTRY__
+    void
+    setPitchOption(Options options)
+    {
+        if (m_r2) m_r2->setPitchOption(options);
+        else if (m_r3) m_r3->setPitchOption(options);
+    }
+
+    void
+    setExpectedInputDuration(size_t samples) 
+    {
+        if (m_r2) m_r2->setExpectedInputDuration(samples);
+        else m_r3->setExpectedInputDuration(samples);
+    }
+
+    void
+    setMaxProcessSize(size_t samples)
+    {
+        if (m_r2) m_r2->setMaxProcessSize(samples);
+        else m_r3->setMaxProcessSize(samples);
+    }
+
+    size_t
+    getProcessSizeLimit() const
+    {
+        if (m_r2) return m_r2->getProcessSizeLimit();
+        else return m_r3->getProcessSizeLimit();
+    }
+
+    void
+    setKeyFrameMap(const std::map<size_t, size_t> &mapping)
+    {
+        if (m_r2) m_r2->setKeyFrameMap(mapping);
+        else m_r3->setKeyFrameMap(mapping);
+    }
+
+    RTENTRY__
+    size_t
+    getSamplesRequired() const
+    {
+        if (m_r2) return m_r2->getSamplesRequired();
+        else return m_r3->getSamplesRequired();
+    }
+
+    void
+    study(const float *const *input, size_t samples,
+          bool final)
+    {
+        if (m_r2) m_r2->study(input, samples, final);
+        else m_r3->study(input, samples, final);
+    }
+
+    RTENTRY__
+    void
+    process(const float *const *input, size_t samples,
+            bool final)
+    {
+        if (m_r2) m_r2->process(input, samples, final);
+        else m_r3->process(input, samples, final);
+    }
+
+    RTENTRY__
+    int
+    available() const
+    {
+        if (m_r2) return m_r2->available();
+        else return m_r3->available();
+    }
+
+    RTENTRY__
+    size_t
+    retrieve(float *const *output, size_t samples) const
+    {
+        if (m_r2) return m_r2->retrieve(output, samples);
+        else return m_r3->retrieve(output, samples);
+    }
+
+    float
+    getFrequencyCutoff(int n) const
+    {
+        if (m_r2) return m_r2->getFrequencyCutoff(n);
+        else return {};
+    }
+
+    void
+    setFrequencyCutoff(int n, float f) 
+    {
+        if (m_r2) m_r2->setFrequencyCutoff(n, f);
+    }
+
+    size_t
+    getInputIncrement() const
+    {
+        if (m_r2) return m_r2->getInputIncrement();
+        else return {};
+    }
+
+    std::vector<int>
+    getOutputIncrements() const
+    {
+        if (m_r2) return m_r2->getOutputIncrements();
+        else return {};
+    }
+
+    std::vector<float>
+    getPhaseResetCurve() const
+    {
+        if (m_r2) return m_r2->getPhaseResetCurve();
+        else return {};
+    }
+
+    std::vector<int>
+    getExactTimePoints() const
+    {
+        if (m_r2) return m_r2->getExactTimePoints();
+        else return {};
+    }
+
+    RTENTRY__
+    size_t
+    getChannelCount() const
+    {
+        if (m_r2) return m_r2->getChannelCount();
+        else return m_r3->getChannelCount();
+    }
+
+    void
+    calculateStretch()
+    {
+        if (m_r2) m_r2->calculateStretch();
+    }
+
+    void
+    setDebugLevel(int level)
+    {
+        if (m_r2) m_r2->setDebugLevel(level);
+        else m_r3->setDebugLevel(level);
+    }
+
+    static void
+    setDefaultDebugLevel(int level)
+    {
+        Log::setDefaultDebugLevel(level);
+    }
+};
+
+RubberBandStretcher::RubberBandStretcher(size_t sampleRate,
+                                         size_t channels,
+                                         Options options,
+                                         double initialTimeRatio,
+                                         double initialPitchScale) :
+    m_d(new Impl(sampleRate, channels, options, nullptr,
+                 initialTimeRatio, initialPitchScale))
+{
+}
+
+RubberBandStretcher::RubberBandStretcher(size_t sampleRate,
+                                         size_t channels,
+                                         std::shared_ptr<Logger> logger,
+                                         Options options,
+                                         double initialTimeRatio,
+                                         double initialPitchScale) :
+    m_d(new Impl(sampleRate, channels, options, logger,
+                 initialTimeRatio, initialPitchScale))
+{
+}
+
+RubberBandStretcher::~RubberBandStretcher()
+{
+    delete m_d;
+}
+
+void
+RubberBandStretcher::reset()
+{
+    m_d->reset();
+}
+
+int
+RubberBandStretcher::getEngineVersion() const
+{
+    return m_d->getEngineVersion();
+}
+
+RTENTRY__
+void
+RubberBandStretcher::setTimeRatio(double ratio)
+{
+    m_d->setTimeRatio(ratio);
+}
+
+RTENTRY__
+void
+RubberBandStretcher::setPitchScale(double scale)
+{
+    m_d->setPitchScale(scale);
+}
+
+RTENTRY__
+void
+RubberBandStretcher::setFormantScale(double scale)
+{
+    m_d->setFormantScale(scale);
+}
+
+RTENTRY__
+double
+RubberBandStretcher::getTimeRatio() const
+{
+    return m_d->getTimeRatio();
+}
+
+RTENTRY__
+double
+RubberBandStretcher::getPitchScale() const
+{
+    return m_d->getPitchScale();
+}
+
+RTENTRY__
+double
+RubberBandStretcher::getFormantScale() const
+{
+    return m_d->getFormantScale();
+}
+
+RTENTRY__
+size_t
+RubberBandStretcher::getPreferredStartPad() const
+{
+    return m_d->getPreferredStartPad();
+}
+
+RTENTRY__
+size_t
+RubberBandStretcher::getStartDelay() const
+{
+    return m_d->getStartDelay();
+}
+
+RTENTRY__
+size_t
+RubberBandStretcher::getLatency() const
+{
+    // deprecated alias for getStartDelay
+    return m_d->getStartDelay();
+}
+
+RTENTRY__
+void
+RubberBandStretcher::setTransientsOption(Options options) 
+{
+    m_d->setTransientsOption(options);
+}
+
+RTENTRY__
+void
+RubberBandStretcher::setDetectorOption(Options options) 
+{
+    m_d->setDetectorOption(options);
+}
+
+RTENTRY__
+void
+RubberBandStretcher::setPhaseOption(Options options) 
+{
+    m_d->setPhaseOption(options);
+}
+
+RTENTRY__
+void
+RubberBandStretcher::setFormantOption(Options options)
+{
+    m_d->setFormantOption(options);
+}
+
+RTENTRY__
+void
+RubberBandStretcher::setPitchOption(Options options)
+{
+    m_d->setPitchOption(options);
+}
+
+void
+RubberBandStretcher::setExpectedInputDuration(size_t samples) 
+{
+    m_d->setExpectedInputDuration(samples);
+}
+
+void
+RubberBandStretcher::setMaxProcessSize(size_t samples)
+{
+    m_d->setMaxProcessSize(samples);
+}
+
+size_t
+RubberBandStretcher::getProcessSizeLimit() const
+{
+    return m_d->getProcessSizeLimit();
+}
+
+void
+RubberBandStretcher::setKeyFrameMap(const std::map<size_t, size_t> &mapping)
+{
+    m_d->setKeyFrameMap(mapping);
+}
+
+RTENTRY__
+size_t
+RubberBandStretcher::getSamplesRequired() const
+{
+    return m_d->getSamplesRequired();
+}
+
+void
+RubberBandStretcher::study(const float *const *input, size_t samples,
+                           bool final)
+{
+    m_d->study(input, samples, final);
+}
+
+RTENTRY__
+void
+RubberBandStretcher::process(const float *const *input, size_t samples,
+                             bool final)
+{
+    m_d->process(input, samples, final);
+}
+
+RTENTRY__
+int
+RubberBandStretcher::available() const
+{
+    return m_d->available();
+}
+
+RTENTRY__
+size_t
+RubberBandStretcher::retrieve(float *const *output, size_t samples) const
+{
+    return m_d->retrieve(output, samples);
+}
+
+float
+RubberBandStretcher::getFrequencyCutoff(int n) const
+{
+    return m_d->getFrequencyCutoff(n);
+}
+
+void
+RubberBandStretcher::setFrequencyCutoff(int n, float f) 
+{
+    m_d->setFrequencyCutoff(n, f);
+}
+
+size_t
+RubberBandStretcher::getInputIncrement() const
+{
+    return m_d->getInputIncrement();
+}
+
+std::vector<int>
+RubberBandStretcher::getOutputIncrements() const
+{
+    return m_d->getOutputIncrements();
+}
+
+std::vector<float>
+RubberBandStretcher::getPhaseResetCurve() const
+{
+    return m_d->getPhaseResetCurve();
+}
+
+std::vector<int>
+RubberBandStretcher::getExactTimePoints() const
+{
+    return m_d->getExactTimePoints();
+}
+
+RTENTRY__
+size_t
+RubberBandStretcher::getChannelCount() const
+{
+    return m_d->getChannelCount();
+}
+
+void
+RubberBandStretcher::calculateStretch()
+{
+    m_d->calculateStretch();
+}
+
+void
+RubberBandStretcher::setDebugLevel(int level)
+{
+    m_d->setDebugLevel(level);
+}
+
+void
+RubberBandStretcher::setDefaultDebugLevel(int level)
+{
+    Impl::setDefaultDebugLevel(level);
+}
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Allocators.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Allocators.cpp
@@ -1,0 +1,69 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "Allocators.h"
+
+#ifdef HAVE_IPP
+#include <ipps.h>
+#endif
+
+#include <iostream>
+using std::cerr;
+using std::endl;
+
+namespace RubberBand {
+
+#ifdef HAVE_IPP
+
+template <>
+float *allocate(size_t count)
+{
+    float *ptr = ippsMalloc_32f(count);
+    if (!ptr) throw (std::bad_alloc());
+    return ptr;
+}
+
+template <>
+double *allocate(size_t count)
+{
+    double *ptr = ippsMalloc_64f(count);
+    if (!ptr) throw (std::bad_alloc());
+    return ptr;
+}
+
+template <>
+void deallocate(float *ptr)
+{
+    if (ptr) ippsFree((void *)ptr);
+}
+
+template <>
+void deallocate(double *ptr)
+{
+    if (ptr) ippsFree((void *)ptr);
+}
+
+#endif
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Allocators.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Allocators.h
@@ -1,0 +1,408 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_ALLOCATORS_H
+#define RUBBERBAND_ALLOCATORS_H
+
+#include "VectorOps.h"
+
+#include <new> // for std::bad_alloc
+#include <cstdlib>
+#include <cstddef> // ptrdiff_t
+
+#include <stdexcept>
+
+#ifndef HAVE_POSIX_MEMALIGN
+#ifndef _WIN32
+#ifndef __APPLE__
+#ifndef LACK_POSIX_MEMALIGN
+#define HAVE_POSIX_MEMALIGN
+#endif
+#endif
+#endif
+#endif
+
+#ifndef MALLOC_IS_ALIGNED
+#ifndef MALLOC_IS_NOT_ALIGNED
+#ifdef __APPLE__
+#define MALLOC_IS_ALIGNED
+#endif
+#endif
+#endif
+
+#ifndef HAVE__ALIGNED_MALLOC
+#ifndef LACK__ALIGNED_MALLOC
+#ifdef _WIN32
+#define HAVE__ALIGNED_MALLOC
+#endif
+#endif
+#endif
+
+#ifdef HAVE_POSIX_MEMALIGN
+#include <sys/mman.h>
+#include <errno.h>
+#endif
+
+#ifdef LACK_BAD_ALLOC
+namespace std { struct bad_alloc { }; }
+#endif
+
+namespace RubberBand {
+
+template <typename T>
+T *allocate(size_t count)
+{
+    void *ptr = 0;
+
+    // We'd like to check HAVE_IPP first and, if it's defined, call
+    // ippsMalloc_8u(count * sizeof(T)). But that isn't a general
+    // replacement for malloc() because it only takes an int
+    // argument. So we save it for the specialisations of
+    // allocate<float> and allocate<double> below, where we're more
+    // likely to get away with it.
+
+#ifdef MALLOC_IS_ALIGNED
+    ptr = malloc(count * sizeof(T));
+#else /* !MALLOC_IS_ALIGNED */
+
+    // That's the "sufficiently aligned" functions dealt with, the
+    // rest need a specific alignment provided to the call. 64-byte
+    // alignment is enough for 8x8 double operations
+    static const int alignment = 64;
+
+#ifdef HAVE__ALIGNED_MALLOC
+    ptr = _aligned_malloc(count * sizeof(T), alignment);
+#else /* !HAVE__ALIGNED_MALLOC */
+
+#ifdef HAVE_POSIX_MEMALIGN
+    int rv = posix_memalign(&ptr, alignment, count * sizeof(T));
+    if (rv) {
+#ifndef NO_EXCEPTIONS
+        if (rv == EINVAL) {
+            throw "Internal error: invalid alignment";
+        } else {
+            throw std::bad_alloc();
+        }
+#else
+        abort();
+#endif
+    }
+#else /* !HAVE_POSIX_MEMALIGN */
+    
+#ifdef USE_OWN_ALIGNED_MALLOC
+#pragma message("Rolling own aligned malloc: this is unlikely to perform as well as the alternatives")
+
+    // Alignment must be a power of two, bigger than the pointer
+    // size. Stuff the actual malloc'd pointer in just before the
+    // returned value.  This is the least desirable way to do this --
+    // the other options below are all better
+    size_t allocd = count * sizeof(T) + alignment;
+    void *buf = malloc(allocd);
+    if (buf) {
+        char *adj = (char *)buf;
+        while ((unsigned long long)adj & (alignment-1)) --adj;
+        ptr = ((char *)adj) + alignment;
+        new (((void **)ptr)[-1]) (void *);
+        ((void **)ptr)[-1] = buf;
+    }
+
+#else /* !USE_OWN_ALIGNED_MALLOC */
+
+#error "No aligned malloc available: define MALLOC_IS_ALIGNED to use system malloc, HAVE_POSIX_MEMALIGN if posix_memalign is available, HAVE__ALIGNED_MALLOC if _aligned_malloc is available, or USE_OWN_ALIGNED_MALLOC to roll our own"
+
+#endif /* !USE_OWN_ALIGNED_MALLOC */
+#endif /* !HAVE_POSIX_MEMALIGN */
+#endif /* !HAVE__ALIGNED_MALLOC */
+#endif /* !MALLOC_IS_ALIGNED */
+
+    if (!ptr) {
+#ifndef NO_EXCEPTIONS
+        throw std::bad_alloc();
+#else
+        abort();
+#endif
+    }
+
+    T *typed_ptr = static_cast<T *>(ptr);
+    for (size_t i = 0; i < count; ++i) {
+        new (typed_ptr + i) T;
+    }
+    return typed_ptr;
+}
+
+#ifdef HAVE_IPP
+
+template <>
+float *allocate(size_t count);
+
+template <>
+double *allocate(size_t count);
+
+#endif
+	
+template <typename T>
+T *allocate_and_zero(size_t count)
+{
+    T *ptr = allocate<T>(count);
+    v_zero(ptr, count);
+    return ptr;
+}
+
+template <typename T>
+void deallocate(T *ptr)
+{
+    if (!ptr) return;
+    
+#ifdef MALLOC_IS_ALIGNED
+    free((void *)ptr);
+#else /* !MALLOC_IS_ALIGNED */
+
+#ifdef HAVE__ALIGNED_MALLOC
+    _aligned_free((void *)ptr);
+#else /* !HAVE__ALIGNED_MALLOC */
+
+#ifdef HAVE_POSIX_MEMALIGN
+    free((void *)ptr);
+#else /* !HAVE_POSIX_MEMALIGN */
+    
+#ifdef USE_OWN_ALIGNED_MALLOC
+    free(((void **)ptr)[-1]);
+#else /* !USE_OWN_ALIGNED_MALLOC */
+
+#error "No aligned malloc available: define MALLOC_IS_ALIGNED to use system malloc, HAVE_POSIX_MEMALIGN if posix_memalign is available, or USE_OWN_ALIGNED_MALLOC to roll our own"
+
+#endif /* !USE_OWN_ALIGNED_MALLOC */
+#endif /* !HAVE_POSIX_MEMALIGN */
+#endif /* !HAVE__ALIGNED_MALLOC */
+#endif /* !MALLOC_IS_ALIGNED */
+}
+
+#ifdef HAVE_IPP
+
+template <>
+void deallocate(float *);
+
+template <>
+void deallocate(double *);
+
+#endif
+
+/// Reallocate preserving contents but leaving additional memory uninitialised	
+template <typename T>
+T *reallocate(T *ptr, size_t oldcount, size_t count)
+{
+    T *newptr = allocate<T>(count);
+    if (oldcount && ptr) {
+        v_copy(newptr, ptr, oldcount < count ? oldcount : count);
+    }
+    if (ptr) deallocate<T>(ptr);
+    return newptr;
+}
+
+/// Reallocate, zeroing all contents
+template <typename T>
+T *reallocate_and_zero(T *ptr, size_t oldcount, size_t count)
+{
+    ptr = reallocate(ptr, oldcount, count);
+    v_zero(ptr, count);
+    return ptr;
+}
+	
+/// Reallocate preserving contents and zeroing any additional memory	
+template <typename T>
+T *reallocate_and_zero_extension(T *ptr, size_t oldcount, size_t count)
+{
+    ptr = reallocate(ptr, oldcount, count);
+    if (count > oldcount) v_zero(ptr + oldcount, count - oldcount);
+    return ptr;
+}
+
+template <typename T>
+T **allocate_channels(size_t channels, size_t count)
+{
+    T **ptr = allocate<T *>(channels);
+    for (size_t c = 0; c < channels; ++c) {
+        ptr[c] = allocate<T>(count);
+    }
+    return ptr;
+}
+	
+template <typename T>
+T **allocate_and_zero_channels(size_t channels, size_t count)
+{
+    T **ptr = allocate<T *>(channels);
+    for (size_t c = 0; c < channels; ++c) {
+        ptr[c] = allocate_and_zero<T>(count);
+    }
+    return ptr;
+}
+
+template <typename T>
+void deallocate_channels(T **ptr, size_t channels)
+{
+    if (!ptr) return;
+    for (size_t c = 0; c < channels; ++c) {
+        deallocate<T>(ptr[c]);
+    }
+    deallocate<T *>(ptr);
+}
+	
+template <typename T>
+T **reallocate_channels(T **ptr,
+                        size_t oldchannels, size_t oldcount,
+                        size_t channels, size_t count)
+{
+    T **newptr = allocate_channels<T>(channels, count);
+    if (oldcount && ptr) {
+        for (size_t c = 0; c < oldchannels && c < channels; ++c) {
+            for (size_t i = 0; i < oldcount && i < count; ++i) {
+                newptr[c][i] = ptr[c][i];
+            }
+        }
+    } 
+    if (ptr) deallocate_channels<T>(ptr, oldchannels);
+    return newptr;
+}
+	
+template <typename T>
+T **reallocate_and_zero_extend_channels(T **ptr,
+                                        size_t oldchannels, size_t oldcount,
+                                        size_t channels, size_t count)
+{
+    T **newptr = allocate_and_zero_channels<T>(channels, count);
+    if (oldcount && ptr) {
+        for (size_t c = 0; c < oldchannels && c < channels; ++c) {
+            for (size_t i = 0; i < oldcount && i < count; ++i) {
+                newptr[c][i] = ptr[c][i];
+            }
+        }
+    } 
+    if (ptr) deallocate_channels<T>(ptr, oldchannels);
+    return newptr;
+}
+
+/// RAII class to call deallocate() on destruction
+template <typename T>
+class Deallocator
+{
+public:
+    Deallocator(T *t) : m_t(t) { }
+    ~Deallocator() { deallocate<T>(m_t); }
+private:
+    T *m_t;
+};
+
+/** Allocator for use with STL classes, e.g. vector, to ensure
+ *  alignment.  Based on example code by Stephan T. Lavavej.
+ *
+ *  e.g. std::vector<float, StlAllocator<float> > v;
+ */
+template <typename T>
+class StlAllocator
+{
+public:
+    typedef T *pointer;
+    typedef const T *const_pointer;
+    typedef T &reference;
+    typedef const T &const_reference;
+    typedef T value_type;
+    typedef size_t size_type;
+    typedef ptrdiff_t difference_type;
+
+    StlAllocator() { }
+    StlAllocator(const StlAllocator&) { }
+    template <typename U> StlAllocator(const StlAllocator<U>&) { }
+    ~StlAllocator() { }
+
+    T *
+    allocate(const size_t n) const {
+        if (n == 0) return 0;
+        if (n > max_size()) {
+#ifndef NO_EXCEPTIONS
+            throw std::length_error("Size overflow in StlAllocator::allocate()");
+#else
+            abort();
+#endif
+        }
+        return RubberBand::allocate<T>(n);
+    }
+
+    void
+    deallocate(T *const p, const size_t) const {
+        RubberBand::deallocate(p);
+    }
+
+    template <typename U>
+    T *
+    allocate(const size_t n, const U *) const {
+        return allocate(n);
+    }
+
+    T *
+    address(T &r) const {
+        return &r;
+    }
+
+    const T *
+    address(const T &s) const {
+        return &s;
+    }
+
+    size_t
+    max_size() const {
+        return (static_cast<size_t>(0) - static_cast<size_t>(1)) / sizeof(T);
+    }
+
+    template <typename U> struct rebind {
+        typedef StlAllocator<U> other;
+    };
+    
+    bool
+    operator==(const StlAllocator &) const {
+        return true;
+    }
+
+    bool
+    operator!=(const StlAllocator &) const {
+        return false;
+    }
+
+    void
+    construct(T *const p, const T &t) const {
+        void *const pv = static_cast<void *>(p);
+        new (pv) T(t);
+    }
+
+    void
+    destroy(T *const p) const {
+        p->~T();
+    }
+
+private:
+    StlAllocator& operator=(const StlAllocator&);
+};
+
+}
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/BQResampler.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/BQResampler.cpp
@@ -1,0 +1,642 @@
+//* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "BQResampler.h"
+
+#include <cmath>
+
+#include <iostream>
+#include <algorithm>
+
+#include "Allocators.h"
+#include "VectorOps.h"
+
+#include "mathmisc.h"
+
+#define BQ_R__ R__
+
+using std::vector;
+using std::cerr;
+using std::endl;
+using std::min;
+using std::max;
+
+namespace RubberBand {
+
+BQResampler::BQResampler(Parameters parameters, int channels) :
+    m_qparams(parameters.quality),
+    m_dynamism(parameters.dynamism),
+    m_ratio_change(parameters.ratioChange),
+    m_debug_level(parameters.debugLevel),
+    m_initial_rate(parameters.referenceSampleRate),
+    m_channels(channels),
+    m_fade_count(0),
+    m_initialised(false)
+{
+    if (m_debug_level > 0) {
+        cerr << "BQResampler::BQResampler: "
+             << (m_dynamism == RatioOftenChanging ? "often-changing" : "mostly-fixed")
+             << ", "
+             << (m_ratio_change == SmoothRatioChange ? "smooth" : "sudden")
+             << " ratio changes, ref " << m_initial_rate << " Hz" << endl;
+    }
+    
+    if (m_dynamism == RatioOftenChanging) {
+        m_proto_length = m_qparams.proto_p * m_qparams.p_multiple + 1;
+        if (m_debug_level > 0) {
+            cerr << "BQResampler: creating prototype filter of length "
+                 << m_proto_length << endl;
+        }
+        m_prototype = make_filter(m_proto_length, m_qparams.proto_p);
+        m_prototype.push_back(0.0); // interpolate without fear
+    }
+
+    int phase_reserve = 2 * int(round(m_initial_rate));
+    int buffer_reserve = 1000 * m_channels;
+    m_state_a.phase_info.reserve(phase_reserve);
+    m_state_a.buffer.reserve(buffer_reserve);
+
+    if (m_dynamism == RatioOftenChanging) {
+        m_state_b.phase_info.reserve(phase_reserve);
+        m_state_b.buffer.reserve(buffer_reserve);
+    }
+
+    m_s = &m_state_a;
+    m_fade = &m_state_b;
+}
+
+BQResampler::BQResampler(const BQResampler &other) :
+    m_qparams(other.m_qparams),
+    m_dynamism(other.m_dynamism),
+    m_ratio_change(other.m_ratio_change),
+    m_debug_level(other.m_debug_level),
+    m_initial_rate(other.m_initial_rate),
+    m_channels(other.m_channels),
+    m_state_a(other.m_state_a),
+    m_state_b(other.m_state_b),
+    m_fade_count(other.m_fade_count),
+    m_prototype(other.m_prototype),
+    m_proto_length(other.m_proto_length),
+    m_initialised(other.m_initialised)
+{
+    if (other.m_s == &(other.m_state_a)) {
+        m_s = &m_state_a;
+        m_fade = &m_state_b;
+    } else {
+        m_s = &m_state_b;
+        m_fade = &m_state_a;
+    }
+}
+
+void
+BQResampler::reset()
+{
+    m_initialised = false;
+    m_fade_count = 0;
+}
+
+BQResampler::QualityParams::QualityParams(Quality q)
+{
+    switch (q) {
+    case Fastest:
+        p_multiple = 12;
+        proto_p = 160;
+        k_snr = 70.0;
+        k_transition = 0.2;
+        cut = 0.9;
+        rational_max = 48000;
+        break;
+    case FastestTolerable:
+        p_multiple = 62;
+        proto_p = 160;
+        k_snr = 90.0;
+        k_transition = 0.05;
+        cut = 0.975;
+        rational_max = 96000;
+        break;
+    case Best:
+        p_multiple = 122;
+        proto_p = 800;
+        k_snr = 100.0;
+        k_transition = 0.01;
+        cut = 0.995;
+        rational_max = 192000;
+        break;
+    }
+}
+    
+int
+BQResampler::resampleInterleaved(float *const out,
+                                 int outspace,
+                                 const float *const in,
+                                 int incount,
+                                 double ratio,
+                                 bool final)
+{
+    int fade_length = int(round(m_initial_rate / 1000.0));
+    if (fade_length < 6) {
+        fade_length = 6;
+    }
+    int max_fade = min(outspace, int(floor(incount * ratio))) / 2;
+    if (fade_length > max_fade) {
+        fade_length = max_fade;
+    }
+        
+    if (!m_initialised) {
+        state_for_ratio(*m_s, ratio, *m_fade);
+        m_initialised = true;
+    } else if (ratio != m_s->parameters.ratio) {
+        state *tmp = m_fade;
+        m_fade = m_s;
+        m_s = tmp;
+        state_for_ratio(*m_s, ratio, *m_fade);
+        if (m_ratio_change == SmoothRatioChange) {
+            if (m_debug_level > 0) {
+                cerr << "BQResampler: ratio changed, beginning fade of length "
+                     << fade_length << endl;
+            }
+            m_fade_count = fade_length;
+        }
+    }
+
+    int i = 0, o = 0;
+    int bufsize = m_s->buffer.size();
+
+    int incount_samples = incount * m_channels;
+    int outspace_samples = outspace * m_channels;
+    
+    while (o < outspace_samples) {
+        while (i < incount_samples && m_s->fill < bufsize) {
+            m_s->buffer[m_s->fill++] = in[i++];
+        }
+        if (m_s->fill == bufsize) {
+            out[o++] = reconstruct_one(m_s);
+        } else if (final && m_s->fill > m_s->centre) {
+            out[o++] = reconstruct_one(m_s);
+        } else if (final && m_s->fill == m_s->centre &&
+                   m_s->current_phase != m_s->initial_phase) {
+            out[o++] = reconstruct_one(m_s);
+        } else {
+            break;
+        }
+    }
+
+    int fbufsize = m_fade->buffer.size();
+    int fi = 0, fo = 0;
+    while (fo < o && m_fade_count > 0) {
+        while (fi < incount_samples && m_fade->fill < fbufsize) {
+            m_fade->buffer[m_fade->fill++] = in[fi++];
+        }
+        if (m_fade->fill == fbufsize) {
+            double r = reconstruct_one(m_fade);
+            double fadeWith = out[fo];
+            double extent = double(m_fade_count - 1) / double(fade_length);
+            double mixture = 0.5 * (1.0 - cos(M_PI * extent));
+            double mixed = r * mixture + fadeWith * (1.0 - mixture);
+            out[fo] = mixed;
+            ++fo;
+            if (m_fade->current_channel == 0) {
+                --m_fade_count;
+            }
+        } else {
+            break;
+        }
+    }
+        
+    return o / m_channels;
+}
+
+double
+BQResampler::getEffectiveRatio(double ratio) const {
+    if (m_initialised && ratio == m_s->parameters.ratio) {
+        return m_s->parameters.effective;
+    } else {
+        return pick_params(ratio).effective;
+    }
+}
+    
+int
+BQResampler::gcd(int a, int b) const
+{
+    int c = a % b;
+    if (c == 0) return b;
+    else return gcd(b, c);
+}
+
+double
+BQResampler::bessel0(double x) const
+{
+    static double facsquared[] = {
+        0.0, 1.0, 4.0, 36.0,
+        576.0, 14400.0, 518400.0, 25401600.0,
+        1625702400.0, 131681894400.0, 1.316818944E13, 1.59335092224E15,
+        2.29442532803E17, 3.87757880436E19, 7.60005445655E21,
+        1.71001225272E24, 4.37763136697E26, 1.26513546506E29,
+        4.09903890678E31, 1.47975304535E34
+    };
+    static int nterms = sizeof(facsquared) / sizeof(facsquared[0]);
+    double b = 1.0;
+    for (int n = 1; n < nterms; ++n) {
+        double ff = facsquared[n];
+        double term = pow(x / 2.0, n * 2.0) / ff;
+        b += term;
+    }
+    return b;
+}
+
+vector<double>
+BQResampler::kaiser(double beta, int len) const
+{
+    double denominator = bessel0(beta);
+    int half = (len % 2 == 0 ? len/2 : (len+1)/2);
+    vector<double> v(len, 0.0);
+    for (int n = 0; n < half; ++n) {
+        double k = (2.0 * n) / (len-1) - 1.0;
+        v[n] = bessel0 (beta * sqrt(1.0 - k*k)) / denominator;
+    }
+    for (int n = half; n < len; ++n) {
+        v[n] = v[len-1 - n];
+    }
+    return v;
+}
+
+void
+BQResampler::kaiser_params(double attenuation,
+                           double transition,
+                           double &beta,
+                           int &len) const
+{
+    if (attenuation > 21.0) {
+        len = 1 + int(ceil((attenuation - 7.95) / (2.285 * transition)));
+    } else {
+        len = 1 + int(ceil(5.79 / transition));
+    }
+    beta = 0.0;
+    if (attenuation > 50.0) {
+        beta = 0.1102 * (attenuation - 8.7);
+    } else if (attenuation > 21.0) {
+        beta = 0.5842 * (pow (attenuation - 21.0, 0.4)) +
+            0.07886 * (attenuation - 21.0);
+    }
+}
+
+vector<double>
+BQResampler::kaiser_for(double attenuation,
+                        double transition,
+                        int minlen,
+                        int maxlen) const
+{
+    double beta;
+    int m;
+    kaiser_params(attenuation, transition, beta, m);
+    int mb = m;
+    if (maxlen > 0 && mb > maxlen - 1) {
+        mb = maxlen - 1;
+    } else if (minlen > 0 && mb < minlen) {
+        mb = minlen;
+    }
+    if (mb % 2 == 0) ++mb;
+    if (m_debug_level > 0) {
+        cerr << "BQResampler: window attenuation " << attenuation
+             << ", transition " << transition
+             << " -> length " << m << " adjusted to " << mb
+             << ", beta " << beta << endl;
+    }
+    return kaiser(beta, mb);
+}
+    
+void
+BQResampler::sinc_multiply(double peak_to_zero, vector<double> &buf) const
+{
+    int len = int(buf.size());
+    if (len < 2) return;
+
+    int left = len / 2;
+    int right = (len + 1) / 2;
+    double m = M_PI / peak_to_zero;
+
+    for (int i = 1; i <= right; ++i) {
+        double x = i * m;
+        double sinc = sin(x) / x;
+        if (i <= left) {
+            buf[left - i] *= sinc;
+        }
+        if (i < right) {
+            buf[i + left] *= sinc;
+        }
+    }
+}
+
+BQResampler::params
+BQResampler::fill_params(double ratio, double numd, double denomd) const
+{
+    int num = int(round(numd));
+    int denom = int(round(denomd));
+    params p;
+    int g = gcd (num, denom);
+    p.ratio = ratio;
+    p.numerator = num / g;
+    p.denominator = denom / g;
+    p.effective = double(p.numerator) / double(p.denominator);
+    p.peak_to_zero = max(p.denominator, p.numerator);
+    p.peak_to_zero /= m_qparams.cut;
+    p.scale = double(p.numerator) / double(p.peak_to_zero);
+
+    if (m_debug_level > 0) {
+        cerr << "BQResampler: ratio " << p.ratio
+             << " -> fraction " << p.numerator << "/" << p.denominator
+             << " with error " << p.effective - p.ratio
+             << endl;
+        cerr << "BQResampler: peak-to-zero " << p.peak_to_zero
+             << ", scale " << p.scale
+             << endl;
+    }
+    
+    return p;
+}
+    
+BQResampler::params
+BQResampler::pick_params(double ratio) const
+{
+    int max_denom;
+    if (m_dynamism == RatioMostlyFixed) {
+        max_denom = 192000;
+    } else {
+        max_denom = m_qparams.rational_max;
+        if (ratio > 1.0) {
+            max_denom = int(ceil(max_denom / ratio));
+        }
+    }
+    int num, denom;
+    pickNearestRational(ratio, max_denom, num, denom);
+    return fill_params(ratio, num, denom);
+}
+
+void
+BQResampler::phase_data_for(vector<BQResampler::phase_rec> &target_phase_data,
+                            floatbuf &target_phase_sorted_filter,
+                            int filter_length,
+                            const vector<double> *filter,
+                            int initial_phase,
+                            int input_spacing,
+                            int output_spacing) const
+{
+    target_phase_data.clear();
+    target_phase_data.reserve(input_spacing);
+        
+    for (int p = 0; p < input_spacing; ++p) {
+        int next_phase = p - output_spacing;
+        while (next_phase < 0) next_phase += input_spacing;
+        next_phase %= input_spacing;
+        double dspace = double(input_spacing);
+        int zip_length = int(ceil(double(filter_length - p) / dspace));
+        int drop = int(ceil(double(max(0, output_spacing - p)) / dspace));
+        phase_rec phase;
+        phase.next_phase = next_phase;
+        phase.drop = drop;
+        phase.length = zip_length;
+        phase.start_index = 0; // we fill this in below if needed
+        target_phase_data.push_back(phase);
+    }
+
+    if (m_dynamism == RatioMostlyFixed) {
+        if (!filter) {
+#ifndef NO_EXCEPTIONS
+            throw std::logic_error("filter required at phase_data_for in RatioMostlyFixed mode");
+#else        
+            abort();
+#endif
+        }
+        target_phase_sorted_filter.clear();
+        target_phase_sorted_filter.reserve(filter_length);
+        for (int p = initial_phase; ; ) {
+            phase_rec &phase = target_phase_data[p];
+            phase.start_index = target_phase_sorted_filter.size();
+            for (int i = 0; i < phase.length; ++i) {
+                target_phase_sorted_filter.push_back
+                    ((*filter)[i * input_spacing + p]);
+            }
+            p = phase.next_phase;
+            if (p == initial_phase) {
+                break;
+            }
+        }
+    }
+}
+
+vector<double>
+BQResampler::make_filter(int filter_length, double peak_to_zero) const
+{
+    vector<double> filter;
+    filter.reserve(filter_length);
+
+    vector<double> kaiser = kaiser_for(m_qparams.k_snr, m_qparams.k_transition,
+                                       1, filter_length);
+    int k_length = kaiser.size();
+
+    if (k_length == filter_length) {
+        sinc_multiply(peak_to_zero, kaiser);
+        return kaiser;
+    } else {
+        kaiser.push_back(0.0);
+        double m = double(k_length - 1) / double(filter_length - 1);
+        for (int i = 0; i < filter_length; ++i) {
+            double ix = i * m;
+            int iix = int(floor(ix));
+            double remainder = ix - iix;
+            double value = 0.0;
+            value += kaiser[iix] * (1.0 - remainder);
+            value += kaiser[iix+1] * remainder;
+            filter.push_back(value);
+        }
+        sinc_multiply(peak_to_zero, filter);
+        return filter;
+    }
+}
+
+void
+BQResampler::state_for_ratio(BQResampler::state &target_state,
+                             double ratio,
+                             const BQResampler::state &BQ_R__ prev_state) const
+{
+    params parameters = pick_params(ratio);
+    target_state.parameters = parameters;
+    
+    target_state.filter_length =
+        int(parameters.peak_to_zero * m_qparams.p_multiple + 1);
+
+    if (target_state.filter_length % 2 == 0) {
+        ++target_state.filter_length;
+    }
+
+    int half_length = target_state.filter_length / 2; // nb length is odd
+    int input_spacing = parameters.numerator;
+    int initial_phase = half_length % input_spacing;
+
+    target_state.initial_phase = initial_phase;
+    target_state.current_phase = initial_phase;
+
+    if (m_dynamism == RatioMostlyFixed) {
+        
+        if (m_debug_level > 0) {
+            cerr << "BQResampler: creating filter of length "
+                 << target_state.filter_length << endl;
+        }
+
+        vector<double> filter =
+            make_filter(target_state.filter_length, parameters.peak_to_zero);
+
+        phase_data_for(target_state.phase_info,
+                       target_state.phase_sorted_filter,
+                       target_state.filter_length, &filter,
+                       target_state.initial_phase,
+                       input_spacing,
+                       parameters.denominator);
+    } else {
+        phase_data_for(target_state.phase_info,
+                       target_state.phase_sorted_filter,
+                       target_state.filter_length, 0,
+                       target_state.initial_phase,
+                       input_spacing,
+                       parameters.denominator);
+    }
+
+    int buffer_left = half_length / input_spacing;
+    int buffer_right = buffer_left + 1;
+
+    int buffer_length = buffer_left + buffer_right;
+    buffer_length = max(buffer_length,
+                        int(prev_state.buffer.size() / m_channels));
+
+    target_state.centre = buffer_length / 2;
+    target_state.left = target_state.centre - buffer_left;
+    target_state.fill = target_state.centre;
+
+    buffer_length *= m_channels;
+    target_state.centre *= m_channels;
+    target_state.left *= m_channels;
+    target_state.fill *= m_channels;
+    
+    int n_phases = int(target_state.phase_info.size());
+
+    if (m_debug_level > 0) {
+        cerr << "BQResampler: " << m_channels << " channel(s) interleaved"
+             << ", buffer left " << buffer_left
+             << ", right " << buffer_right
+             << ", total " << buffer_length << endl;
+    
+        cerr << "BQResampler: input spacing " << input_spacing
+             << ", output spacing " << parameters.denominator
+             << ", initial phase " << initial_phase
+             << " of " << n_phases << endl;
+    }
+
+    if (prev_state.buffer.size() > 0) {
+        if (int(prev_state.buffer.size()) == buffer_length) {
+            target_state.buffer = prev_state.buffer;
+            target_state.fill = prev_state.fill;
+        } else {
+            target_state.buffer = floatbuf(buffer_length, 0.0);
+            for (int i = 0; i < prev_state.fill; ++i) {
+                int offset = i - prev_state.centre;
+                int new_ix = offset + target_state.centre;
+                if (new_ix >= 0 && new_ix < buffer_length) {
+                    target_state.buffer[new_ix] = prev_state.buffer[i];
+                    target_state.fill = new_ix + 1;
+                }
+            }
+        }
+
+        int phases_then = int(prev_state.phase_info.size());
+        double distance_through =
+            double(prev_state.current_phase) / double(phases_then);
+        target_state.current_phase = int(round(n_phases * distance_through));
+        if (target_state.current_phase >= n_phases) {
+            target_state.current_phase = n_phases - 1;
+        }
+    } else {
+        target_state.buffer = floatbuf(buffer_length, 0.0);
+    }
+}
+
+double
+BQResampler::reconstruct_one(state *s) const
+{
+    const phase_rec &pr = s->phase_info[s->current_phase];
+    int phase_length = pr.length;
+    double result = 0.0;
+
+    int dot_length =
+        min(phase_length,
+            (int(s->buffer.size()) - s->left) / m_channels);
+
+    if (m_dynamism == RatioMostlyFixed) {
+        int phase_start = pr.start_index;
+        if (m_channels == 1) {
+            result = v_multiply_and_sum
+                (s->phase_sorted_filter.data() + phase_start,
+                 s->buffer.data() + s->left,
+                 dot_length);
+        } else {
+            for (int i = 0; i < dot_length; ++i) {
+                result +=
+                    s->phase_sorted_filter[phase_start + i] *
+                    s->buffer[s->left + i * m_channels + s->current_channel];
+            }
+        }
+    } else {
+        double m = double(m_proto_length - 1) / double(s->filter_length - 1);
+        for (int i = 0; i < dot_length; ++i) {
+            double sample =
+                s->buffer[s->left + i * m_channels + s->current_channel];
+            int filter_index = i * s->parameters.numerator + s->current_phase;
+            double proto_index = m * filter_index;
+            int iix = int(floor(proto_index));
+            double remainder = proto_index - iix;
+            double filter_value = m_prototype[iix] * (1.0 - remainder);
+            filter_value += m_prototype[iix+1] * remainder;
+            result += filter_value * sample;
+        }
+    }
+
+    s->current_channel = (s->current_channel + 1) % m_channels;
+    
+    if (s->current_channel == 0) {
+
+        if (pr.drop > 0) {
+            int drop = pr.drop * m_channels;
+            v_move(s->buffer.data(), s->buffer.data() + drop,
+                   int(s->buffer.size()) - drop);
+            for (int i = 1; i <= drop; ++i) {
+                s->buffer[s->buffer.size() - i] = 0.0;
+            }
+            s->fill -= drop;
+        }
+
+        s->current_phase = pr.next_phase;
+    }
+    
+    return result * s->parameters.scale;
+}
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/BQResampler.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/BQResampler.h
@@ -1,0 +1,168 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BQ_BQRESAMPLER_H
+#define BQ_BQRESAMPLER_H
+
+#include <vector>
+
+#include "Allocators.h"
+#include "VectorOps.h"
+
+namespace RubberBand {
+
+class BQResampler
+{
+public:
+    enum Quality { Best, FastestTolerable, Fastest };
+    enum Dynamism { RatioOftenChanging, RatioMostlyFixed };
+    enum RatioChange { SmoothRatioChange, SuddenRatioChange };
+    
+    struct Parameters {
+        Quality quality;
+        Dynamism dynamism; 
+        RatioChange ratioChange;
+        double referenceSampleRate;
+        int debugLevel;
+
+        Parameters() :
+            quality(FastestTolerable),
+            dynamism(RatioMostlyFixed),
+            ratioChange(SmoothRatioChange),
+            referenceSampleRate(44100),
+            debugLevel(0) { }
+    };
+
+    BQResampler(Parameters parameters, int channels);
+    BQResampler(const BQResampler &);
+
+    int resampleInterleaved(float *const out, int outspace,
+                            const float *const in, int incount,
+                            double ratio, bool final);
+
+    double getEffectiveRatio(double ratio) const;
+    
+    void reset();
+
+private:
+    struct QualityParams {
+        int p_multiple;
+        int proto_p;
+        double k_snr;
+        double k_transition;
+        double cut;
+        int rational_max;
+        QualityParams(Quality);
+    };
+
+    const QualityParams m_qparams;
+    const Dynamism m_dynamism;
+    const RatioChange m_ratio_change;
+    const int m_debug_level;
+    const double m_initial_rate;
+    const int m_channels;
+
+    struct params {
+        double ratio;
+        int numerator;
+        int denominator;
+        double effective;
+        double peak_to_zero;
+        double scale;
+        params() : ratio(1.0), numerator(1), denominator(1),
+                   effective(1.0), peak_to_zero(0), scale(1.0) { }
+    };
+
+    struct phase_rec {
+        int next_phase;
+        int length;
+        int start_index;
+        int drop;
+        phase_rec() : next_phase(0), length(0), start_index(0), drop(0) { }
+    };
+
+    typedef std::vector<float, RubberBand::StlAllocator<float> > floatbuf;
+    
+    struct state {
+        params parameters;
+        int initial_phase;
+        int current_phase;
+        int current_channel;
+        int filter_length;
+        std::vector<phase_rec> phase_info;
+        floatbuf phase_sorted_filter;
+        floatbuf buffer;
+        int left;
+        int centre;
+        int fill;
+        state() : initial_phase(0), current_phase(0), current_channel(0),
+                  filter_length(0), left(0), centre(0), fill(0) { }
+    };
+
+    state m_state_a;
+    state m_state_b;
+
+    state *m_s;        // points at either m_state_a or m_state_b
+    state *m_fade;     // whichever one m_s does not point to
+    
+    int m_fade_count;
+    
+    std::vector<double> m_prototype;
+    int m_proto_length;
+    bool m_initialised;
+
+    int gcd(int a, int b) const;
+    double bessel0(double x) const;
+    std::vector<double> kaiser(double beta, int len) const;
+    void kaiser_params(double attenuation, double transition,
+                       double &beta, int &len) const;
+    std::vector<double> kaiser_for(double attenuation, double transition,
+                                   int minlen, int maxlen) const;
+    void sinc_multiply(double peak_to_zero, std::vector<double> &buf) const;
+
+    params fill_params(double ratio, double numd, double denomd) const;
+    params pick_params(double ratio) const;
+
+    std::vector<double> make_filter(int filter_length,
+                                    double peak_to_zero) const;
+    
+    void phase_data_for(std::vector<phase_rec> &target_phase_data,
+                        floatbuf &target_phase_sorted_filter,
+                        int filter_length,
+                        const std::vector<double> *filter,
+                        int initial_phase,
+                        int input_spacing,
+                        int output_spacing) const;
+    
+    void state_for_ratio(state &target_state,
+                         double ratio,
+                         const state &R__ prev_state) const;
+    
+    double reconstruct_one(state *s) const;
+
+    BQResampler &operator=(const BQResampler &); // not provided
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/FFT.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/FFT.cpp
@@ -1,0 +1,3193 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "FFT.h"
+#include "Thread.h"
+#include "Profiler.h"
+#include "Allocators.h"
+#include "VectorOps.h"
+#include "VectorOpsComplex.h"
+#include "mathmisc.h"
+
+// Define USE_FFTW_WISDOM if you are defining HAVE_FFTW3 and you want
+// to use FFTW_MEASURE mode with persistent wisdom files. This will
+// make things much slower on first use if no suitable wisdom has been
+// saved, but may be faster during subsequent use.
+//#define USE_FFTW_WISDOM 1
+
+// Define FFT_MEASUREMENT to include timing measurement code callable
+// via the static method FFT::tune(). Must be defined when the header
+// is included as well.
+//#define FFT_MEASUREMENT 1
+
+#ifdef FFT_MEASUREMENT
+#define FFT_MEASUREMENT_RETURN_RESULT_TEXT 1
+#include <sstream>
+#endif
+
+#ifdef HAVE_IPP
+#include <ippversion.h>
+#include <ipps.h>
+#endif
+
+#ifdef HAVE_FFTW3
+#include <fftw3.h>
+#endif
+
+#ifdef HAVE_SLEEF
+extern "C" {
+#include <sleef.h>
+#include <sleefdft.h>
+}
+#endif
+
+#ifdef HAVE_VDSP
+#include <Accelerate/Accelerate.h>
+#endif
+
+#ifdef HAVE_KISSFFT
+#include "kiss_fftr.h"
+#endif
+
+#ifndef HAVE_IPP
+#ifndef HAVE_FFTW3
+#ifndef HAVE_SLEEF
+#ifndef HAVE_KISSFFT
+#ifndef USE_BUILTIN_FFT
+#ifndef HAVE_VDSP
+#error No FFT implementation selected!
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#ifdef FFT_MEASUREMENT
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+#endif
+
+#define BQ_R__ R__
+
+namespace RubberBand {
+
+class FFTImpl
+{
+public:
+    virtual ~FFTImpl() { }
+
+    virtual FFT::Precisions getSupportedPrecisions() const = 0;
+
+    virtual int getSize() const = 0;
+    
+    virtual void initFloat() = 0;
+    virtual void initDouble() = 0;
+
+    virtual void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) = 0;
+    virtual void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) = 0;
+    virtual void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) = 0;
+    virtual void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) = 0;
+
+    virtual void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) = 0;
+    virtual void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) = 0;
+    virtual void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) = 0;
+    virtual void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) = 0;
+
+    virtual void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) = 0;
+    virtual void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) = 0;
+    virtual void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) = 0;
+    virtual void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) = 0;
+
+    virtual void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) = 0;
+    virtual void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) = 0;
+    virtual void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) = 0;
+    virtual void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) = 0;
+};    
+
+namespace FFTs {
+
+#ifdef HAVE_IPP
+
+class D_IPP : public FFTImpl
+{
+public:
+    D_IPP(int size) :
+        m_size(size), m_fspec(0), m_dspec(0)
+    { 
+        for (int i = 0; ; ++i) {
+            if (m_size & (1 << i)) {
+                m_order = i;
+                break;
+            }
+        }
+    }
+
+    ~D_IPP() {
+        if (m_fspec) {
+#if (IPP_VERSION_MAJOR >= 9)
+            ippsFree(m_fspecbuf);
+#else
+            ippsFFTFree_R_32f(m_fspec);
+#endif
+            ippsFree(m_fbuf);
+            ippsFree(m_fpacked);
+            ippsFree(m_fspare);
+        }
+        if (m_dspec) {
+#if (IPP_VERSION_MAJOR >= 9)
+            ippsFree(m_dspecbuf);
+#else
+            ippsFFTFree_R_64f(m_dspec);
+#endif
+            ippsFree(m_dbuf);
+            ippsFree(m_dpacked);
+            ippsFree(m_dspare);
+        }
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+    
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::SinglePrecision | FFT::DoublePrecision;
+    }
+
+    //!!! rv check
+
+    void initFloat() {
+        if (m_fspec) return;
+#if (IPP_VERSION_MAJOR >= 9)
+        int specSize, specBufferSize, bufferSize;
+        ippsFFTGetSize_R_32f(m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                             &specSize, &specBufferSize, &bufferSize);
+        m_fspecbuf = ippsMalloc_8u(specSize);
+        Ipp8u *tmp = ippsMalloc_8u(specBufferSize);
+        m_fbuf = ippsMalloc_8u(bufferSize);
+        m_fpacked = ippsMalloc_32f(m_size + 2);
+        m_fspare = ippsMalloc_32f(m_size / 2 + 1);
+        ippsFFTInit_R_32f(&m_fspec,
+                          m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                          m_fspecbuf, tmp);
+        ippsFree(tmp);
+#else
+        int specSize, specBufferSize, bufferSize;
+        ippsFFTGetSize_R_32f(m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                             &specSize, &specBufferSize, &bufferSize);
+        m_fbuf = ippsMalloc_8u(bufferSize);
+        m_fpacked = ippsMalloc_32f(m_size + 2);
+        m_fspare = ippsMalloc_32f(m_size / 2 + 1);
+        ippsFFTInitAlloc_R_32f(&m_fspec, m_order, IPP_FFT_NODIV_BY_ANY, 
+                               ippAlgHintFast);
+#endif
+    }
+
+    void initDouble() {
+        if (m_dspec) return;
+#if (IPP_VERSION_MAJOR >= 9)
+        int specSize, specBufferSize, bufferSize;
+        ippsFFTGetSize_R_64f(m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                             &specSize, &specBufferSize, &bufferSize);
+        m_dspecbuf = ippsMalloc_8u(specSize);
+        Ipp8u *tmp = ippsMalloc_8u(specBufferSize);
+        m_dbuf = ippsMalloc_8u(bufferSize);
+        m_dpacked = ippsMalloc_64f(m_size + 2);
+        m_dspare = ippsMalloc_64f(m_size / 2 + 1);
+        ippsFFTInit_R_64f(&m_dspec,
+                          m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                          m_dspecbuf, tmp);
+        ippsFree(tmp);
+#else
+        int specSize, specBufferSize, bufferSize;
+        ippsFFTGetSize_R_64f(m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                             &specSize, &specBufferSize, &bufferSize);
+        m_dbuf = ippsMalloc_8u(bufferSize);
+        m_dpacked = ippsMalloc_64f(m_size + 2);
+        m_dspare = ippsMalloc_64f(m_size / 2 + 1);
+        ippsFFTInitAlloc_R_64f(&m_dspec, m_order, IPP_FFT_NODIV_BY_ANY, 
+                               ippAlgHintFast);
+#endif
+    }
+
+    void packFloat(const float *BQ_R__ re, const float *BQ_R__ im) {
+        int index = 0;
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[index++] = re[i];
+            index++;
+        }
+        index = 0;
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                m_fpacked[index++] = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                m_fpacked[index++] = 0.f;
+            }
+        }
+    }
+
+    void packDouble(const double *BQ_R__ re, const double *BQ_R__ im) {
+        int index = 0;
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_dpacked[index++] = re[i];
+            index++;
+        }
+        index = 0;
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                m_dpacked[index++] = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                m_dpacked[index++] = 0.0;
+            }
+        }
+    }
+
+    void unpackFloat(float *re, float *BQ_R__ im) { // re may be equal to m_fpacked
+        int index = 0;
+        const int hs = m_size/2;
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                im[i] = m_fpacked[index++];
+            }
+        }
+        index = 0;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_fpacked[index++];
+            index++;
+        }
+    }        
+
+    void unpackDouble(double *re, double *BQ_R__ im) { // re may be equal to m_dpacked
+        int index = 0;
+        const int hs = m_size/2;
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                im[i] = m_dpacked[index++];
+            }
+        }
+        index = 0;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_dpacked[index++];
+            index++;
+        }
+    }        
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTFwd_RToCCS_64f(realIn, m_dpacked, m_dspec, m_dbuf);
+        unpackDouble(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTFwd_RToCCS_64f(realIn, complexOut, m_dspec, m_dbuf);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTFwd_RToCCS_64f(realIn, m_dpacked, m_dspec, m_dbuf);
+        unpackDouble(m_dpacked, m_dspare);
+        ippsCartToPolar_64f(m_dpacked, m_dspare, magOut, phaseOut, m_size/2+1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTFwd_RToCCS_64f(realIn, m_dpacked, m_dspec, m_dbuf);
+        unpackDouble(m_dpacked, m_dspare);
+        ippsMagnitude_64f(m_dpacked, m_dspare, magOut, m_size/2+1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTFwd_RToCCS_32f(realIn, m_fpacked, m_fspec, m_fbuf);
+        unpackFloat(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTFwd_RToCCS_32f(realIn, complexOut, m_fspec, m_fbuf);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTFwd_RToCCS_32f(realIn, m_fpacked, m_fspec, m_fbuf);
+        unpackFloat(m_fpacked, m_fspare);
+        ippsCartToPolar_32f(m_fpacked, m_fspare, magOut, phaseOut, m_size/2+1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTFwd_RToCCS_32f(realIn, m_fpacked, m_fspec, m_fbuf);
+        unpackFloat(m_fpacked, m_fspare);
+        ippsMagnitude_32f(m_fpacked, m_fspare, magOut, m_size/2+1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        packDouble(realIn, imagIn);
+        ippsFFTInv_CCSToR_64f(m_dpacked, realOut, m_dspec, m_dbuf);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTInv_CCSToR_64f(complexIn, realOut, m_dspec, m_dbuf);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        ippsPolarToCart_64f(magIn, phaseIn, realOut, m_dspare, m_size/2+1);
+        packDouble(realOut, m_dspare); // to m_dpacked
+        ippsFFTInv_CCSToR_64f(m_dpacked, realOut, m_dspec, m_dbuf);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        if (!m_dspec) initDouble();
+        const int hs1 = m_size/2 + 1;
+        ippsCopy_64f(magIn, m_dspare, hs1);
+        ippsAddC_64f_I(0.000001, m_dspare, hs1);
+        ippsLn_64f_I(m_dspare, hs1);
+        packDouble(m_dspare, 0);
+        ippsFFTInv_CCSToR_64f(m_dpacked, cepOut, m_dspec, m_dbuf);
+    }
+    
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        packFloat(realIn, imagIn);
+        ippsFFTInv_CCSToR_32f(m_fpacked, realOut, m_fspec, m_fbuf);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTInv_CCSToR_32f(complexIn, realOut, m_fspec, m_fbuf);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        ippsPolarToCart_32f(magIn, phaseIn, realOut, m_fspare, m_size/2+1);
+        packFloat(realOut, m_fspare); // to m_fpacked
+        ippsFFTInv_CCSToR_32f(m_fpacked, realOut, m_fspec, m_fbuf);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        if (!m_fspec) initFloat();
+        const int hs1 = m_size/2 + 1;
+        ippsCopy_32f(magIn, m_fspare, hs1);
+        ippsAddC_32f_I(0.000001f, m_fspare, hs1);
+        ippsLn_32f_I(m_fspare, hs1);
+        packFloat(m_fspare, 0);
+        ippsFFTInv_CCSToR_32f(m_fpacked, cepOut, m_fspec, m_fbuf);
+    }
+
+private:
+    const int m_size;
+    int m_order;
+    IppsFFTSpec_R_32f *m_fspec;
+    IppsFFTSpec_R_64f *m_dspec;
+    Ipp8u *m_fspecbuf;
+    Ipp8u *m_dspecbuf;
+    Ipp8u *m_fbuf;
+    Ipp8u *m_dbuf;
+    float *m_fpacked;
+    float *m_fspare;
+    double *m_dpacked;
+    double *m_dspare;
+};
+
+#endif /* HAVE_IPP */
+
+#ifdef HAVE_VDSP
+
+class D_VDSP : public FFTImpl
+{
+public:
+    D_VDSP(int size) :
+        m_size(size), m_fspec(0), m_dspec(0),
+        m_fpacked(0), m_fspare(0),
+        m_dpacked(0), m_dspare(0)
+    { 
+        for (int i = 0; ; ++i) {
+            if (m_size & (1 << i)) {
+                m_order = i;
+                break;
+            }
+        }
+    }
+
+    ~D_VDSP() {
+        if (m_fspec) {
+            vDSP_destroy_fftsetup(m_fspec);
+            deallocate(m_fspare);
+            deallocate(m_fspare2);
+            deallocate(m_fbuf->realp);
+            deallocate(m_fbuf->imagp);
+            delete m_fbuf;
+            deallocate(m_fpacked->realp);
+            deallocate(m_fpacked->imagp);
+            delete m_fpacked;
+        }
+        if (m_dspec) {
+            vDSP_destroy_fftsetupD(m_dspec);
+            deallocate(m_dspare);
+            deallocate(m_dspare2);
+            deallocate(m_dbuf->realp);
+            deallocate(m_dbuf->imagp);
+            delete m_dbuf;
+            deallocate(m_dpacked->realp);
+            deallocate(m_dpacked->imagp);
+            delete m_dpacked;
+        }
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::SinglePrecision | FFT::DoublePrecision;
+    }
+
+    //!!! rv check
+
+    void initFloat() {
+        if (m_fspec) return;
+        m_fspec = vDSP_create_fftsetup(m_order, FFT_RADIX2);
+        m_fbuf = new DSPSplitComplex;
+        //!!! "If possible, tempBuffer->realp and tempBuffer->imagp should be 32-byte aligned for best performance."
+        m_fbuf->realp = allocate<float>(m_size);
+        m_fbuf->imagp = allocate<float>(m_size);
+        m_fpacked = new DSPSplitComplex;
+        m_fpacked->realp = allocate<float>(m_size / 2 + 1);
+        m_fpacked->imagp = allocate<float>(m_size / 2 + 1);
+        m_fspare = allocate<float>(m_size + 2);
+        m_fspare2 = allocate<float>(m_size + 2);
+    }
+
+    void initDouble() {
+        if (m_dspec) return;
+        m_dspec = vDSP_create_fftsetupD(m_order, FFT_RADIX2);
+        m_dbuf = new DSPDoubleSplitComplex;
+        //!!! "If possible, tempBuffer->realp and tempBuffer->imagp should be 32-byte aligned for best performance."
+        m_dbuf->realp = allocate<double>(m_size);
+        m_dbuf->imagp = allocate<double>(m_size);
+        m_dpacked = new DSPDoubleSplitComplex;
+        m_dpacked->realp = allocate<double>(m_size / 2 + 1);
+        m_dpacked->imagp = allocate<double>(m_size / 2 + 1);
+        m_dspare = allocate<double>(m_size + 2);
+        m_dspare2 = allocate<double>(m_size + 2);
+    }
+
+    void packReal(const float *BQ_R__ const re) {
+        // Pack input for forward transform 
+        vDSP_ctoz((DSPComplex *)re, 2, m_fpacked, 1, m_size/2);
+    }
+    void packComplex(const float *BQ_R__ const re, const float *BQ_R__ const im) {
+        // Pack input for inverse transform 
+        if (re) v_copy(m_fpacked->realp, re, m_size/2 + 1);
+        else v_zero(m_fpacked->realp, m_size/2 + 1);
+        if (im) v_copy(m_fpacked->imagp, im, m_size/2 + 1);
+        else v_zero(m_fpacked->imagp, m_size/2 + 1);
+        fnyq();
+    }
+
+    void unpackReal(float *BQ_R__ const re) {
+        // Unpack output for inverse transform
+        vDSP_ztoc(m_fpacked, 1, (DSPComplex *)re, 2, m_size/2);
+    }
+    void unpackComplex(float *BQ_R__ const re, float *BQ_R__ const im) {
+        // Unpack output for forward transform
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        float two = 2.f;
+        vDSP_vsdiv(m_fpacked->realp, 1, &two, re, 1, m_size/2 + 1);
+        vDSP_vsdiv(m_fpacked->imagp, 1, &two, im, 1, m_size/2 + 1);
+    }
+    void unpackComplex(float *BQ_R__ const cplx) {
+        // Unpack output for forward transform
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        const int hs1 = m_size/2 + 1;
+        for (int i = 0; i < hs1; ++i) {
+            cplx[i*2] = m_fpacked->realp[i] * 0.5f;
+            cplx[i*2+1] = m_fpacked->imagp[i] * 0.5f;
+        }
+    }
+
+    void packReal(const double *BQ_R__ const re) {
+        // Pack input for forward transform
+        vDSP_ctozD((DSPDoubleComplex *)re, 2, m_dpacked, 1, m_size/2);
+    }
+    void packComplex(const double *BQ_R__ const re, const double *BQ_R__ const im) {
+        // Pack input for inverse transform
+        if (re) v_copy(m_dpacked->realp, re, m_size/2 + 1);
+        else v_zero(m_dpacked->realp, m_size/2 + 1);
+        if (im) v_copy(m_dpacked->imagp, im, m_size/2 + 1);
+        else v_zero(m_dpacked->imagp, m_size/2 + 1);
+        dnyq();
+    }
+
+    void unpackReal(double *BQ_R__ const re) {
+        // Unpack output for inverse transform
+        vDSP_ztocD(m_dpacked, 1, (DSPDoubleComplex *)re, 2, m_size/2);
+    }
+    void unpackComplex(double *BQ_R__ const re, double *BQ_R__ const im) {
+        // Unpack output for forward transform
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        double two = 2.0;
+        vDSP_vsdivD(m_dpacked->realp, 1, &two, re, 1, m_size/2 + 1);
+        vDSP_vsdivD(m_dpacked->imagp, 1, &two, im, 1, m_size/2 + 1);
+    }
+    void unpackComplex(double *BQ_R__ const cplx) {
+        // Unpack output for forward transform
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        const int hs1 = m_size/2 + 1;
+        for (int i = 0; i < hs1; ++i) {
+            cplx[i*2] = m_dpacked->realp[i] * 0.5;
+            cplx[i*2+1] = m_dpacked->imagp[i] * 0.5;
+        }
+    }
+
+    void fdenyq() {
+        // for fft result in packed form, unpack the DC and Nyquist bins
+        const int hs = m_size/2;
+        m_fpacked->realp[hs] = m_fpacked->imagp[0];
+        m_fpacked->imagp[hs] = 0.f;
+        m_fpacked->imagp[0] = 0.f;
+    }
+    void ddenyq() {
+        // for fft result in packed form, unpack the DC and Nyquist bins
+        const int hs = m_size/2;
+        m_dpacked->realp[hs] = m_dpacked->imagp[0];
+        m_dpacked->imagp[hs] = 0.;
+        m_dpacked->imagp[0] = 0.;
+    }
+
+    void fnyq() {
+        // for ifft input in packed form, pack the DC and Nyquist bins
+        const int hs = m_size/2;
+        m_fpacked->imagp[0] = m_fpacked->realp[hs];
+        m_fpacked->realp[hs] = 0.f;
+        m_fpacked->imagp[hs] = 0.f;
+    }
+    void dnyq() {
+        // for ifft input in packed form, pack the DC and Nyquist bins
+        const int hs = m_size/2;
+        m_dpacked->imagp[0] = m_dpacked->realp[hs];
+        m_dpacked->realp[hs] = 0.;
+        m_dpacked->imagp[hs] = 0.;
+    }
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        if (!m_dspec) initDouble();
+        packReal(realIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_FORWARD);
+        ddenyq();
+        unpackComplex(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        if (!m_dspec) initDouble();
+        packReal(realIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_FORWARD);
+        ddenyq();
+        unpackComplex(complexOut);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        if (!m_dspec) initDouble();
+        const int hs1 = m_size/2+1;
+        packReal(realIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_FORWARD);
+        ddenyq();
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        for (int i = 0; i < hs1; ++i) m_dpacked->realp[i] *= 0.5;
+        for (int i = 0; i < hs1; ++i) m_dpacked->imagp[i] *= 0.5;
+        v_cartesian_to_polar(magOut, phaseOut,
+                             m_dpacked->realp, m_dpacked->imagp, hs1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        if (!m_dspec) initDouble();
+        packReal(realIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_FORWARD);
+        ddenyq();
+        const int hs1 = m_size/2+1;
+        vDSP_zvmagsD(m_dpacked, 1, m_dspare, 1, hs1);
+        vvsqrt(m_dspare2, m_dspare, &hs1);
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        double two = 2.0;
+        vDSP_vsdivD(m_dspare2, 1, &two, magOut, 1, hs1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        if (!m_fspec) initFloat();
+        packReal(realIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_FORWARD);
+        fdenyq();
+        unpackComplex(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        if (!m_fspec) initFloat();
+        packReal(realIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_FORWARD);
+        fdenyq();
+        unpackComplex(complexOut);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        if (!m_fspec) initFloat();
+        const int hs1 = m_size/2+1;
+        packReal(realIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_FORWARD);
+        fdenyq();
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        for (int i = 0; i < hs1; ++i) m_fpacked->realp[i] *= 0.5f;
+        for (int i = 0; i < hs1; ++i) m_fpacked->imagp[i] *= 0.5f;
+        v_cartesian_to_polar(magOut, phaseOut,
+                             m_fpacked->realp, m_fpacked->imagp, hs1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        if (!m_fspec) initFloat();
+        packReal(realIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_FORWARD);
+        fdenyq();
+        const int hs1 = m_size/2 + 1;
+        vDSP_zvmags(m_fpacked, 1, m_fspare, 1, hs1);
+        vvsqrtf(m_fspare2, m_fspare, &hs1);
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        float two = 2.f;
+        vDSP_vsdiv(m_fspare2, 1, &two, magOut, 1, hs1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        packComplex(realIn, imagIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        double *d[2] = { m_dpacked->realp, m_dpacked->imagp };
+        v_deinterleave(d, complexIn, 2, m_size/2 + 1);
+        dnyq();
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        const int hs1 = m_size/2+1;
+        vvsincos(m_dpacked->imagp, m_dpacked->realp, phaseIn, &hs1);
+        double *const rp = m_dpacked->realp;
+        double *const ip = m_dpacked->imagp;
+        for (int i = 0; i < hs1; ++i) rp[i] *= magIn[i];
+        for (int i = 0; i < hs1; ++i) ip[i] *= magIn[i];
+        dnyq();
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        if (!m_dspec) initDouble();
+        const int hs1 = m_size/2 + 1;
+        v_copy(m_dspare, magIn, hs1);
+        for (int i = 0; i < hs1; ++i) m_dspare[i] += 0.000001;
+        vvlog(m_dspare2, m_dspare, &hs1);
+        inverse(m_dspare2, 0, cepOut);
+    }
+    
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        packComplex(realIn, imagIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        float *f[2] = { m_fpacked->realp, m_fpacked->imagp };
+        v_deinterleave(f, complexIn, 2, m_size/2 + 1);
+        fnyq();
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+
+        const int hs1 = m_size/2+1;
+        vvsincosf(m_fpacked->imagp, m_fpacked->realp, phaseIn, &hs1);
+        float *const rp = m_fpacked->realp;
+        float *const ip = m_fpacked->imagp;
+        for (int i = 0; i < hs1; ++i) rp[i] *= magIn[i];
+        for (int i = 0; i < hs1; ++i) ip[i] *= magIn[i];
+        fnyq();
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        if (!m_fspec) initFloat();
+        const int hs1 = m_size/2 + 1;
+        v_copy(m_fspare, magIn, hs1);
+        for (int i = 0; i < hs1; ++i) m_fspare[i] += 0.000001f;
+        vvlogf(m_fspare2, m_fspare, &hs1);
+        inverse(m_fspare2, 0, cepOut);
+    }
+
+private:
+    const int m_size;
+    int m_order;
+    FFTSetup m_fspec;
+    FFTSetupD m_dspec;
+    DSPSplitComplex *m_fbuf;
+    DSPDoubleSplitComplex *m_dbuf;
+    DSPSplitComplex *m_fpacked;
+    float *m_fspare;
+    float *m_fspare2;
+    DSPDoubleSplitComplex *m_dpacked;
+    double *m_dspare;
+    double *m_dspare2;
+};
+
+#endif /* HAVE_VDSP */
+
+#ifdef HAVE_FFTW3
+
+/*
+ Define FFTW_DOUBLE_ONLY to make all uses of FFTW functions be
+ double-precision (so "float" FFTs are calculated by casting to
+ doubles and using the double-precision FFTW function).
+
+ Define FFTW_SINGLE_ONLY to make all uses of FFTW functions be
+ single-precision (so "double" FFTs are calculated by casting to
+ floats and using the single-precision FFTW function).
+
+ Neither of these flags is desirable for either performance or
+ precision. The main reason to define either flag is to avoid linking
+ against both fftw3 and fftw3f libraries.
+*/
+
+//#define FFTW_DOUBLE_ONLY 1
+//#define FFTW_SINGLE_ONLY 1
+
+#if defined(FFTW_DOUBLE_ONLY) && defined(FFTW_SINGLE_ONLY)
+// Can't meaningfully define both
+#error Can only define one of FFTW_DOUBLE_ONLY and FFTW_SINGLE_ONLY
+#endif
+
+#if defined(FFTW_FLOAT_ONLY)
+#warning FFTW_FLOAT_ONLY is deprecated, use FFTW_SINGLE_ONLY instead
+#define FFTW_SINGLE_ONLY 1
+#endif
+
+#ifdef FFTW_DOUBLE_ONLY
+#define fft_float_type double
+#define fftwf_complex fftw_complex
+#define fftwf_plan fftw_plan
+#define fftwf_plan_dft_r2c_1d fftw_plan_dft_r2c_1d
+#define fftwf_plan_dft_c2r_1d fftw_plan_dft_c2r_1d
+#define fftwf_destroy_plan fftw_destroy_plan
+#define fftwf_malloc fftw_malloc
+#define fftwf_free fftw_free
+#define fftwf_execute fftw_execute
+#define atan2f atan2
+#define sqrtf sqrt
+#define cosf cos
+#define sinf sin
+#else
+#define fft_float_type float
+#endif /* FFTW_DOUBLE_ONLY */
+
+#ifdef FFTW_SINGLE_ONLY
+#define fft_double_type float
+#define fftw_complex fftwf_complex
+#define fftw_plan fftwf_plan
+#define fftw_plan_dft_r2c_1d fftwf_plan_dft_r2c_1d
+#define fftw_plan_dft_c2r_1d fftwf_plan_dft_c2r_1d
+#define fftw_destroy_plan fftwf_destroy_plan
+#define fftw_malloc fftwf_malloc
+#define fftw_free fftwf_free
+#define fftw_execute fftwf_execute
+#define atan2 atan2f
+#define sqrt sqrtf
+#define cos cosf
+#define sin sinf
+#else
+#define fft_double_type double
+#endif /* FFTW_SINGLE_ONLY */
+
+class D_FFTW : public FFTImpl
+{
+public:
+    D_FFTW(int size) :
+        m_fplanf(0), m_dplanf(0), m_size(size)
+    {
+    }
+
+    ~D_FFTW() {
+        if (m_fplanf) {
+            lock();
+            bool save = false;
+            if (m_extantf > 0 && --m_extantf == 0) save = true;
+            (void)save; // avoid compiler warning
+#ifdef USE_FFTW_WISDOM
+#ifndef FFTW_DOUBLE_ONLY
+            if (save) saveWisdom('f');
+#endif
+#endif
+            fftwf_destroy_plan(m_fplanf);
+            fftwf_destroy_plan(m_fplani);
+            fftwf_free(m_fbuf);
+            fftwf_free(m_fpacked);
+            unlock();
+        }
+        if (m_dplanf) {
+            lock();
+            bool save = false;
+            if (m_extantd > 0 && --m_extantd == 0) save = true;
+            (void)save; // avoid compiler warning
+#ifdef USE_FFTW_WISDOM
+#ifndef FFTW_SINGLE_ONLY
+            if (save) saveWisdom('d');
+#endif
+#endif
+            fftw_destroy_plan(m_dplanf);
+            fftw_destroy_plan(m_dplani);
+            fftw_free(m_dbuf);
+            fftw_free(m_dpacked);
+            unlock();
+        }
+        lock();
+        if (m_extantf <= 0 && m_extantd <= 0) {
+#ifndef FFTW_DOUBLE_ONLY
+            fftwf_cleanup();
+#endif
+#ifndef FFTW_SINGLE_ONLY
+            fftw_cleanup();
+#endif
+        }
+        unlock();
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+#ifdef FFTW_SINGLE_ONLY
+        return FFT::SinglePrecision;
+#else
+#ifdef FFTW_DOUBLE_ONLY
+        return FFT::DoublePrecision;
+#else
+        return FFT::SinglePrecision | FFT::DoublePrecision;
+#endif
+#endif
+    }
+
+    void initFloat() {
+        if (m_fplanf) return;
+        bool load = false;
+        lock();
+        if (m_extantf++ == 0) load = true;
+        (void)load; // avoid compiler warning
+#ifdef USE_FFTW_WISDOM
+#ifdef FFTW_DOUBLE_ONLY
+        if (load) loadWisdom('d');
+#else
+        if (load) loadWisdom('f');
+#endif
+#endif
+        m_fbuf = (fft_float_type *)fftw_malloc(m_size * sizeof(fft_float_type));
+        m_fpacked = (fftwf_complex *)fftw_malloc
+            ((m_size/2 + 1) * sizeof(fftwf_complex));
+#ifdef USE_FFTW_WISDOM
+        m_fplanf = fftwf_plan_dft_r2c_1d
+            (m_size, m_fbuf, m_fpacked, FFTW_MEASURE);
+        m_fplani = fftwf_plan_dft_c2r_1d
+            (m_size, m_fpacked, m_fbuf, FFTW_MEASURE);
+#else
+        m_fplanf = fftwf_plan_dft_r2c_1d
+            (m_size, m_fbuf, m_fpacked, FFTW_ESTIMATE);
+        m_fplani = fftwf_plan_dft_c2r_1d
+            (m_size, m_fpacked, m_fbuf, FFTW_ESTIMATE);
+#endif
+        unlock();
+    }
+
+    void initDouble() {
+        if (m_dplanf) return;
+        bool load = false;
+        lock();
+        if (m_extantd++ == 0) load = true;
+        (void)load; // avoid compiler warning
+#ifdef USE_FFTW_WISDOM
+#ifdef FFTW_SINGLE_ONLY
+        if (load) loadWisdom('f');
+#else
+        if (load) loadWisdom('d');
+#endif
+#endif
+        m_dbuf = (fft_double_type *)fftw_malloc(m_size * sizeof(fft_double_type));
+        m_dpacked = (fftw_complex *)fftw_malloc
+            ((m_size/2 + 1) * sizeof(fftw_complex));
+#ifdef USE_FFTW_WISDOM
+        m_dplanf = fftw_plan_dft_r2c_1d
+            (m_size, m_dbuf, m_dpacked, FFTW_MEASURE);
+        m_dplani = fftw_plan_dft_c2r_1d
+            (m_size, m_dpacked, m_dbuf, FFTW_MEASURE);
+#else
+        m_dplanf = fftw_plan_dft_r2c_1d
+            (m_size, m_dbuf, m_dpacked, FFTW_ESTIMATE);
+        m_dplani = fftw_plan_dft_c2r_1d
+            (m_size, m_dpacked, m_dbuf, FFTW_ESTIMATE);
+#endif
+        unlock();
+    }
+
+    void loadWisdom(char type) { wisdom(false, type); }
+    void saveWisdom(char type) { wisdom(true, type); }
+
+    void wisdom(bool save, char type) {
+#ifdef USE_FFTW_WISDOM
+#ifdef FFTW_DOUBLE_ONLY
+        if (type == 'f') return;
+#endif
+#ifdef FFTW_SINGLE_ONLY
+        if (type == 'd') return;
+#endif
+
+        const char *home = getenv("HOME");
+        if (!home) return;
+
+        char fn[256];
+        snprintf(fn, 256, "%s/%s.%c", home, ".bqfft.wisdom", type);
+
+        FILE *f = fopen(fn, save ? "wb" : "rb");
+        if (!f) return;
+
+        if (save) {
+            switch (type) {
+#ifdef FFTW_DOUBLE_ONLY
+            case 'f': break;
+#else
+            case 'f': fftwf_export_wisdom_to_file(f); break;
+#endif
+#ifdef FFTW_SINGLE_ONLY
+            case 'd': break;
+#else
+            case 'd': fftw_export_wisdom_to_file(f); break;
+#endif
+            default: break;
+            }
+        } else {
+            switch (type) {
+#ifdef FFTW_DOUBLE_ONLY
+            case 'f': break;
+#else
+            case 'f': fftwf_import_wisdom_from_file(f); break;
+#endif
+#ifdef FFTW_SINGLE_ONLY
+            case 'd': break;
+#else
+            case 'd': fftw_import_wisdom_from_file(f); break;
+#endif
+            default: break;
+            }
+        }
+
+        fclose(f);
+#else
+        (void)save;
+        (void)type;
+#endif
+    }
+
+    void packFloat(const float *BQ_R__ re, const float *BQ_R__ im) {
+        const int hs = m_size/2;
+        fftwf_complex *const BQ_R__ fpacked = m_fpacked; 
+        for (int i = 0; i <= hs; ++i) {
+            fpacked[i][0] = re[i];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                fpacked[i][1] = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                fpacked[i][1] = 0.f;
+            }
+        }                
+    }
+
+    void packDouble(const double *BQ_R__ re, const double *BQ_R__ im) {
+        const int hs = m_size/2;
+        fftw_complex *const BQ_R__ dpacked = m_dpacked; 
+        for (int i = 0; i <= hs; ++i) {
+            dpacked[i][0] = re[i];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                dpacked[i][1] = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                dpacked[i][1] = 0.0;
+            }
+        }
+    }
+
+    void unpackFloat(float *BQ_R__ re, float *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_fpacked[i][0];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                im[i] = m_fpacked[i][1];
+            }
+        }
+    }        
+
+    void unpackDouble(double *BQ_R__ re, double *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_dpacked[i][0];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                im[i] = m_dpacked[i][1];
+            }
+        }
+    }        
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        if (!m_dplanf) initDouble();
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realIn != dbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                dbuf[i] = realIn[i];
+            }
+        fftw_execute(m_dplanf);
+        unpackDouble(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        if (!m_dplanf) initDouble();
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realIn != dbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                dbuf[i] = realIn[i];
+            }
+        fftw_execute(m_dplanf);
+        v_convert(complexOut, (const fft_double_type *)m_dpacked, sz + 2);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        if (!m_dplanf) initDouble();
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+        const int sz = m_size;
+#ifndef FFTW_SINGLE_ONLY
+        if (realIn != dbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                dbuf[i] = realIn[i];
+            }
+        fftw_execute(m_dplanf);
+        v_cartesian_interleaved_to_polar
+            (magOut, phaseOut, (const fft_double_type *)m_dpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        if (!m_dplanf) initDouble();
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+        const int sz = m_size;
+#ifndef FFTW_SINGLE_ONLY
+        if (realIn != m_dbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                dbuf[i] = realIn[i];
+            }
+        fftw_execute(m_dplanf);
+        v_cartesian_interleaved_to_magnitudes
+            (magOut, (const fft_double_type *)m_dpacked, m_size/2+1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        if (!m_fplanf) initFloat();
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+        const int sz = m_size;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realIn != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                fbuf[i] = realIn[i];
+            }
+        fftwf_execute(m_fplanf);
+        unpackFloat(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        if (!m_fplanf) initFloat();
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+        const int sz = m_size;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realIn != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                fbuf[i] = realIn[i];
+            }
+        fftwf_execute(m_fplanf);
+        v_convert(complexOut, (const fft_float_type *)m_fpacked, sz + 2);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        if (!m_fplanf) initFloat();
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+        const int sz = m_size;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realIn != fbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                fbuf[i] = realIn[i];
+            }
+        fftwf_execute(m_fplanf);
+        v_cartesian_interleaved_to_polar
+            (magOut, phaseOut, (const fft_float_type *)m_fpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        if (!m_fplanf) initFloat();
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+        const int sz = m_size;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realIn != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                fbuf[i] = realIn[i];
+            }
+        fftwf_execute(m_fplanf);
+        v_cartesian_interleaved_to_magnitudes
+            (magOut, (const fft_float_type *)m_fpacked, m_size/2+1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        packDouble(realIn, imagIn);
+        fftw_execute(m_dplani);
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realOut != dbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = dbuf[i];
+            }
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        v_convert((fft_double_type *)m_dpacked, complexIn, m_size + 2);
+        fftw_execute(m_dplani);
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realOut != dbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = dbuf[i];
+            }
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        v_polar_to_cartesian_interleaved
+            ((fft_double_type *)m_dpacked, magIn, phaseIn, m_size/2+1);
+        fftw_execute(m_dplani);
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realOut != dbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = dbuf[i];
+            }
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        if (!m_dplanf) initDouble();
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+        fftw_complex *const BQ_R__ dpacked = m_dpacked;
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            dpacked[i][0] = log(magIn[i] + 0.000001);
+        }
+        for (int i = 0; i <= hs; ++i) {
+            dpacked[i][1] = 0.0;
+        }
+        fftw_execute(m_dplani);
+        const int sz = m_size;
+#ifndef FFTW_SINGLE_ONLY
+        if (cepOut != dbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                cepOut[i] = dbuf[i];
+            }
+    }
+
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        packFloat(realIn, imagIn);
+        fftwf_execute(m_fplani);
+        const int sz = m_size;
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realOut != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = fbuf[i];
+            }
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        v_convert((fft_float_type *)m_fpacked, complexIn, m_size + 2);
+        fftwf_execute(m_fplani);
+        const int sz = m_size;
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realOut != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = fbuf[i];
+            }
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        v_polar_to_cartesian_interleaved
+            ((fft_float_type *)m_fpacked, magIn, phaseIn, m_size/2+1);
+        fftwf_execute(m_fplani);
+        const int sz = m_size;
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realOut != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = fbuf[i];
+            }
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        if (!m_fplanf) initFloat();
+        const int hs = m_size/2;
+        fftwf_complex *const BQ_R__ fpacked = m_fpacked;
+        for (int i = 0; i <= hs; ++i) {
+            fpacked[i][0] = logf(magIn[i] + 0.000001f);
+        }
+        for (int i = 0; i <= hs; ++i) {
+            fpacked[i][1] = 0.f;
+        }
+        fftwf_execute(m_fplani);
+        const int sz = m_size;
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+#ifndef FFTW_DOUBLE_ONLY
+        if (cepOut != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                cepOut[i] = fbuf[i];
+            }
+    }
+
+private:
+    fftwf_plan m_fplanf;
+    fftwf_plan m_fplani;
+#ifdef FFTW_DOUBLE_ONLY
+    double *m_fbuf;
+#else
+    float *m_fbuf;
+#endif
+    fftwf_complex *m_fpacked;
+    fftw_plan m_dplanf;
+    fftw_plan m_dplani;
+#ifdef FFTW_SINGLE_ONLY
+    float *m_dbuf;
+#else
+    double *m_dbuf;
+#endif
+    fftw_complex *m_dpacked;
+    const int m_size;
+    static int m_extantf;
+    static int m_extantd;
+#ifdef NO_THREADING
+    void lock() {}
+    void unlock() {}
+#else
+#ifdef _WIN32
+    static HANDLE m_commonMutex;
+    void lock() { WaitForSingleObject(m_commonMutex, INFINITE); }
+    void unlock() { ReleaseMutex(m_commonMutex); }
+#else
+    static pthread_mutex_t m_commonMutex;
+    static bool m_haveMutex;
+    void lock() { pthread_mutex_lock(&m_commonMutex); }
+    void unlock() { pthread_mutex_unlock(&m_commonMutex); }
+#endif
+#endif
+};
+
+int
+D_FFTW::m_extantf = 0;
+
+int
+D_FFTW::m_extantd = 0;
+
+#ifndef NO_THREADING
+#ifdef _WIN32
+HANDLE D_FFTW::m_commonMutex = CreateMutex(NULL, FALSE, NULL);
+#else
+pthread_mutex_t D_FFTW::m_commonMutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+#endif
+
+#undef fft_float_type
+#undef fft_double_type
+
+#ifdef FFTW_DOUBLE_ONLY
+#undef fftwf_complex
+#undef fftwf_plan 
+#undef fftwf_plan_dft_r2c_1d
+#undef fftwf_plan_dft_c2r_1d
+#undef fftwf_destroy_plan 
+#undef fftwf_malloc 
+#undef fftwf_free 
+#undef fftwf_execute
+#undef atan2f 
+#undef sqrtf 
+#undef cosf 
+#undef sinf
+#endif /* FFTW_DOUBLE_ONLY */
+
+#ifdef FFTW_SINGLE_ONLY
+#undef fftw_complex
+#undef fftw_plan
+#undef fftw_plan_dft_r2c_1d
+#undef fftw_plan_dft_c2r_1d 
+#undef fftw_destroy_plan
+#undef fftw_malloc
+#undef fftw_free
+#undef fftw_execute
+#undef atan2
+#undef sqrt
+#undef cos
+#undef sin
+#endif /* FFTW_SINGLE_ONLY */
+
+#endif /* HAVE_FFTW3 */
+
+#ifdef HAVE_SLEEF
+
+class D_SLEEF : public FFTImpl
+{
+    bool isAligned(const void *ptr) {
+        return ! ((uintptr_t)ptr & 63);
+    }
+    
+public:
+    D_SLEEF(int size) :
+        m_fplanf(0), m_fplani(0), m_fbuf(0), m_fpacked(0),
+        m_dplanf(0), m_dplani(0), m_dbuf(0), m_dpacked(0),
+        m_size(size)
+    {
+    }
+
+    ~D_SLEEF() {
+        if (m_fplanf) {
+            SleefDFT_dispose(m_fplanf);
+            SleefDFT_dispose(m_fplani);
+            Sleef_free(m_fbuf);
+            Sleef_free(m_fpacked);
+        }
+        if (m_dplanf) {
+            SleefDFT_dispose(m_dplanf);
+            SleefDFT_dispose(m_dplani);
+            Sleef_free(m_dbuf);
+            Sleef_free(m_dpacked);
+        }
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::SinglePrecision | FFT::DoublePrecision;
+    }
+
+    void initFloat() {
+        if (m_fplanf) return;
+
+        m_fbuf = static_cast<float *>
+            (Sleef_malloc(m_size * sizeof(float)));
+        m_fpacked = static_cast<float *>
+            (Sleef_malloc((m_size + 2) * sizeof(float)));
+
+        m_fplanf = SleefDFT_float_init1d
+            (m_size, m_fbuf, m_fpacked,
+             SLEEF_MODE_FORWARD | SLEEF_MODE_REAL | SLEEF_MODE_ESTIMATE);
+
+        m_fplani = SleefDFT_float_init1d
+            (m_size, m_fpacked, m_fbuf,
+             SLEEF_MODE_BACKWARD | SLEEF_MODE_REAL | SLEEF_MODE_ESTIMATE);
+    }
+
+    void initDouble() {
+        if (m_dplanf) return;
+
+        m_dbuf = static_cast<double *>
+            (Sleef_malloc(m_size * sizeof(double)));
+        m_dpacked = static_cast<double *>
+            (Sleef_malloc((m_size + 2) * sizeof(double)));
+
+        m_dplanf = SleefDFT_double_init1d
+            (m_size, m_dbuf, m_dpacked,
+             SLEEF_MODE_FORWARD | SLEEF_MODE_REAL | SLEEF_MODE_ESTIMATE);
+
+        m_dplani = SleefDFT_double_init1d
+            (m_size, m_dpacked, m_dbuf,
+             SLEEF_MODE_BACKWARD | SLEEF_MODE_REAL | SLEEF_MODE_ESTIMATE);
+    }
+
+    void packFloat(const float *BQ_R__ re, const float *BQ_R__ im) {
+        const float *src[2] = { re, im };
+        v_interleave(m_fpacked, src, 2, m_size/2 + 1);
+    }
+
+    void packDouble(const double *BQ_R__ re, const double *BQ_R__ im) {
+        const double *src[2] = { re, im };
+        v_interleave(m_dpacked, src, 2, m_size/2 + 1);
+    }
+
+    void unpackFloat(float *BQ_R__ re, float *BQ_R__ im) {
+        float *dst[2] = { re, im };
+        v_deinterleave(dst, m_fpacked, 2, m_size/2 + 1);
+    }        
+
+    void unpackDouble(double *BQ_R__ re, double *BQ_R__ im) {
+        double *dst[2] = { re, im };
+        v_deinterleave(dst, m_dpacked, 2, m_size/2 + 1);
+    }        
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        if (!m_dplanf) initDouble();
+        if (isAligned(realIn)) {
+            SleefDFT_double_execute(m_dplanf, realIn, 0);
+        } else {
+            v_copy(m_dbuf, realIn, m_size);
+            SleefDFT_double_execute(m_dplanf, 0, 0);
+        }
+        unpackDouble(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        if (!m_dplanf) initDouble();
+        if (isAligned(realIn) && isAligned(complexOut)) {
+            SleefDFT_double_execute(m_dplanf, realIn, complexOut);
+        } else {
+            v_copy(m_dbuf, realIn, m_size);
+            SleefDFT_double_execute(m_dplanf, 0, 0);
+            v_copy(complexOut, m_dpacked, m_size + 2);
+        }
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        if (!m_dplanf) initDouble();
+        if (isAligned(realIn)) {
+            SleefDFT_double_execute(m_dplanf, realIn, 0);
+        } else {
+            v_copy(m_dbuf, realIn, m_size);
+            SleefDFT_double_execute(m_dplanf, 0, 0);
+        }
+        v_cartesian_interleaved_to_polar(magOut, phaseOut, m_dpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        if (!m_dplanf) initDouble();
+        if (isAligned(realIn)) {
+            SleefDFT_double_execute(m_dplanf, realIn, 0);
+        } else {
+            v_copy(m_dbuf, realIn, m_size);
+            SleefDFT_double_execute(m_dplanf, 0, 0);
+        }
+        v_cartesian_interleaved_to_magnitudes(magOut, m_dpacked, m_size/2+1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        if (!m_fplanf) initFloat();
+        if (isAligned(realIn)) {
+            SleefDFT_float_execute(m_fplanf, realIn, 0);
+        } else {
+            v_copy(m_fbuf, realIn, m_size);
+            SleefDFT_float_execute(m_fplanf, 0, 0);
+        }
+        unpackFloat(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        if (!m_fplanf) initFloat();
+        if (isAligned(realIn) && isAligned(complexOut)) {
+            SleefDFT_float_execute(m_fplanf, realIn, complexOut);
+        } else {
+            v_copy(m_fbuf, realIn, m_size);
+            SleefDFT_float_execute(m_fplanf, 0, 0);
+            v_copy(complexOut, m_fpacked, m_size + 2);
+        }
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        if (!m_fplanf) initFloat();
+        if (isAligned(realIn)) {
+            SleefDFT_float_execute(m_fplanf, realIn, 0);
+        } else {
+            v_copy(m_fbuf, realIn, m_size);
+            SleefDFT_float_execute(m_fplanf, 0, 0);
+        }
+        v_cartesian_interleaved_to_polar(magOut, phaseOut, m_fpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        if (!m_fplanf) initFloat();
+        if (isAligned(realIn)) {
+            SleefDFT_float_execute(m_fplanf, realIn, 0);
+        } else {
+            v_copy(m_fbuf, realIn, m_size);
+            SleefDFT_float_execute(m_fplanf, 0, 0);
+        }
+        v_cartesian_interleaved_to_magnitudes(magOut, m_fpacked, m_size/2+1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        packDouble(realIn, imagIn);
+        if (isAligned(realOut)) {
+            SleefDFT_double_execute(m_dplani, 0, realOut);
+        } else {
+            SleefDFT_double_execute(m_dplani, 0, 0);
+            v_copy(realOut, m_dbuf, m_size);
+        }
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        if (isAligned(complexIn) && isAligned(realOut)) {
+            SleefDFT_double_execute(m_dplani, complexIn, realOut);
+        } else {            
+            v_copy(m_dpacked, complexIn, m_size + 2);
+            SleefDFT_double_execute(m_dplani, 0, 0);
+            v_copy(realOut, m_dbuf, m_size);
+        }
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        v_polar_to_cartesian_interleaved(m_dpacked, magIn, phaseIn, m_size/2+1);
+        if (isAligned(realOut)) {
+            SleefDFT_double_execute(m_dplani, 0, realOut);
+        } else {
+            SleefDFT_double_execute(m_dplani, 0, 0);
+            v_copy(realOut, m_dbuf, m_size);
+        }
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        if (!m_dplanf) initDouble();
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_dpacked[i*2] = log(magIn[i] + 0.000001);
+            m_dpacked[i*2+1] = 0.0;
+        }
+        if (isAligned(cepOut)) {
+            SleefDFT_double_execute(m_dplani, 0, cepOut);
+        } else {
+            SleefDFT_double_execute(m_dplani, 0, 0);
+            v_copy(cepOut, m_dbuf, m_size);
+        }
+    }
+
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        packFloat(realIn, imagIn);
+        if (isAligned(realOut)) {
+            SleefDFT_float_execute(m_dplani, 0, realOut);
+        } else {
+            SleefDFT_float_execute(m_fplani, 0, 0);
+            v_copy(realOut, m_fbuf, m_size);
+        }
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        if (isAligned(complexIn) && isAligned(realOut)) {
+            SleefDFT_float_execute(m_fplani, complexIn, realOut);
+        } else {
+            v_copy(m_fpacked, complexIn, m_size + 2);
+            SleefDFT_float_execute(m_fplani, 0, 0);
+            v_copy(realOut, m_fbuf, m_size);
+        }
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        v_polar_to_cartesian_interleaved(m_fpacked, magIn, phaseIn, m_size/2+1);
+        if (isAligned(realOut)) {
+            SleefDFT_float_execute(m_fplani, 0, realOut);
+        } else {
+            SleefDFT_float_execute(m_fplani, 0, 0);
+            v_copy(realOut, m_fbuf, m_size);
+        }
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        if (!m_fplanf) initFloat();
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i*2] = logf(magIn[i] + 0.000001f);
+            m_fpacked[i*2+1] = 0.0;
+        }
+        if (isAligned(cepOut)) {
+            SleefDFT_float_execute(m_fplani, 0, cepOut);
+        } else {
+            SleefDFT_float_execute(m_fplani, 0, 0);
+            v_copy(cepOut, m_fbuf, m_size);
+        }
+    }
+
+private:
+    SleefDFT *m_fplanf;
+    SleefDFT *m_fplani;
+
+    float *m_fbuf;
+    float *m_fpacked;
+    
+    SleefDFT *m_dplanf;
+    SleefDFT *m_dplani;
+
+    double *m_dbuf;
+    double *m_dpacked;
+    
+    const int m_size;
+};
+
+#endif /* HAVE_SLEEF */
+
+#ifdef HAVE_KISSFFT
+
+class D_KISSFFT : public FFTImpl
+{
+public:
+    D_KISSFFT(int size) :
+        m_size(size),
+        m_fplanf(0),  
+        m_fplani(0)
+    {
+#ifdef FIXED_POINT
+#error KISSFFT is not configured for float values
+#endif
+        if (sizeof(kiss_fft_scalar) != sizeof(float)) {
+            std::cerr << "ERROR: KISSFFT is not configured for float values"
+                      << std::endl;
+        }
+
+        m_fbuf = new kiss_fft_scalar[m_size + 2];
+        m_fpacked = new kiss_fft_cpx[m_size + 2];
+        m_fplanf = kiss_fftr_alloc(m_size, 0, NULL, NULL);
+        m_fplani = kiss_fftr_alloc(m_size, 1, NULL, NULL);
+    }
+
+    ~D_KISSFFT() {
+        kiss_fftr_free(m_fplanf);
+        kiss_fftr_free(m_fplani);
+
+        delete[] m_fbuf;
+        delete[] m_fpacked;
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::SinglePrecision;
+    }
+
+    void initFloat() { }
+    void initDouble() { }
+
+    void packFloat(const float *BQ_R__ re, const float *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i].r = re[i];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                m_fpacked[i].i = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                m_fpacked[i].i = 0.f;
+            }
+        }
+    }
+
+    void unpackFloat(float *BQ_R__ re, float *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_fpacked[i].r;
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                im[i] = m_fpacked[i].i;
+            }
+        }
+    }        
+
+    void packDouble(const double *BQ_R__ re, const double *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i].r = float(re[i]);
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                m_fpacked[i].i = float(im[i]);
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                m_fpacked[i].i = 0.f;
+            }
+        }
+    }
+
+    void unpackDouble(double *BQ_R__ re, double *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = double(m_fpacked[i].r);
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                im[i] = double(m_fpacked[i].i);
+            }
+        }
+    }        
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        v_convert(m_fbuf, realIn, m_size);
+        kiss_fftr(m_fplanf, m_fbuf, m_fpacked);
+        unpackDouble(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        v_convert(m_fbuf, realIn, m_size);
+        kiss_fftr(m_fplanf, m_fbuf, m_fpacked);
+        v_convert(complexOut, (float *)m_fpacked, m_size + 2);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        v_convert(m_fbuf, realIn, m_size);
+        kiss_fftr(m_fplanf, m_fbuf, m_fpacked);
+        v_cartesian_interleaved_to_polar
+            (magOut, phaseOut, (float *)m_fpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        v_convert(m_fbuf, realIn, m_size);
+        kiss_fftr(m_fplanf, m_fbuf, m_fpacked);
+        v_cartesian_interleaved_to_magnitudes
+            (magOut, (float *)m_fpacked, m_size/2+1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        kiss_fftr(m_fplanf, realIn, m_fpacked);
+        unpackFloat(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        kiss_fftr(m_fplanf, realIn, (kiss_fft_cpx *)complexOut);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        kiss_fftr(m_fplanf, realIn, m_fpacked);
+        v_cartesian_interleaved_to_polar
+            (magOut, phaseOut, (float *)m_fpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        kiss_fftr(m_fplanf, realIn, m_fpacked);
+        v_cartesian_interleaved_to_magnitudes
+            (magOut, (float *)m_fpacked, m_size/2+1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        packDouble(realIn, imagIn);
+        kiss_fftri(m_fplani, m_fpacked, m_fbuf);
+        v_convert(realOut, m_fbuf, m_size);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        v_convert((float *)m_fpacked, complexIn, m_size + 2);
+        kiss_fftri(m_fplani, m_fpacked, m_fbuf);
+        v_convert(realOut, m_fbuf, m_size);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        v_polar_to_cartesian_interleaved
+            ((float *)m_fpacked, magIn, phaseIn, m_size/2+1);
+        kiss_fftri(m_fplani, m_fpacked, m_fbuf);
+        v_convert(realOut, m_fbuf, m_size);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i].r = float(log(magIn[i] + 0.000001));
+            m_fpacked[i].i = 0.0f;
+        }
+        kiss_fftri(m_fplani, m_fpacked, m_fbuf);
+        v_convert(cepOut, m_fbuf, m_size);
+    }
+    
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        packFloat(realIn, imagIn);
+        kiss_fftri(m_fplani, m_fpacked, realOut);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        v_copy((float *)m_fpacked, complexIn, m_size + 2);
+        kiss_fftri(m_fplani, m_fpacked, realOut);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        v_polar_to_cartesian_interleaved
+            ((float *)m_fpacked, magIn, phaseIn, m_size/2+1);
+        kiss_fftri(m_fplani, m_fpacked, realOut);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i].r = logf(magIn[i] + 0.000001f);
+            m_fpacked[i].i = 0.0f;
+        }
+        kiss_fftri(m_fplani, m_fpacked, cepOut);
+    }
+
+private:
+    const int m_size;
+    kiss_fftr_cfg m_fplanf;
+    kiss_fftr_cfg m_fplani;
+    kiss_fft_scalar *m_fbuf;
+    kiss_fft_cpx *m_fpacked;
+};
+
+#endif /* HAVE_KISSFFT */
+
+#ifdef USE_BUILTIN_FFT
+
+class D_Builtin : public FFTImpl
+{
+public:
+    D_Builtin(int size) :
+        m_size(size),
+        m_half(size/2),
+        m_blockTableSize(16),
+        m_maxTabledBlock(1 << m_blockTableSize)
+    {
+        m_table = allocate_and_zero<int>(m_half);
+        m_sincos = allocate_and_zero<double>(m_blockTableSize * 4);
+        m_sincos_r = allocate_and_zero<double>(m_half);
+        m_vr = allocate_and_zero<double>(m_half);
+        m_vi = allocate_and_zero<double>(m_half);
+        m_a = allocate_and_zero<double>(m_half + 1);
+        m_b = allocate_and_zero<double>(m_half + 1);
+        m_c = allocate_and_zero<double>(m_half + 1);
+        m_d = allocate_and_zero<double>(m_half + 1);
+        m_a_and_b[0] = m_a;
+        m_a_and_b[1] = m_b;
+        m_c_and_d[0] = m_c;
+        m_c_and_d[1] = m_d;
+        makeTables();
+    }
+
+    ~D_Builtin() {
+        deallocate(m_table);
+        deallocate(m_sincos);
+        deallocate(m_sincos_r);
+        deallocate(m_vr);
+        deallocate(m_vi);
+        deallocate(m_a);
+        deallocate(m_b);
+        deallocate(m_c);
+        deallocate(m_d);
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::DoublePrecision;
+    }
+
+    void initFloat() { }
+    void initDouble() { }
+
+    void forward(const double *BQ_R__ realIn,
+                 double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        transformF(realIn, realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn,
+                            double *BQ_R__ complexOut) {
+        transformF(realIn, m_c, m_d);
+        v_interleave(complexOut, m_c_and_d, 2, m_half + 1);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn,
+                      double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        transformF(realIn, m_c, m_d);
+        v_cartesian_to_polar(magOut, phaseOut, m_c, m_d, m_half + 1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn,
+                          double *BQ_R__ magOut) {
+        transformF(realIn, m_c, m_d);
+        v_cartesian_to_magnitudes(magOut, m_c, m_d, m_half + 1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut,
+                 float *BQ_R__ imagOut) {
+        transformF(realIn, m_c, m_d);
+        v_convert(realOut, m_c, m_half + 1);
+        v_convert(imagOut, m_d, m_half + 1);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn,
+                            float *BQ_R__ complexOut) {
+        transformF(realIn, m_c, m_d);
+        for (int i = 0; i <= m_half; ++i) complexOut[i*2] = m_c[i];
+        for (int i = 0; i <= m_half; ++i) complexOut[i*2+1] = m_d[i];
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn,
+                      float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        transformF(realIn, m_c, m_d);
+        v_cartesian_to_polar(magOut, phaseOut, m_c, m_d, m_half + 1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn,
+                          float *BQ_R__ magOut) {
+        transformF(realIn, m_c, m_d);
+        v_cartesian_to_magnitudes(magOut, m_c, m_d, m_half + 1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn,
+                 double *BQ_R__ realOut) {
+        transformI(realIn, imagIn, realOut);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn,
+                            double *BQ_R__ realOut) {
+        v_deinterleave(m_a_and_b, complexIn, 2, m_half + 1);
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn,
+                      double *BQ_R__ realOut) {
+        v_polar_to_cartesian(m_a, m_b, magIn, phaseIn, m_half + 1);
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn,
+                         double *BQ_R__ cepOut) {
+        for (int i = 0; i <= m_half; ++i) {
+            double real = log(magIn[i] + 0.000001);
+            m_a[i] = real;
+            m_b[i] = 0.0;
+        }
+        transformI(m_a, m_b, cepOut);
+    }
+
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn,
+                 float *BQ_R__ realOut) {
+        v_convert(m_a, realIn, m_half + 1);
+        v_convert(m_b, imagIn, m_half + 1);
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn,
+                            float *BQ_R__ realOut) {
+        for (int i = 0; i <= m_half; ++i) m_a[i] = complexIn[i*2];
+        for (int i = 0; i <= m_half; ++i) m_b[i] = complexIn[i*2+1];
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn,
+                      float *BQ_R__ realOut) {
+        v_polar_to_cartesian(m_a, m_b, magIn, phaseIn, m_half + 1);
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn,
+                         float *BQ_R__ cepOut) {
+        for (int i = 0; i <= m_half; ++i) {
+            float real = logf(magIn[i] + 0.000001);
+            m_a[i] = real;
+            m_b[i] = 0.0;
+        }
+        transformI(m_a, m_b, cepOut);
+    }
+
+private:
+    const int m_size;
+    const int m_half;
+    const int m_blockTableSize;
+    const int m_maxTabledBlock;
+    int *m_table;
+    double *m_sincos;
+    double *m_sincos_r;
+    double *m_vr;
+    double *m_vi;
+    double *m_a;
+    double *m_b;
+    double *m_c;
+    double *m_d;
+    double *m_a_and_b[2];
+    double *m_c_and_d[2];
+
+    void makeTables() {
+
+        // main table for complex fft - this is of size m_half,
+        // because we are at heart a real-complex fft only
+        
+        int bits;
+        int i, j, k, m;
+
+        int n = m_half;
+        
+        for (i = 0; ; ++i) {
+            if (n & (1 << i)) {
+                bits = i;
+                break;
+            }
+        }
+        
+        for (i = 0; i < n; ++i) {
+            m = i;
+            for (j = k = 0; j < bits; ++j) {
+                k = (k << 1) | (m & 1);
+                m >>= 1;
+            }
+            m_table[i] = k;
+        }
+
+        // sin and cos tables for complex fft
+        int ix = 0;
+        for (i = 2; i <= m_maxTabledBlock; i <<= 1) {
+            double phase = 2.0 * M_PI / double(i);
+            m_sincos[ix++] = sin(phase);
+            m_sincos[ix++] = sin(2.0 * phase);
+            m_sincos[ix++] = cos(phase);
+            m_sincos[ix++] = cos(2.0 * phase);
+        }
+        
+        // sin and cos tables for real-complex transform
+        ix = 0;
+        for (i = 0; i < n/2; ++i) {
+            double phase = M_PI * (double(i + 1) / double(m_half) + 0.5);
+            m_sincos_r[ix++] = sin(phase);
+            m_sincos_r[ix++] = cos(phase);
+        }
+    }        
+
+    // Uses m_a and m_b internally; does not touch m_c or m_d
+    template <typename T>
+    void transformF(const T *BQ_R__ ri,
+                    double *BQ_R__ ro, double *BQ_R__ io) {
+
+        int halfhalf = m_half / 2;
+        for (int i = 0; i < m_half; ++i) {
+            m_a[i] = ri[i * 2];
+            m_b[i] = ri[i * 2 + 1];
+        }
+        transformComplex(m_a, m_b, m_vr, m_vi, false);
+        ro[0] = m_vr[0] + m_vi[0];
+        ro[m_half] = m_vr[0] - m_vi[0];
+        io[0] = io[m_half] = 0.0;
+        int ix = 0;
+        for (int i = 0; i < halfhalf; ++i) {
+            double s = -m_sincos_r[ix++];
+            double c =  m_sincos_r[ix++];
+            int k = i + 1;
+            double r0 = m_vr[k];
+            double i0 = m_vi[k];
+            double r1 = m_vr[m_half - k];
+            double i1 = -m_vi[m_half - k];
+            double tw_r = (r0 - r1) * c - (i0 - i1) * s;
+            double tw_i = (r0 - r1) * s + (i0 - i1) * c;
+            ro[k] = (r0 + r1 + tw_r) * 0.5;
+            ro[m_half - k] = (r0 + r1 - tw_r) * 0.5;
+            io[k] = (i0 + i1 + tw_i) * 0.5;
+            io[m_half - k] = (tw_i - i0 - i1) * 0.5;
+        }
+    }
+
+    // Uses m_c and m_d internally; does not touch m_a or m_b
+    template <typename T>
+    void transformI(const double *BQ_R__ ri, const double *BQ_R__ ii,
+                    T *BQ_R__ ro) {
+        
+        int halfhalf = m_half / 2;
+        m_vr[0] = ri[0] + ri[m_half];
+        m_vi[0] = ri[0] - ri[m_half];
+        int ix = 0;
+        for (int i = 0; i < halfhalf; ++i) {
+            double s = m_sincos_r[ix++];
+            double c = m_sincos_r[ix++];
+            int k = i + 1;
+            double r0 = ri[k];
+            double r1 = ri[m_half - k];
+            double i0 = ii[k];
+            double i1 = -ii[m_half - k];
+            double tw_r = (r0 - r1) * c - (i0 - i1) * s;
+            double tw_i = (r0 - r1) * s + (i0 - i1) * c;
+            m_vr[k] = (r0 + r1 + tw_r);
+            m_vr[m_half - k] = (r0 + r1 - tw_r);
+            m_vi[k] = (i0 + i1 + tw_i);
+            m_vi[m_half - k] = (tw_i - i0 - i1);
+        }
+        transformComplex(m_vr, m_vi, m_c, m_d, true);
+        for (int i = 0; i < m_half; ++i) {
+            ro[i*2] = m_c[i];
+            ro[i*2+1] = m_d[i];
+        }
+    }
+    
+    void transformComplex(const double *BQ_R__ ri, const double *BQ_R__ ii,
+                          double *BQ_R__ ro, double *BQ_R__ io,
+                          bool inverse) {
+
+        // Following Don Cross's 1998 implementation, described by its
+        // author as public domain.
+        
+        // Because we are at heart a real-complex fft only, and we know that:
+        const int n = m_half;
+
+        for (int i = 0; i < n; ++i) {
+            int j = m_table[i];
+            ro[j] = ri[i];
+            io[j] = ii[i];
+        }
+        
+        int ix = 0;
+        int blockEnd = 1;
+        double ifactor = (inverse ? -1.0 : 1.0);
+        
+        for (int blockSize = 2; blockSize <= n; blockSize <<= 1) {
+
+            double sm1, sm2, cm1, cm2;
+
+            if (blockSize <= m_maxTabledBlock) {
+                sm1 = ifactor * m_sincos[ix++];
+                sm2 = ifactor * m_sincos[ix++];
+                cm1 = m_sincos[ix++];
+                cm2 = m_sincos[ix++];
+            } else {
+                double phase = 2.0 * M_PI / double(blockSize);
+                sm1 = ifactor * sin(phase);
+                sm2 = ifactor * sin(2.0 * phase);
+                cm1 = cos(phase);
+                cm2 = cos(2.0 * phase);
+            }
+            
+            double w = 2 * cm1;
+            double ar[3], ai[3];
+            
+            for (int i = 0; i < n; i += blockSize) {
+                
+                ar[2] = cm2;
+                ar[1] = cm1;
+                
+                ai[2] = sm2;
+                ai[1] = sm1;
+
+                int j = i;
+                
+                for (int m = 0; m < blockEnd; ++m) {
+                    
+                    ar[0] = w * ar[1] - ar[2];
+                    ar[2] = ar[1];
+                    ar[1] = ar[0];
+
+                    ai[0] = w * ai[1] - ai[2];
+                    ai[2] = ai[1];
+                    ai[1] = ai[0];
+
+                    int k = j + blockEnd;
+                    double tr = ar[0] * ro[k] - ai[0] * io[k];
+                    double ti = ar[0] * io[k] + ai[0] * ro[k];
+
+                    ro[k] = ro[j] - tr;
+                    io[k] = io[j] - ti;
+
+                    ro[j] += tr;
+                    io[j] += ti;
+
+                    ++j;
+                }
+            }
+
+            blockEnd = blockSize;
+        }
+    }
+};
+
+#endif /* USE_BUILTIN_FFT */
+
+class D_DFT : public FFTImpl
+{
+private:
+    template <typename T>
+    class DFT
+    {
+    public:
+        DFT(int size) : m_size(size), m_bins(size/2 + 1) {
+            
+            m_sin = allocate_channels<double>(m_size, m_size);
+            m_cos = allocate_channels<double>(m_size, m_size);
+
+            for (int i = 0; i < m_size; ++i) {
+                for (int j = 0; j < m_size; ++j) {
+                    double arg = (double(i) * double(j) * M_PI * 2.0) / m_size;
+                    m_sin[i][j] = sin(arg);
+                    m_cos[i][j] = cos(arg);
+                }
+            }
+
+            m_tmp = allocate_channels<double>(2, m_size);
+        }
+
+        ~DFT() {
+            deallocate_channels(m_tmp, 2);
+            deallocate_channels(m_sin, m_size);
+            deallocate_channels(m_cos, m_size);
+        }
+
+        void forward(const T *BQ_R__ realIn, T *BQ_R__ realOut, T *BQ_R__ imagOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                double re = 0.0, im = 0.0;
+                for (int j = 0; j < m_size; ++j) re += realIn[j] * m_cos[i][j];
+                for (int j = 0; j < m_size; ++j) im -= realIn[j] * m_sin[i][j];
+                realOut[i] = T(re);
+                imagOut[i] = T(im);
+            }
+        }
+
+        void forwardInterleaved(const T *BQ_R__ realIn, T *BQ_R__ complexOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                double re = 0.0, im = 0.0;
+                for (int j = 0; j < m_size; ++j) re += realIn[j] * m_cos[i][j];
+                for (int j = 0; j < m_size; ++j) im -= realIn[j] * m_sin[i][j];
+                complexOut[i*2] = T(re);
+                complexOut[i*2 + 1] = T(im);
+            }
+        }
+
+        void forwardPolar(const T *BQ_R__ realIn, T *BQ_R__ magOut, T *BQ_R__ phaseOut) {
+            forward(realIn, magOut, phaseOut); // temporarily
+            for (int i = 0; i < m_bins; ++i) {
+                T re = magOut[i], im = phaseOut[i];
+                c_magphase(magOut + i, phaseOut + i, re, im);
+            }
+        }
+
+        void forwardMagnitude(const T *BQ_R__ realIn, T *BQ_R__ magOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                double re = 0.0, im = 0.0;
+                for (int j = 0; j < m_size; ++j) re += realIn[j] * m_cos[i][j];
+                for (int j = 0; j < m_size; ++j) im -= realIn[j] * m_sin[i][j];
+                magOut[i] = T(sqrt(re * re + im * im));
+            }
+        }
+
+        void inverse(const T *BQ_R__ realIn, const T *BQ_R__ imagIn, T *BQ_R__ realOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                m_tmp[0][i] = realIn[i];
+                m_tmp[1][i] = imagIn[i];
+            }
+            for (int i = m_bins; i < m_size; ++i) {
+                m_tmp[0][i] = realIn[m_size - i];
+                m_tmp[1][i] = -imagIn[m_size - i];
+            }
+            for (int i = 0; i < m_size; ++i) {
+                double re = 0.0;
+                const double *const cos = m_cos[i];
+                const double *const sin = m_sin[i];
+                for (int j = 0; j < m_size; ++j) re += m_tmp[0][j] * cos[j];
+                for (int j = 0; j < m_size; ++j) re -= m_tmp[1][j] * sin[j];
+                realOut[i] = T(re);
+            }
+        }
+
+        void inverseInterleaved(const T *BQ_R__ complexIn, T *BQ_R__ realOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                m_tmp[0][i] = complexIn[i*2];
+                m_tmp[1][i] = complexIn[i*2+1];
+            }
+            for (int i = m_bins; i < m_size; ++i) {
+                m_tmp[0][i] = complexIn[(m_size - i) * 2];
+                m_tmp[1][i] = -complexIn[(m_size - i) * 2 + 1];
+            }
+            for (int i = 0; i < m_size; ++i) {
+                double re = 0.0;
+                const double *const cos = m_cos[i];
+                const double *const sin = m_sin[i];
+                for (int j = 0; j < m_size; ++j) re += m_tmp[0][j] * cos[j];
+                for (int j = 0; j < m_size; ++j) re -= m_tmp[1][j] * sin[j];
+                realOut[i] = T(re);
+            }
+        }
+
+        void inversePolar(const T *BQ_R__ magIn, const T *BQ_R__ phaseIn, T *BQ_R__ realOut) {
+            T *complexIn = allocate<T>(m_bins * 2);
+            v_polar_to_cartesian_interleaved(complexIn, magIn, phaseIn, m_bins);
+            inverseInterleaved(complexIn, realOut);
+            deallocate(complexIn);
+        }
+
+        void inverseCepstral(const T *BQ_R__ magIn, T *BQ_R__ cepOut) {
+            T *complexIn = allocate_and_zero<T>(m_bins * 2);
+            for (int i = 0; i < m_bins; ++i) {
+                complexIn[i*2] = T(log(magIn[i] + 0.000001));
+            }
+            inverseInterleaved(complexIn, cepOut);
+            deallocate(complexIn);
+        }
+
+    private:
+        const int m_size;
+        const int m_bins;
+        double **m_sin;
+        double **m_cos;
+        double **m_tmp;
+    };
+    
+public:
+    D_DFT(int size) : m_size(size), m_double(0), m_float(0) { }
+
+    ~D_DFT() {
+        delete m_double;
+        delete m_float;
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::DoublePrecision;
+    }
+
+    void initFloat() {
+        if (!m_float) {
+            m_float = new DFT<float>(m_size);
+        }
+    }
+        
+    void initDouble() {
+        if (!m_double) {
+            m_double = new DFT<double>(m_size);
+        }
+    }
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        initDouble();
+        m_double->forward(realIn, realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        initDouble();
+        m_double->forwardInterleaved(realIn, complexOut);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        initDouble();
+        m_double->forwardPolar(realIn, magOut, phaseOut);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        initDouble();
+        m_double->forwardMagnitude(realIn, magOut);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        initFloat();
+        m_float->forward(realIn, realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        initFloat();
+        m_float->forwardInterleaved(realIn, complexOut);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        initFloat();
+        m_float->forwardPolar(realIn, magOut, phaseOut);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        initFloat();
+        m_float->forwardMagnitude(realIn, magOut);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        initDouble();
+        m_double->inverse(realIn, imagIn, realOut);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        initDouble();
+        m_double->inverseInterleaved(complexIn, realOut);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        initDouble();
+        m_double->inversePolar(magIn, phaseIn, realOut);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        initDouble();
+        m_double->inverseCepstral(magIn, cepOut);
+    }
+
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        initFloat();
+        m_float->inverse(realIn, imagIn, realOut);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        initFloat();
+        m_float->inverseInterleaved(complexIn, realOut);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        initFloat();
+        m_float->inversePolar(magIn, phaseIn, realOut);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        initFloat();
+        m_float->inverseCepstral(magIn, cepOut);
+    }
+
+private:
+    int m_size;
+    DFT<double> *m_double;
+    DFT<float> *m_float;
+};
+
+} /* end namespace FFTs */
+
+enum SizeConstraint {
+    SizeConstraintNone           = 0x0,
+    SizeConstraintEven           = 0x1,
+    SizeConstraintPowerOfTwo     = 0x2,
+    SizeConstraintEvenPowerOfTwo = 0x3 // i.e. 0x1 | 0x2. Excludes size 1 obvs
+};
+
+typedef std::map<std::string, SizeConstraint> ImplMap;
+
+static std::string defaultImplementation;
+
+static ImplMap
+getImplementationDetails()
+{
+    ImplMap impls;
+    
+#ifdef HAVE_IPP
+    impls["ipp"] = SizeConstraintEvenPowerOfTwo;
+#endif
+#ifdef HAVE_FFTW3
+    impls["fftw"] = SizeConstraintNone;
+#endif
+#ifdef HAVE_SLEEF
+    impls["sleef"] = SizeConstraintEvenPowerOfTwo;
+#endif
+#ifdef HAVE_KISSFFT
+    impls["kissfft"] = SizeConstraintEven;
+#endif
+#ifdef HAVE_VDSP
+    impls["vdsp"] = SizeConstraintEvenPowerOfTwo;
+#endif
+#ifdef USE_BUILTIN_FFT
+    impls["builtin"] = SizeConstraintEvenPowerOfTwo;
+#endif
+
+    impls["dft"] = SizeConstraintNone;
+
+    return impls;
+}
+
+static std::string
+pickImplementation(int size)
+{
+    ImplMap impls = getImplementationDetails();
+
+    bool isPowerOfTwo = !(size & (size-1));
+    bool isEven = !(size & 1);
+
+    if (defaultImplementation != "") {
+        ImplMap::const_iterator itr = impls.find(defaultImplementation);
+        if (itr != impls.end()) {
+            if (((itr->second & SizeConstraintPowerOfTwo) && !isPowerOfTwo) ||
+                ((itr->second & SizeConstraintEven) && !isEven)) {
+//                std::cerr << "NOTE: bqfft: Explicitly-set default "
+//                          << "implementation \"" << defaultImplementation
+//                          << "\" does not support size " << size
+//                          << ", trying other compiled-in implementations"
+//                          << std::endl;
+            } else {
+                return defaultImplementation;
+            }
+        } else {
+            std::cerr << "WARNING: bqfft: Default implementation \""
+                      << defaultImplementation << "\" is not compiled in"
+                      << std::endl;
+        }
+    } 
+    
+    std::string preference[] = {
+        "ipp", "vdsp", "sleef", "fftw", "builtin", "kissfft"
+    };
+
+    for (int i = 0; i < int(sizeof(preference)/sizeof(preference[0])); ++i) {
+        ImplMap::const_iterator itr = impls.find(preference[i]);
+        if (itr != impls.end()) {
+            if ((itr->second & SizeConstraintPowerOfTwo) &&
+                // out of an abundance of caution we don't attempt to
+                // use power-of-two implementations with size 2
+                // either, as they may involve a half-half
+                // complex-complex underneath (which would end up with
+                // size 0)
+                (!isPowerOfTwo || size < 4)) {
+                continue;
+            }
+            if ((itr->second & SizeConstraintEven) && !isEven) {
+                continue;
+            }
+            return preference[i];
+        }
+    }
+
+    std::cerr << "WARNING: bqfft: No compiled-in implementation supports size "
+              << size << ", falling back to slow DFT" << std::endl;
+    
+    return "dft";
+}
+
+std::set<std::string>
+FFT::getImplementations()
+{
+    ImplMap impls = getImplementationDetails();
+    std::set<std::string> toReturn;
+    for (ImplMap::const_iterator i = impls.begin(); i != impls.end(); ++i) {
+        toReturn.insert(i->first);
+    }
+    return toReturn;
+}
+
+std::string
+FFT::getDefaultImplementation()
+{
+    return defaultImplementation;
+}
+
+void
+FFT::setDefaultImplementation(std::string i)
+{
+    if (i == "") {
+        defaultImplementation = i;
+        return;
+    } 
+    ImplMap impls = getImplementationDetails();
+    ImplMap::const_iterator itr = impls.find(i);
+    if (itr == impls.end()) {
+        std::cerr << "WARNING: bqfft: setDefaultImplementation: "
+                  << "requested implementation \"" << i
+                  << "\" is not compiled in" << std::endl;
+    } else {
+        defaultImplementation = i;
+    }
+}
+
+FFT::FFT(int size, int debugLevel) :
+    d(0)
+{
+    std::string impl = pickImplementation(size);
+
+    if (debugLevel > 0) {
+        std::cerr << "FFT::FFT(" << size << "): using implementation: "
+                  << impl << std::endl;
+    }
+
+    if (impl == "ipp") {
+#ifdef HAVE_IPP
+        d = new FFTs::D_IPP(size);
+#endif
+    } else if (impl == "fftw") {
+#ifdef HAVE_FFTW3
+        d = new FFTs::D_FFTW(size);
+#endif
+    } else if (impl == "sleef") {
+#ifdef HAVE_SLEEF
+        d = new FFTs::D_SLEEF(size);
+#endif
+    } else if (impl == "kissfft") {        
+#ifdef HAVE_KISSFFT
+        d = new FFTs::D_KISSFFT(size);
+#endif
+    } else if (impl == "vdsp") {
+#ifdef HAVE_VDSP
+        d = new FFTs::D_VDSP(size);
+#endif
+    } else if (impl == "builtin") {
+#ifdef USE_BUILTIN_FFT
+        d = new FFTs::D_Builtin(size);
+#endif
+    } else if (impl == "dft") {
+        d = new FFTs::D_DFT(size);
+    }
+
+    if (!d) {
+        std::cerr << "FFT::FFT(" << size << "): ERROR: implementation "
+                  << impl << " is not compiled in" << std::endl;
+#ifndef NO_EXCEPTIONS
+        throw InvalidImplementation;
+#else
+        abort();
+#endif
+    }
+}
+
+FFT::~FFT()
+{
+    delete d;
+}
+
+#ifndef NO_EXCEPTIONS
+#define CHECK_NOT_NULL(x) \
+    if (!(x)) { \
+        std::cerr << "FFT: ERROR: Null argument " #x << std::endl;  \
+        throw NullArgument; \
+    }
+#else
+#define CHECK_NOT_NULL(x) \
+    if (!(x)) { \
+        std::cerr << "FFT: ERROR: Null argument " #x << std::endl;  \
+        std::cerr << "FFT: Would be throwing NullArgument here, if exceptions were not disabled" << std::endl;  \
+        return; \
+    }
+#endif
+
+void
+FFT::forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(realOut);
+    CHECK_NOT_NULL(imagOut);
+    d->forward(realIn, realOut, imagOut);
+}
+
+void
+FFT::forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(complexOut);
+    d->forwardInterleaved(realIn, complexOut);
+}
+
+void
+FFT::forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(magOut);
+    CHECK_NOT_NULL(phaseOut);
+    d->forwardPolar(realIn, magOut, phaseOut);
+}
+
+void
+FFT::forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(magOut);
+    d->forwardMagnitude(realIn, magOut);
+}
+
+void
+FFT::forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(realOut);
+    CHECK_NOT_NULL(imagOut);
+    d->forward(realIn, realOut, imagOut);
+}
+
+void
+FFT::forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(complexOut);
+    d->forwardInterleaved(realIn, complexOut);
+}
+
+void
+FFT::forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(magOut);
+    CHECK_NOT_NULL(phaseOut);
+    d->forwardPolar(realIn, magOut, phaseOut);
+}
+
+void
+FFT::forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(magOut);
+    d->forwardMagnitude(realIn, magOut);
+}
+
+void
+FFT::inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(imagIn);
+    CHECK_NOT_NULL(realOut);
+    d->inverse(realIn, imagIn, realOut);
+}
+
+void
+FFT::inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(complexIn);
+    CHECK_NOT_NULL(realOut);
+    d->inverseInterleaved(complexIn, realOut);
+}
+
+void
+FFT::inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(magIn);
+    CHECK_NOT_NULL(phaseIn);
+    CHECK_NOT_NULL(realOut);
+    d->inversePolar(magIn, phaseIn, realOut);
+}
+
+void
+FFT::inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut)
+{
+    CHECK_NOT_NULL(magIn);
+    CHECK_NOT_NULL(cepOut);
+    d->inverseCepstral(magIn, cepOut);
+}
+
+void
+FFT::inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(imagIn);
+    CHECK_NOT_NULL(realOut);
+    d->inverse(realIn, imagIn, realOut);
+}
+
+void
+FFT::inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(complexIn);
+    CHECK_NOT_NULL(realOut);
+    d->inverseInterleaved(complexIn, realOut);
+}
+
+void
+FFT::inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(magIn);
+    CHECK_NOT_NULL(phaseIn);
+    CHECK_NOT_NULL(realOut);
+    d->inversePolar(magIn, phaseIn, realOut);
+}
+
+void
+FFT::inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut)
+{
+    CHECK_NOT_NULL(magIn);
+    CHECK_NOT_NULL(cepOut);
+    d->inverseCepstral(magIn, cepOut);
+}
+
+void
+FFT::initFloat() 
+{
+    d->initFloat();
+}
+
+void
+FFT::initDouble() 
+{
+    d->initDouble();
+}
+
+int
+FFT::getSize() const
+{
+    return d->getSize();
+}
+
+FFT::Precisions
+FFT::getSupportedPrecisions() const
+{
+    return d->getSupportedPrecisions();
+}
+
+#ifdef FFT_MEASUREMENT
+
+#ifdef FFT_MEASUREMENT_RETURN_RESULT_TEXT
+std::string
+#else
+void
+#endif
+FFT::tune()
+{
+#ifdef FFT_MEASUREMENT_RETURN_RESULT_TEXT
+    std::ostringstream os;
+#else
+#define os std::cerr
+#endif
+    os << "FFT::tune()..." << std::endl;
+
+    std::vector<int> sizes;
+    std::map<std::string, FFTImpl *> candidates;
+    std::map<std::string, int> wins;
+
+    sizes.push_back(512);
+    sizes.push_back(1024);
+    sizes.push_back(2048);
+    sizes.push_back(4096);
+    
+    for (unsigned int si = 0; si < sizes.size(); ++si) {
+
+        int size = sizes[si];
+
+        while (!candidates.empty()) {
+            delete candidates.begin()->second;
+            candidates.erase(candidates.begin());
+        }
+
+        FFTImpl *d;
+        
+#ifdef HAVE_IPP
+        os << "Constructing new IPP FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_IPP(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["ipp"] = d;
+#endif
+        
+#ifdef HAVE_FFTW3
+        os << "Constructing new FFTW3 FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_FFTW(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["fftw"] = d;
+#endif
+
+#ifdef HAVE_SLEEF
+        os << "Constructing new SLEEF FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_SLEEF(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["sleef"] = d;
+#endif
+
+#ifdef HAVE_KISSFFT
+        os << "Constructing new KISSFFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_KISSFFT(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["kissfft"] = d;
+#endif        
+
+#ifdef USE_BUILTIN_FFT
+        os << "Constructing new Builtin FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_Builtin(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["builtin"] = d;
+#endif
+        
+#ifdef HAVE_VDSP
+        os << "Constructing new vDSP FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_VDSP(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["vdsp"] = d;
+#endif
+
+        os << "Constructing new DFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_DFT(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["dft"] = d;
+
+        os << "CLOCKS_PER_SEC = " << CLOCKS_PER_SEC << std::endl;
+        float divisor = float(CLOCKS_PER_SEC) / 1000.f;
+        
+        os << "Timing order is: ";
+        for (std::map<std::string, FFTImpl *>::iterator ci = candidates.begin();
+             ci != candidates.end(); ++ci) {
+            os << ci->first << " ";
+        }
+        os << std::endl;
+
+        int iterations = 500;
+        os << "Iterations: " << iterations << std::endl;
+
+        double *da = new double[size];
+        double *db = new double[size];
+        double *dc = new double[size];
+        double *dd = new double[size];
+        double *di = new double[size + 2];
+        double *dj = new double[size + 2];
+
+        float *fa = new float[size];
+        float *fb = new float[size];
+        float *fc = new float[size];
+        float *fd = new float[size];
+        float *fi = new float[size + 2];
+        float *fj = new float[size + 2];
+
+        for (int type = 0; type < 16; ++type) {
+    
+            //!!!
+            if ((type > 3 && type < 8) ||
+                (type > 11)) {
+                continue;
+            }
+
+            if (type > 7) {
+                // inverse transform: bigger inputs, to simulate the
+                // fact that the forward transform is unscaled
+                for (int i = 0; i < size; ++i) {
+                    da[i] = drand48() * size;
+                    fa[i] = da[i];
+                    db[i] = drand48() * size;
+                    fb[i] = db[i];
+                }
+            } else {    
+                for (int i = 0; i < size; ++i) {
+                    da[i] = drand48();
+                    fa[i] = da[i];
+                    db[i] = drand48();
+                    fb[i] = db[i];
+                }
+            }
+                
+            for (int i = 0; i < size + 2; ++i) {
+                di[i] = drand48();
+                fi[i] = di[i];
+            }
+
+            std::string low;
+            clock_t lowscore = 0;
+
+            const char *names[] = {
+
+                "Forward Cartesian Double",
+                "Forward Interleaved Double",
+                "Forward Polar Double",
+                "Forward Magnitude Double",
+                "Forward Cartesian Float",
+                "Forward Interleaved Float",
+                "Forward Polar Float",
+                "Forward Magnitude Float",
+
+                "Inverse Cartesian Double",
+                "Inverse Interleaved Double",
+                "Inverse Polar Double",
+                "Inverse Cepstral Double",
+                "Inverse Cartesian Float",
+                "Inverse Interleaved Float",
+                "Inverse Polar Float",
+                "Inverse Cepstral Float"
+            };
+            os << names[type] << " :: ";
+
+            for (std::map<std::string, FFTImpl *>::iterator ci = candidates.begin();
+                 ci != candidates.end(); ++ci) {
+
+                FFTImpl *d = ci->second;
+
+                double mean = 0;
+
+                clock_t start = clock();
+                
+                for (int i = 0; i < iterations; ++i) {
+
+                    if (i == 0) {
+                        for (int j = 0; j < size; ++j) {
+                            dc[j] = 0;
+                            dd[j] = 0;
+                            fc[j] = 0;
+                            fd[j] = 0;
+                            fj[j] = 0;
+                            dj[j] = 0;
+                        }
+                    }
+
+                    switch (type) {
+                    case 0: d->forward(da, dc, dd); break;
+                    case 1: d->forwardInterleaved(da, dj); break;
+                    case 2: d->forwardPolar(da, dc, dd); break;
+                    case 3: d->forwardMagnitude(da, dc); break;
+                    case 4: d->forward(fa, fc, fd); break;
+                    case 5: d->forwardInterleaved(fa, fj); break;
+                    case 6: d->forwardPolar(fa, fc, fd); break;
+                    case 7: d->forwardMagnitude(fa, fc); break;
+                    case 8: d->inverse(da, db, dc); break;
+                    case 9: d->inverseInterleaved(di, dc); break;
+                    case 10: d->inversePolar(da, db, dc); break;
+                    case 11: d->inverseCepstral(da, dc); break;
+                    case 12: d->inverse(fa, fb, fc); break;
+                    case 13: d->inverseInterleaved(fi, fc); break;
+                    case 14: d->inversePolar(fa, fb, fc); break;
+                    case 15: d->inverseCepstral(fa, fc); break;
+                    }
+
+                    if (i == 0) {
+                        mean = 0;
+                        for (int j = 0; j < size; ++j) {
+                            mean += dc[j];
+                            mean += dd[j];
+                            mean += fc[j];
+                            mean += fd[j];
+                            mean += fj[j];
+                            mean += dj[j];
+                        }
+                        mean /= size * 6;
+                    }
+                }
+
+                clock_t end = clock();
+
+                os << float(end - start)/divisor << " (" << mean << ") ";
+
+                if (low == "" || (end - start) < lowscore) {
+                    low = ci->first;
+                    lowscore = end - start;
+                }
+            }
+
+            os << std::endl;
+
+            os << "  size " << size << ", type " << type << ": fastest is " << low << " (time " << float(lowscore)/divisor << ")" << std::endl;
+
+            wins[low]++;
+        }
+        
+        delete[] fa;
+        delete[] fb;
+        delete[] fc;
+        delete[] fd;
+        delete[] da;
+        delete[] db;
+        delete[] dc;
+        delete[] dd;
+    }
+
+    while (!candidates.empty()) {
+        delete candidates.begin()->second;
+        candidates.erase(candidates.begin());
+    }
+
+    int bestscore = 0;
+    std::string best;
+
+    for (std::map<std::string, int>::iterator wi = wins.begin(); wi != wins.end(); ++wi) {
+        if (best == "" || wi->second > bestscore) {
+            best = wi->first;
+            bestscore = wi->second;
+        }
+    }
+
+    os << "overall winner is " << best << " with " << bestscore << " wins" << std::endl;
+
+#ifdef FFT_MEASUREMENT_RETURN_RESULT_TEXT
+    return os.str();
+#endif
+}
+
+#endif
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/FFT.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/FFT.h
@@ -1,0 +1,135 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_FFT_H
+#define RUBBERBAND_FFT_H
+
+#include "sysutils.h"
+
+#include <string>
+#include <set>
+
+namespace RubberBand {
+
+class FFTImpl;
+
+/**
+ * Provide the basic FFT computations we need, using one of a set of
+ * candidate FFT implementations (depending on compile flags).
+ *
+ * Implements real->complex FFTs of power-of-two sizes only.  Note
+ * that only the first half of the output signal is returned (the
+ * complex conjugates half is omitted), so the "complex" arrays need
+ * room for size/2+1 elements.
+ *
+ * The "interleaved" functions use the format sometimes called CCS --
+ * size/2+1 real+imaginary pairs.  So, the array elements at indices 1
+ * and size+1 will always be zero (since the signal is real).
+ * 
+ * All pointer arguments must point to valid data. A NullArgument
+ * exception is thrown if any argument is NULL.
+ *
+ * Neither forward nor inverse transform is scaled.
+ *
+ * This class is reentrant but not thread safe: use a separate
+ * instance per thread, or use a mutex.
+ */
+class FFT
+{
+public:
+    enum Exception {
+        NullArgument, InvalidSize, InvalidImplementation, InternalError
+    };
+
+    FFT(int size, int debugLevel = 0); // may throw InvalidSize
+    ~FFT();
+
+    int getSize() const;
+    
+    void forward(const double *R__ realIn, double *R__ realOut, double *R__ imagOut);
+    void forwardInterleaved(const double *R__ realIn, double *R__ complexOut);
+    void forwardPolar(const double *R__ realIn, double *R__ magOut, double *R__ phaseOut);
+    void forwardMagnitude(const double *R__ realIn, double *R__ magOut);
+
+    void forward(const float *R__ realIn, float *R__ realOut, float *R__ imagOut);
+    void forwardInterleaved(const float *R__ realIn, float *R__ complexOut);
+    void forwardPolar(const float *R__ realIn, float *R__ magOut, float *R__ phaseOut);
+    void forwardMagnitude(const float *R__ realIn, float *R__ magOut);
+
+    void inverse(const double *R__ realIn, const double *R__ imagIn, double *R__ realOut);
+    void inverseInterleaved(const double *R__ complexIn, double *R__ realOut);
+    void inversePolar(const double *R__ magIn, const double *R__ phaseIn, double *R__ realOut);
+    void inverseCepstral(const double *R__ magIn, double *R__ cepOut);
+
+    void inverse(const float *R__ realIn, const float *R__ imagIn, float *R__ realOut);
+    void inverseInterleaved(const float *R__ complexIn, float *R__ realOut);
+    void inversePolar(const float *R__ magIn, const float *R__ phaseIn, float *R__ realOut);
+    void inverseCepstral(const float *R__ magIn, float *R__ cepOut);
+
+    // Calling one or both of these is optional -- if neither is
+    // called, the first call to a forward or inverse method will call
+    // init().  You only need call these if you don't want to risk
+    // expensive allocations etc happening in forward or inverse.
+    void initFloat();
+    void initDouble();
+
+    enum Precision {
+        SinglePrecision = 0x1,
+        DoublePrecision = 0x2
+    };
+    typedef int Precisions;
+
+    /**
+     * Return the OR of all precisions supported by this
+     * implementation. All of the functions (float and double) are
+     * available regardless of the supported implementations, but they
+     * will be calculated at the proper precision only if it is
+     * available. (So float functions will be calculated using doubles
+     * and then truncated if single-precision is unavailable, and
+     * double functions will use single-precision arithmetic if double
+     * is unavailable.)
+     */
+    Precisions getSupportedPrecisions() const;
+
+    static std::set<std::string> getImplementations();
+    static std::string getDefaultImplementation();
+    static void setDefaultImplementation(std::string);
+
+#ifdef FFT_MEASUREMENT
+    static std::string tune();
+#endif
+
+protected:
+    FFTImpl *d;
+    static std::string m_implementation;
+    static void pickDefaultImplementation();
+    
+private:
+    FFT(const FFT &); // not provided
+    FFT &operator=(const FFT &); // not provided
+};
+
+}
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/FixedVector.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/FixedVector.h
@@ -1,0 +1,48 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_FIXED_VECTOR_H
+#define RUBBERBAND_FIXED_VECTOR_H
+
+#include "Allocators.h"
+#include <vector>
+
+namespace RubberBand
+{
+
+template <typename T>
+class FixedVector : public std::vector<T, StlAllocator<T>>
+{
+public:
+    using std::vector<T, StlAllocator<T>>::vector;
+    
+private:
+    FixedVector(const FixedVector &) =delete;
+    FixedVector(FixedVector &&) =delete;
+    FixedVector &operator=(const FixedVector &) =delete;
+    FixedVector &operator=(FixedVector &&) =delete;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/HistogramFilter.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/HistogramFilter.h
@@ -1,0 +1,194 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_HISTOGRAM_FILTER_H
+#define RUBBERBAND_HISTOGRAM_FILTER_H
+
+#include "SingleThreadRingBuffer.h"
+
+#include <vector>
+#include <iostream>
+
+namespace RubberBand {
+
+/**
+ * A median or modal filter implemented using a histogram. The values
+ * must come from a compact set of integers within [0,n) where n is
+ * specified in the constructor. Pushing a value updates the
+ * histogram, after which you can get either the median or the mode.
+ * You can call drop() to drop the oldest value without pushing a new
+ * one, for example to drain the filter at the tail of the sequence.
+ */
+class HistogramFilter
+{
+public:
+    HistogramFilter(int nValues, int filterLength) :
+        m_buffer(filterLength),
+        m_histogram(nValues, 0),
+        m_mode(-1) { }
+    ~HistogramFilter() { }
+
+    int getFilterLength() const {
+        return m_buffer.getSize();
+    }
+
+    int getNValues() const {
+        return int(m_histogram.size());
+    }
+    
+    void reset() {
+        m_buffer.reset();
+        for (int i = 0; i < getNValues(); ++i) {
+            m_histogram[i] = 0;
+        }
+    }
+    
+    void push(int value) {
+        if (m_buffer.getWriteSpace() == 0) {
+            int toDrop = m_buffer.readOne();
+            --m_histogram[toDrop];
+        }
+        m_buffer.writeOne(value);
+        int height = ++m_histogram[value];
+        if (m_mode >= 0 && height >= m_histogram[m_mode]) {
+            if (height > m_histogram[m_mode] || value < m_mode) {
+                m_mode = value;
+            }
+        }
+    }
+
+    void drop() {
+        if (m_buffer.getReadSpace() > 0) {
+            int toDrop = m_buffer.readOne();
+            --m_histogram[toDrop];
+            if (toDrop == m_mode) {
+                m_mode = -1;
+            }
+        }
+    }
+
+    /** Return the median of the values in the filter currently. If
+     *  the median lies between two values, return the first of them.
+     */
+    int getMedian() const {
+        int half = (m_buffer.getReadSpace() + 1) / 2;
+        int acc = 0;
+        int nvalues = getNValues();
+        for (int i = 0; i < nvalues; ++i) {
+            acc += m_histogram[i];
+            if (acc >= half) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    /** Return the modal value, that is, the value that occurs the
+     *  most often in the filter currently. If multiple values occur
+     *  an equal number of times, return the smallest of them.
+     */
+    int getMode() const {
+        if (m_mode >= 0) {
+            return m_mode;
+        }
+        int max = 0;
+        int mode = 0;
+        int nvalues = getNValues();
+        for (int i = 0; i < nvalues; ++i) {
+            int h = m_histogram[i];
+            if (i == 0 || h > max) {
+                max = h;
+                mode = i;
+            }
+        }
+        m_mode = mode;
+        return mode;
+    }
+
+    // Convenience function that filters an array in-place. Filter is
+    // a median filter unless modal is true. Array has length n.
+    // Modifies both the filter and the array.
+    //
+    static void filter(HistogramFilter &f, int *v, int n, bool modal = false) {
+        f.reset();
+        int flen = f.getFilterLength();
+        int i = -(flen / 2);
+        int j = 0;
+        while (i != n) {
+            if (j < n) {
+                f.push(v[j]);
+            } else if (j >= flen) {
+                f.drop();
+            }
+            if (i >= 0) {
+                int m = modal ? f.getMode() : f.getMedian();
+                v[i] = m;
+            }
+            ++i;
+            ++j;
+        }
+    }
+
+    // As above but with a vector argument
+    //
+    static void filter(HistogramFilter &f, std::vector<int> &v, bool modal = false) {
+        filter(f, v.data(), v.size(), modal);
+    }
+
+    // Convenience function that median-filters an array
+    // in-place. Array has length n. Modifies both the filter and the
+    // array.
+    //
+    static void medianFilter(HistogramFilter &f, int *v, int n) {
+        filter(f, v, n, false);
+    }
+
+    // As above but with a vector argument
+    //
+    static void medianFilter(HistogramFilter &f, std::vector<int> &v) {
+        medianFilter(f, v.data(), v.size());
+    }
+
+    // Convenience function that modal-filters an array
+    // in-place. Array has length n. Modifies both the filter and the
+    // array.
+    //
+    static void modalFilter(HistogramFilter &f, int *v, int n) {
+        filter(f, v, n, true);
+    }
+
+    // As above but with a vector argument
+    //
+    static void modalFilter(HistogramFilter &f, std::vector<int> &v) {
+        modalFilter(f, v.data(), v.size());
+    }
+    
+private:
+    SingleThreadRingBuffer<int> m_buffer;
+    std::vector<int> m_histogram;
+    mutable int m_mode;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Log.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Log.cpp
@@ -1,0 +1,31 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "Log.h"
+
+namespace RubberBand
+{
+
+int Log::m_defaultDebugLevel = 0;
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Log.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Log.h
@@ -1,0 +1,72 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_LOG_H
+#define RUBBERBAND_LOG_H
+
+#include <functional>
+#include <iostream>
+
+namespace RubberBand {
+
+class Log {
+public:
+    Log(std::function<void(const char *)> _log0,
+        std::function<void(const char *, double)> _log1,
+        std::function<void(const char *, double, double)> _log2) :
+        m_log0(_log0),
+        m_log1(_log1),
+        m_log2(_log2),
+        m_debugLevel(m_defaultDebugLevel) { }
+
+    Log(const Log &other) =default;
+    Log(Log &&other) =default;
+    Log &operator=(const Log &other) =default;
+    Log &operator=(Log &&other) =default;
+
+    void setDebugLevel(int level) { m_debugLevel = level; }
+    int getDebugLevel() const { return m_debugLevel; }
+
+    static void setDefaultDebugLevel(int level) { m_defaultDebugLevel = level; }
+    
+    void log(int level, const char *message) const {
+        if (level <= m_debugLevel) m_log0(message);
+    }
+    void log(int level, const char *message, double arg0) const {
+        if (level <= m_debugLevel) m_log1(message, arg0);
+    }
+    void log(int level, const char *message, double arg0, double arg1) const {
+        if (level <= m_debugLevel) m_log2(message, arg0, arg1);
+    }
+
+private:
+    std::function<void(const char *)> m_log0;
+    std::function<void(const char *, double)> m_log1;
+    std::function<void(const char *, double, double)> m_log2;
+    int m_debugLevel;
+    static int m_defaultDebugLevel;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/MovingMedian.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/MovingMedian.h
@@ -1,0 +1,256 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_MOVING_MEDIAN_H
+#define RUBBERBAND_MOVING_MEDIAN_H
+
+#include "SampleFilter.h"
+#include "FixedVector.h"
+#include "Allocators.h"
+#include "SingleThreadRingBuffer.h"
+
+#include <algorithm>
+#include <iostream>
+
+namespace RubberBand
+{
+
+/**
+ * A median or modal filter implemented using sorting, for continuous
+ * values. Pushing a value updates the sorted record, after which you
+ * can get() the median.  You can call drop() to drop the oldest value
+ * without pushing a new one, for example to drain the filter at the
+ * tail of the sequence.
+ */
+template <typename T>
+class MovingMedian : public SampleFilter<T>
+{
+    static constexpr float fifty = 50.f;
+    
+public:
+    MovingMedian(int filterLength, float percentile = fifty) :
+        m_buffer(filterLength),
+        m_sortspace(filterLength, {}),
+        m_fill(0),
+        m_percentile(percentile)
+    { }
+
+    ~MovingMedian() { }
+
+    MovingMedian(const MovingMedian &) =default;
+    MovingMedian &operator=(const MovingMedian &) =default;
+
+    int getSize() const {
+        return m_buffer.getSize();
+    }
+
+    void setPercentile(float p) {
+        m_percentile = p;
+    }
+    
+    void push(T value) {
+        if (value != value) {
+            std::cerr << "WARNING: MovingMedian: NaN encountered" << std::endl;
+            value = T();
+        }
+        if (m_fill == getSize()) {
+            T toDrop = m_buffer.readOne();
+            dropAndPut(toDrop, value);
+        } else {
+            put(value);
+        }
+        m_buffer.writeOne(value);
+    }
+
+    void drop() {
+        if (m_fill > 0) {
+            T toDrop = m_buffer.readOne();
+            drop(toDrop);
+        }
+    }
+    
+    /** Return the median of the values in the filter currently. If
+     *  the median lies between two values, return the first of them.
+     */
+    T get() const {
+        int n = m_fill - 1;
+        if (m_percentile == fifty) { // exact default value
+            return m_sortspace[n / 2];
+        } else {
+            int index = int(floorf(float(n) * m_percentile / 100.f));
+            if (index >= m_fill) index = m_fill - 1;
+            return m_sortspace[index];
+        }
+    }
+
+    void reset() {
+        m_buffer.reset();
+	v_zero(m_sortspace.data(), m_sortspace.size());
+        m_fill = 0;
+    }
+
+    // Convenience function that applies a given filter to an array
+    // in-place. Array has length n. Modifies both the filter and the
+    // array.
+    //
+    static void filter(MovingMedian<T> &f, T *v, int n) {
+        f.reset();
+        int flen = f.getSize();
+        int i = -(flen / 2);
+        int j = 0;
+        while (i != n) {
+            if (j < n) {
+                f.push(v[j]);
+            } else if (j >= flen) {
+                f.drop();
+            }
+            if (i >= 0) {
+                v[i] = f.get();
+            }
+            ++i;
+            ++j;
+        }
+    }
+
+    // As above but with a vector argument
+    //
+    static void filter(MovingMedian<T> &mm, std::vector<T> &v) {
+        filter(mm, v.data(), v.size());
+    }
+    
+private:
+    SingleThreadRingBuffer<T> m_buffer;
+    std::vector<T> m_sortspace;
+    int m_fill;
+    float m_percentile;
+
+    void dropAndPut(const T &toDrop, const T &toPut) {
+	// precondition: sorted contains getSize values, one of which is toDrop
+	// postcondition: sorted contains getSize values, one of which is toPut
+        // (and one instance of toDrop has been removed)
+
+        // This implementation was timed for rather short filters (no
+        // longer than maybe 16 items). Two binary searches plus a
+        // memmove should be faster for longer ones.
+        
+        const int n = m_fill;
+        T *sorted = m_sortspace.data();
+        int dropIx;
+        if (toDrop <= *sorted) {
+            // this is quite a common short-circuit in situations
+            // where many values can be (the equivalent of) 0
+            dropIx = 0;
+        } else {
+            dropIx = std::lower_bound(sorted, sorted + n, toDrop) - sorted;
+        }
+        if (toPut > toDrop) {
+            int i = dropIx;
+            while (i+1 < n) {
+                if (sorted[i+1] > toPut) {
+                    break;
+                }
+                sorted[i] = sorted[i+1];
+                ++i;
+            }
+            sorted[i] = toPut;
+        } else if (toPut < toDrop) {
+            int i = dropIx;
+            while (true) {
+                if (--i < 0 || sorted[i] < toPut) {
+                    break;
+                }
+                sorted[i+1] = sorted[i];
+            }
+            sorted[i+1] = toPut;
+        }
+    }
+
+    void put(const T &toPut) {
+	// precondition: sorted contains m_fill values, m_fill < m_length,
+	// packed at the start
+	// postcondition: m_fill is incremented, sorted contains m_fill values,
+        // packed at the start, one of which is toPut
+        int n = m_fill;
+        T *sorted = m_sortspace.data();
+        int putIx = std::lower_bound(sorted, sorted + n, toPut) - sorted;
+        if (putIx < n) {
+            v_move(sorted + putIx + 1, sorted + putIx, n - putIx);
+        }
+        sorted[putIx] = toPut;
+        ++m_fill;
+    }
+
+    void drop(const T &toDrop) {
+	// precondition: sorted contains m_fill values, m_fill > 0, <= m_length,
+	// packed at the start, one of which is toDrop
+	// postcondition: m_fill decremented, sorted contains m_fill values,
+        // packed at the start, none of which is toDrop
+        int n = m_fill;
+        T *sorted = m_sortspace.data();
+        int dropIx = std::lower_bound(sorted, sorted + n, toDrop) - sorted;
+        if (dropIx < n - 1) {
+            v_move(sorted + dropIx, sorted + dropIx + 1, n - dropIx - 1);
+        }
+        --m_fill;
+    }
+
+};
+
+template <typename T>
+class MovingMedianStack
+{
+public:
+    MovingMedianStack(int nfilters, int size) :
+        m_stack(nfilters, { size })
+    {
+    }
+
+    ~MovingMedianStack() {
+    }
+
+    int getSize() const {
+        return m_stack[0].getSize();
+    }
+
+    void push(int filter, T value) {
+        m_stack[filter].push(value);
+    }
+
+    T get(int filter) const {
+        return m_stack[filter].get();
+    }
+
+    void reset() {
+        for (auto &f: m_stack) {
+            f.reset();
+        }
+    }
+    
+private:
+    std::vector<MovingMedian<T>> m_stack;
+};
+
+}
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Profiler.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Profiler.cpp
@@ -1,0 +1,221 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "Profiler.h"
+
+#include "Thread.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <map>
+
+#include <stdio.h>
+
+#ifdef _MSC_VER
+// Ugh --cc
+#define snprintf sprintf_s
+#endif
+
+namespace RubberBand {
+
+#ifndef NO_TIMING
+
+Profiler::ProfileMap
+Profiler::m_profiles;
+
+Profiler::WorstCallMap
+Profiler::m_worstCalls;
+
+static Mutex profileMutex;
+
+void
+Profiler::add(const char *id, double us)
+{
+    profileMutex.lock();
+    
+    ProfileMap::iterator pmi = m_profiles.find(id);
+    if (pmi != m_profiles.end()) {
+        ++pmi->second.first;
+        pmi->second.second += us;
+    } else {
+        m_profiles[id] = TimePair(1, us);
+    }
+
+    WorstCallMap::iterator wci = m_worstCalls.find(id);
+    if (wci != m_worstCalls.end()) {
+        if (us > wci->second) wci->second = us;
+    } else {
+        m_worstCalls[id] = us;
+    }
+
+    profileMutex.unlock();
+}
+
+void
+Profiler::dump()
+{
+    std::string report = getReport();
+    fprintf(stderr, "%s", report.c_str());
+}
+
+std::string
+Profiler::getReport()
+{
+    profileMutex.lock();
+    
+    static const int buflen = 256;
+    char buffer[buflen];
+    std::string report;
+
+#ifdef PROFILE_CLOCKS
+    snprintf(buffer, buflen, "Profiling points [CPU time]:\n");
+#else
+    snprintf(buffer, buflen, "Profiling points [Wall time]:\n");
+#endif
+    report += buffer;
+
+    typedef std::multimap<double, const char *> TimeRMap;
+    typedef std::multimap<int, const char *> IntRMap;
+    TimeRMap totmap, avgmap, worstmap;
+    IntRMap ncallmap;
+
+    const unsigned char mu_s[] = { 0xce, 0xbc, 's', 0x0 };
+    
+    for (ProfileMap::const_iterator i = m_profiles.begin();
+         i != m_profiles.end(); ++i) {
+        totmap.insert(TimeRMap::value_type(i->second.second, i->first));
+        avgmap.insert(TimeRMap::value_type(i->second.second /
+                                           i->second.first, i->first));
+        ncallmap.insert(IntRMap::value_type(i->second.first, i->first));
+    }
+
+    for (WorstCallMap::const_iterator i = m_worstCalls.begin();
+         i != m_worstCalls.end(); ++i) {
+        worstmap.insert(TimeRMap::value_type(i->second, i->first));
+    }
+
+    snprintf(buffer, buflen, "\nBy name:\n");
+    report += buffer;
+
+    typedef std::set<const char *, std::less<std::string> > StringSet;
+
+    StringSet profileNames;
+    for (ProfileMap::const_iterator i = m_profiles.begin();
+         i != m_profiles.end(); ++i) {
+        profileNames.insert(i->first);
+    }
+
+    for (StringSet::const_iterator i = profileNames.begin();
+         i != profileNames.end(); ++i) {
+
+        ProfileMap::const_iterator j = m_profiles.find(*i);
+        if (j == m_profiles.end()) continue;
+
+        const TimePair &pp(j->second);
+        snprintf(buffer, buflen, "%s(%d):\n", *i, pp.first);
+        report += buffer;
+        snprintf(buffer, buflen, "\tReal: \t%12f %s      \t[%f %s total]\n",
+                 (pp.second / pp.first), mu_s,
+                 (pp.second), mu_s);
+        report += buffer;
+
+        WorstCallMap::const_iterator k = m_worstCalls.find(*i);
+        if (k == m_worstCalls.end()) continue;
+        
+        snprintf(buffer, buflen, "\tWorst:\t%14f %s/call\n", k->second, mu_s);
+        report += buffer;
+    }
+
+    snprintf(buffer, buflen, "\nBy total:\n");
+    report += buffer;
+    for (TimeRMap::const_iterator i = totmap.end(); i != totmap.begin(); ) {
+        --i;
+        snprintf(buffer, buflen, "%-40s  %14f %s\n", i->second, i->first, mu_s);
+        report += buffer;
+    }
+
+    snprintf(buffer, buflen, "\nBy average:\n");
+    report += buffer;
+    for (TimeRMap::const_iterator i = avgmap.end(); i != avgmap.begin(); ) {
+        --i;
+        snprintf(buffer, buflen, "%-40s  %14f %s\n", i->second, i->first, mu_s);
+        report += buffer;
+    }
+
+    snprintf(buffer, buflen, "\nBy worst case:\n");
+    report += buffer;
+    for (TimeRMap::const_iterator i = worstmap.end(); i != worstmap.begin(); ) {
+        --i;
+        snprintf(buffer, buflen, "%-40s  %14f %s\n", i->second, i->first, mu_s);
+        report += buffer;
+    }
+
+    snprintf(buffer, buflen, "\nBy number of calls:\n");
+    report += buffer;
+    for (IntRMap::const_iterator i = ncallmap.end(); i != ncallmap.begin(); ) {
+        --i;
+        snprintf(buffer, buflen, "%-40s  %14d\n", i->second, i->first);
+        report += buffer;
+    }
+
+    profileMutex.unlock();
+    
+    return report;
+}
+
+Profiler::Profiler(const char* c) :
+    m_c(c),
+    m_ended(false)
+{
+    m_start = std::chrono::steady_clock::now();
+}
+
+Profiler::~Profiler()
+{
+    if (!m_ended) end();
+}
+
+void
+Profiler::end()
+{
+    auto finish = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::micro> us = finish - m_start;
+    add(m_c, us.count());
+    m_ended = true;
+}
+ 
+#else /* NO_TIMING */
+
+#ifndef NO_TIMING_COMPLETE_NOOP
+
+Profiler::Profiler(const char *) { }
+Profiler::~Profiler() { }
+void Profiler::end() { }
+void Profiler::dump() { }
+
+#endif
+
+#endif
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Profiler.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Profiler.h
@@ -1,0 +1,119 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_PROFILER_H
+#define RUBBERBAND_PROFILER_H
+
+//#define NO_TIMING 1
+//#define WANT_TIMING 1
+//#define PROFILE_CLOCKS 1
+
+// Define NO_TIMING or NDEBUG to switch off profilers
+#ifdef NDEBUG
+#define NO_TIMING 1
+#endif
+
+// But we always allow WANT_TIMING to switch them back on again
+#ifdef WANT_TIMING
+#undef NO_TIMING
+#endif
+
+#ifndef NO_TIMING
+#include <chrono>
+#endif
+
+#ifndef NO_TIMING
+#include <map>
+#include <string>
+#endif
+
+namespace RubberBand {
+
+#ifndef NO_TIMING
+
+class Profiler
+{
+public:
+    Profiler(const char *name);
+    ~Profiler();
+
+    void end(); // same action as dtor
+
+    static void dump();
+
+    // Unlike the other functions, this is only defined if NO_TIMING
+    // is not set (because it uses std::string which is otherwise
+    // unused here). So, treat this as a tricksy internal function
+    // rather than an API call and guard any call to it appropriately.
+    static std::string getReport();
+
+protected:
+    const char *const m_c;
+    std::chrono::time_point<std::chrono::steady_clock> m_start;
+    bool m_showOnDestruct;
+    bool m_ended;
+
+    typedef std::pair<int, double> TimePair;
+    typedef std::map<const char *, TimePair> ProfileMap;
+    typedef std::map<const char *, double> WorstCallMap;
+    static ProfileMap m_profiles;
+    static WorstCallMap m_worstCalls;
+    static void add(const char *, double);
+};
+
+#else
+
+#ifdef NO_TIMING_COMPLETE_NOOP
+
+// Fastest for release builds, but annoying because it can't be linked
+// with code built in debug mode (expecting non-inline functions), so
+// not preferred during development
+
+class Profiler
+{
+public:
+    Profiler(const char *) { }
+    ~Profiler() { }
+
+    void end() { }
+    static void dump() { }
+};
+
+#else
+
+class Profiler
+{
+public:
+    Profiler(const char *);
+    ~Profiler();
+
+    void end();
+    static void dump();
+};
+
+#endif
+#endif
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Resampler.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Resampler.cpp
@@ -1,0 +1,1396 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "Resampler.h"
+
+#include "Allocators.h"
+#include "VectorOps.h"
+
+#include "mathmisc.h"
+
+#include <cstdlib>
+#include <cmath>
+
+#include <iostream>
+#include <algorithm>
+
+#ifdef HAVE_IPP
+#include <ippversion.h>
+#if (IPP_VERSION_MAJOR < 7)
+#error Unsupported IPP version, must be >= 7
+#else
+#include <ipps.h>
+#endif
+#endif
+
+#ifdef HAVE_SAMPLERATE
+#define HAVE_LIBSAMPLERATE 1
+#endif
+
+#ifdef HAVE_LIBSAMPLERATE
+#include <samplerate.h>
+#endif
+
+#ifdef USE_SPEEX
+#include "../ext/speex/speex_resampler.h"
+#else
+#ifdef HAVE_LIBSPEEXDSP
+#include <speex/speex_resampler.h>
+#endif
+#endif
+
+#ifdef USE_BQRESAMPLER
+#include "BQResampler.h"
+#endif
+
+#ifndef HAVE_IPP
+#ifndef HAVE_LIBSAMPLERATE
+#ifndef HAVE_LIBSPEEXDSP
+#ifndef USE_SPEEX
+#ifndef USE_BQRESAMPLER
+#error No resampler implementation selected!
+#endif
+#endif
+#endif
+#endif
+#endif
+
+#define BQ_R__ R__
+
+using std::cerr;
+using std::endl;
+
+namespace RubberBand {
+
+class Resampler::Impl
+{
+public:
+    virtual ~Impl() { }
+    
+    virtual int resample(float *const BQ_R__ *const BQ_R__ out,
+                         int outcount,
+                         const float *const BQ_R__ *const BQ_R__ in, 
+                         int incount,
+                         double ratio,
+                         bool final) = 0;
+    
+    virtual int resampleInterleaved(float *const BQ_R__ out,
+                                    int outcount,
+                                    const float *const BQ_R__ in, 
+                                    int incount,
+                                    double ratio,
+                                    bool final) = 0;
+
+    virtual int getChannelCount() const = 0;
+    virtual double getEffectiveRatio(double ratio) const = 0;
+
+    virtual void reset() = 0;
+};
+
+namespace Resamplers {
+
+#ifdef HAVE_IPP
+
+class D_IPP : public Resampler::Impl
+{
+public:
+    D_IPP(Resampler::Quality quality, Resampler::RatioChange,
+          int channels, double initialSampleRate,
+          int maxBufferSize, int debugLevel);
+    ~D_IPP();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    int getChannelCount() const { return m_channels; }
+    double getEffectiveRatio(double ratio) const { return ratio; }
+
+    void reset();
+
+protected:
+    // to m_outbuf
+    int doResample(int outcount, double ratio, bool final);
+    
+    IppsResamplingPolyphase_32f **m_state;
+    double m_initialSampleRate;
+    float **m_inbuf;
+    size_t m_inbufsz;
+    float **m_outbuf;
+    size_t m_outbufsz;
+    int m_bufsize;
+    int m_channels;
+    int m_window;
+    float m_factor;
+    int m_history;
+    int *m_lastread;
+    double *m_time;
+    int m_debugLevel;
+    
+    void setBufSize(int);
+};
+
+D_IPP::D_IPP(Resampler::Quality /* quality */,
+             Resampler::RatioChange /* ratioChange */,
+             int channels, double initialSampleRate,
+             int maxBufferSize, int debugLevel) :
+    m_state(0),
+    m_initialSampleRate(initialSampleRate),
+    m_channels(channels),
+    m_debugLevel(debugLevel)
+{
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: IPP" << endl;
+    }
+
+    m_window = 32;
+    int nStep = 64;
+    IppHintAlgorithm hint = ippAlgHintFast;
+    m_factor = 8; // initial upper bound on m_ratio, may be amended later
+
+    // This is largely based on the IPP docs and examples. Adapted
+    // from the docs:
+    //
+    //    m_time defines the time value for which the first output
+    //    sample is calculated. The input vector with indices less
+    //    than m_time [whose initial value is m_history below]
+    //    contains the history data of filters.
+    //
+    //    The history length is [(1/2) window * max(1, 1/factor) ]+1
+    //    where window is the size of the ideal lowpass filter
+    //    window. The input vector must contain the same number of
+    //    elements with indices greater than m_time + length for the
+    //    right filter wing for the last element.
+    
+    m_history = int(m_window * 0.5 * std::max(1.0, 1.0 / m_factor)) + 1;
+
+    m_state = new IppsResamplingPolyphase_32f *[m_channels];
+
+    m_lastread = new int[m_channels];
+    m_time = new double[m_channels];
+
+    m_inbufsz = 0;
+    m_outbufsz = 0;
+    m_inbuf = 0;
+    m_outbuf = 0;
+    m_bufsize = 0;
+    
+    setBufSize(maxBufferSize + m_history);
+
+    if (m_debugLevel > 1) {
+        cerr << "bufsize = " << m_bufsize << ", window = " << m_window << ", nStep = " << nStep << ", history = " << m_history << endl;
+    }
+
+    int specSize = 0;
+    ippsResamplePolyphaseGetSize_32f(float(m_window),
+                                     nStep,
+                                     &specSize,
+                                     hint);
+    if (specSize == 0) {
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#else        
+        abort();
+#endif
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        m_state[c] = (IppsResamplingPolyphase_32f *)ippsMalloc_8u(specSize);
+        ippsResamplePolyphaseInit_32f(float(m_window),
+                                      nStep,
+                                      0.95f,
+                                      9.0f,
+                                      m_state[c],
+                                      hint);
+        
+        m_lastread[c] = m_history;
+        m_time[c] = m_history;
+    }
+
+    if (m_debugLevel > 1) {
+        cerr << "Resampler init done" << endl;
+    }
+}
+
+D_IPP::~D_IPP()
+{
+    for (int c = 0; c < m_channels; ++c) {
+        ippsFree(m_state[c]);
+    }
+
+    deallocate_channels(m_inbuf, m_channels);
+    deallocate_channels(m_outbuf, m_channels);
+
+    delete[] m_lastread;
+    delete[] m_time;
+    delete[] m_state;
+}
+
+void
+D_IPP::setBufSize(int sz)
+{
+    if (m_debugLevel > 1) {
+        if (m_bufsize > 0) {
+            cerr << "resize bufsize " << m_bufsize << " -> ";
+        } else {
+            cerr << "initialise bufsize to ";
+        }
+    }
+
+    m_bufsize = sz;
+
+    if (m_debugLevel > 1) {
+        cerr << m_bufsize << endl;
+    }
+
+    int n1 = m_bufsize + m_history + 2;
+
+    if (m_debugLevel > 1) {
+        cerr << "inbuf allocating " << m_bufsize << " + " << m_history << " + 2 = " << n1 << endl;
+    }
+
+    int n2 = (int)lrintf(ceil((m_bufsize - m_history) * m_factor + 2));
+
+    if (m_debugLevel > 1) {
+        cerr << "outbuf allocating (" << m_bufsize << " - " << m_history << ") * " << m_factor << " + 2 = " << n2 << endl;
+    }
+
+    m_inbuf = reallocate_and_zero_extend_channels
+        (m_inbuf, m_channels, m_inbufsz, m_channels, n1);
+
+    m_outbuf = reallocate_and_zero_extend_channels
+        (m_outbuf, m_channels, m_outbufsz, m_channels, n2);
+            
+    m_inbufsz = n1;
+    m_outbufsz = n2;
+}
+
+int
+D_IPP::resample(float *const BQ_R__ *const BQ_R__ out,
+                int outspace,
+                const float *const BQ_R__ *const BQ_R__ in,
+                int incount,
+                double ratio,
+                bool final)
+{
+    if (ratio > m_factor) {
+        m_factor = ratio;
+        m_history = int(m_window * 0.5 * std::max(1.0, 1.0 / m_factor)) + 1;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "incount = " << incount << ", ratio = " << ratio << ", est space = " << lrintf(ceil(incount * ratio)) << ", outspace = " << outspace << ", final = " << final << endl;
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        if (m_lastread[c] + incount + m_history > m_bufsize) {
+            setBufSize(m_lastread[c] + incount + m_history);
+        }
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        for (int i = 0; i < incount; ++i) {
+            m_inbuf[c][m_lastread[c] + i] = in[c][i];
+        }
+        m_lastread[c] += incount;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "lastread advanced to " << m_lastread[0] << endl;
+    }
+
+    int got = doResample(outspace, ratio, final);
+
+    for (int c = 0; c < m_channels; ++c) {
+        v_copy(out[c], m_outbuf[c], got);
+    }
+
+    return got;
+}
+
+int
+D_IPP::resampleInterleaved(float *const BQ_R__ out,
+                           int outspace,
+                           const float *const BQ_R__ in,
+                           int incount,
+                           double ratio,
+                           bool final)
+{
+    if (ratio > m_factor) {
+        m_factor = ratio;
+        m_history = int(m_window * 0.5 * std::max(1.0, 1.0 / m_factor)) + 1;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "incount = " << incount << ", ratio = " << ratio << ", est space = " << lrintf(ceil(incount * ratio)) << ", outspace = " << outspace << ", final = " << final << endl;
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        if (m_lastread[c] + incount + m_history > m_bufsize) {
+            setBufSize(m_lastread[c] + incount + m_history);
+        }
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        for (int i = 0; i < incount; ++i) {
+            m_inbuf[c][m_lastread[c] + i] = in[i * m_channels + c];
+        }
+        m_lastread[c] += incount;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "lastread advanced to " << m_lastread[0] << " after injection of "
+             << incount << " samples" << endl;
+    }
+
+    int got = doResample(outspace, ratio, final);
+
+    v_interleave(out, m_outbuf, m_channels, got);
+
+    return got;
+}
+
+int
+D_IPP::doResample(int outspace, double ratio, bool final)
+{
+    int outcount = 0;
+    
+    for (int c = 0; c < m_channels; ++c) {
+
+        int n = m_lastread[c] - m_history - int(m_time[c]);
+
+        if (c == 0 && m_debugLevel > 2) {
+            cerr << "at start, lastread = " << m_lastread[c] << ", history = "
+                 << m_history << ", time = " << m_time[c] << ", therefore n = "
+                 << n << endl;
+        }
+
+        if (n <= 0) {
+            if (c == 0 && m_debugLevel > 1) {
+                cerr << "not enough input samples to do anything" << endl;
+            }
+            continue;
+        }
+        
+        if (c == 0 && m_debugLevel > 2) {
+            cerr << "before resample call, time = " << m_time[c] << endl;
+        }
+
+        // We're committed to not overrunning outspace, so we need to
+        // offer the resampler only enough samples to ensure it won't
+
+        int limit = int(floor(outspace / ratio));
+        if (n > limit) {
+            if (c == 0 && m_debugLevel > 1) {
+                cerr << "trimming input samples from " << n << " to " << limit
+                     << " to avoid overrunning " << outspace << " at output"
+                     << endl;
+            }
+            n = limit;
+        }
+        
+        ippsResamplePolyphase_32f(m_inbuf[c],
+                                  n,
+                                  m_outbuf[c],
+                                  ratio,
+                                  1.0f,
+                                  &m_time[c],
+                                  &outcount,
+                                  m_state[c]);
+
+        int t = int(floor(m_time[c]));
+        
+        int moveFrom = t - m_history;
+        
+        if (c == 0 && m_debugLevel > 2) {
+            cerr << "converted " << n << " samples to " << outcount
+                 << " (nb outbufsz = " << m_outbufsz
+                 << "), time advanced to " << m_time[c] << endl;
+            cerr << "rounding time to " << t << ", lastread = "
+                 << m_lastread[c] << ", history = " << m_history << endl;
+            cerr << "will move " << m_lastread[c] - moveFrom
+                 << " unconverted samples back from index " << moveFrom
+                 << " to 0" << endl;
+        }
+
+        if (moveFrom >= m_lastread[c]) {
+
+            moveFrom = m_lastread[c];
+
+            if (c == 0 && m_debugLevel > 2) {
+                cerr << "number of samples to move is <= 0, "
+                     << "not actually moving any" << endl;
+            }
+        } else {
+        
+            v_move(m_inbuf[c],
+                   m_inbuf[c] + moveFrom,
+                   m_lastread[c] - moveFrom);
+        }
+
+        m_lastread[c] -= moveFrom;
+        m_time[c] -= moveFrom;
+
+        if (c == 0 && m_debugLevel > 2) {
+            cerr << "lastread reduced to " << m_lastread[c]
+                 << ", time reduced to " << m_time[c]
+                 << endl;
+        }
+        
+        if (final && n < limit) {
+
+            // Looks like this actually produces too many samples
+            // (additionalcount is a few samples too large).
+
+            // Also, we aren't likely to have enough space in the
+            // output buffer as the caller won't have allowed for
+            // all the samples we're retrieving here.
+
+            // What to do?
+
+            int additionalcount = 0;
+
+            if (c == 0 && m_debugLevel > 2) {
+                cerr << "final call, padding input with " << m_history
+                     << " zeros (symmetrical with m_history)" << endl;
+            }
+            
+            for (int i = 0; i < m_history; ++i) {
+                m_inbuf[c][m_lastread[c] + i] = 0.f;
+            }
+
+            if (c == 0 && m_debugLevel > 2) {
+                cerr << "before resample call, time = " << m_time[c] << endl;
+            }
+
+            int nAdditional = m_lastread[c] - int(m_time[c]);
+
+            if (n + nAdditional > limit) {
+                if (c == 0 && m_debugLevel > 1) {
+                    cerr << "trimming final input samples from " << nAdditional
+                         << " to " << (limit - n)
+                         << " to avoid overrunning " << outspace << " at output"
+                         << endl;
+                }
+                nAdditional = limit - n;
+            }
+            
+            ippsResamplePolyphase_32f(m_inbuf[c],
+                                      nAdditional,
+                                      m_outbuf[c],
+                                      ratio,
+                                      1.0f,
+                                      &m_time[c],
+                                      &additionalcount,
+                                      m_state[c]);
+        
+            if (c == 0 && m_debugLevel > 2) {
+                cerr << "converted " << n << " samples to " << additionalcount
+                     << ", time advanced to " << m_time[c] << endl;
+                cerr << "outcount = " << outcount << ", additionalcount = " << additionalcount << ", sum " << outcount + additionalcount << endl;
+            }
+
+            if (c == 0) {
+                outcount += additionalcount;
+            }
+        }
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "returning " << outcount << " samples" << endl;
+    }
+    
+    return outcount;
+}
+
+void
+D_IPP::reset()
+{
+    //!!!
+}
+
+#endif /* HAVE_IPP */
+
+#ifdef HAVE_LIBSAMPLERATE
+
+class D_SRC : public Resampler::Impl
+{
+public:
+    D_SRC(Resampler::Quality quality, Resampler::RatioChange ratioChange,
+          int channels, double initialSampleRate,
+          int maxBufferSize, int m_debugLevel);
+    ~D_SRC();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    int getChannelCount() const { return m_channels; }
+    double getEffectiveRatio(double ratio) const { return ratio; }
+
+    void reset();
+
+protected:
+    SRC_STATE *m_src;
+    float *m_iin;
+    float *m_iout;
+    int m_channels;
+    int m_iinsize;
+    int m_ioutsize;
+    double m_prevRatio;
+    bool m_ratioUnset;
+    bool m_smoothRatios;
+    int m_debugLevel;
+};
+
+D_SRC::D_SRC(Resampler::Quality quality, Resampler::RatioChange ratioChange,
+             int channels, double, int maxBufferSize, int debugLevel) :
+    m_src(0),
+    m_iin(0),
+    m_iout(0),
+    m_channels(channels),
+    m_iinsize(0),
+    m_ioutsize(0),
+    m_prevRatio(1.0),
+    m_ratioUnset(true),
+    m_smoothRatios(ratioChange == Resampler::SmoothRatioChange),
+    m_debugLevel(debugLevel)
+{
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: libsamplerate"
+             << endl;
+    }
+
+    if (channels < 1) {
+        cerr << "Resampler::Resampler: unable to create resampler: invalid channel count " << channels << " supplied" << endl;
+#ifdef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+        return;
+    }
+    
+    int err = 0;
+    m_src = src_new(quality == Resampler::Best ? SRC_SINC_BEST_QUALITY :
+                    quality == Resampler::Fastest ? SRC_SINC_FASTEST :
+                    SRC_SINC_MEDIUM_QUALITY,
+                    channels, &err);
+
+    if (err) {
+        cerr << "Resampler::Resampler: failed to create libsamplerate resampler: " 
+             << src_strerror(err) << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+        return;
+    } else if (!m_src) {
+        cerr << "Resampler::Resampler: failed to create libsamplerate resampler, but no error reported?" << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+        return;
+    }
+
+    if (maxBufferSize > 0 && m_channels > 1) {
+        m_iinsize = maxBufferSize * m_channels;
+        m_ioutsize = maxBufferSize * m_channels * 2;
+        m_iin = allocate<float>(m_iinsize);
+        m_iout = allocate<float>(m_ioutsize);
+    }
+
+    reset();
+}
+
+D_SRC::~D_SRC()
+{
+    src_delete(m_src);
+    deallocate(m_iin);
+    deallocate(m_iout);
+}
+
+int
+D_SRC::resample(float *const BQ_R__ *const BQ_R__ out,
+                int outcount,
+                const float *const BQ_R__ *const BQ_R__ in,
+                int incount,
+                double ratio,
+                bool final)
+{
+    if (m_channels == 1) {
+        return resampleInterleaved(*out, outcount, *in, incount, ratio, final);
+    }
+
+    if (incount * m_channels > m_iinsize) {
+        m_iin = reallocate<float>(m_iin, m_iinsize, incount * m_channels);
+        m_iinsize = incount * m_channels;
+    }
+    if (outcount * m_channels > m_ioutsize) {
+        m_iout = reallocate<float>(m_iout, m_ioutsize, outcount * m_channels);
+        m_ioutsize = outcount * m_channels;
+    }
+    
+    v_interleave(m_iin, in, m_channels, incount);
+
+    int n = resampleInterleaved(m_iout, outcount, m_iin, incount, ratio, final);
+
+    v_deinterleave(out, m_iout, m_channels, n);
+
+    return n;
+}
+
+int
+D_SRC::resampleInterleaved(float *const BQ_R__ out,
+                           int outcount,
+                           const float *const BQ_R__ in,
+                           int incount,
+                           double ratio,
+                           bool final)
+{
+    SRC_DATA data;
+
+    // libsamplerate smooths the filter change over the duration of
+    // the processing block to avoid artifacts due to sudden changes,
+    // and it uses outcount to determine how long to smooth the change
+    // over. This is a good thing, but it does mean (a) we should
+    // never pass outcount significantly longer than the actual
+    // expected output, and (b) when the ratio has just changed, we
+    // should aim to supply a shortish block next
+    
+    if (!final && (outcount > int(ceil(incount * ratio) + 5))) {
+        outcount = int(ceil(incount * ratio) + 5);
+    }
+
+    if (m_ratioUnset || !m_smoothRatios) {
+
+        // The first time we set a ratio, we want to do it directly
+        src_set_ratio(m_src, ratio);
+        m_ratioUnset = false;
+        m_prevRatio = ratio;
+
+    } else if (ratio != m_prevRatio) {
+
+        // If we are processing a block of appreciable length, turn it
+        // into two recursive calls, one for the short smoothing block
+        // and the other for the rest. Update m_prevRatio before doing
+        // this so that the calls don't themselves recurse!
+        m_prevRatio = ratio;
+
+        int shortBlock = 200;
+        if (outcount > shortBlock * 2) {
+            int shortIn = int(floor(shortBlock / ratio));
+            if (shortIn >= 10) {
+                int shortOut =
+                    resampleInterleaved(out, shortBlock,
+                                        in, shortIn,
+                                        ratio, false);
+                int remainingOut = 0;
+                if (shortOut < outcount) {
+                    remainingOut =
+                        resampleInterleaved(out + shortOut * m_channels,
+                                            outcount - shortOut,
+                                            in + shortIn * m_channels,
+                                            incount - shortIn,
+                                            ratio, final);
+                }
+                return shortOut + remainingOut;
+            }
+        }
+    }
+
+    data.data_in = const_cast<float *>(in);
+    data.data_out = out;
+
+    data.input_frames = incount;
+    data.output_frames = outcount;
+    data.src_ratio = ratio;
+    data.end_of_input = (final ? 1 : 0);
+
+    int err = src_process(m_src, &data);
+
+    if (err) {
+        cerr << "Resampler::process: libsamplerate error: "
+             << src_strerror(err) << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+    }
+
+//    cerr << "Resampler::process: final = " << final << ", incount = "
+//         << incount << ", outcount = " << outcount << ", ratio = "
+//         << ratio << ", gen = " << data.output_frames_gen << endl;
+    
+    return (int)data.output_frames_gen;
+}
+
+void
+D_SRC::reset()
+{
+    src_reset(m_src);
+    m_ratioUnset = true;
+}
+
+#endif /* HAVE_LIBSAMPLERATE */
+
+#ifdef USE_BQRESAMPLER
+    
+class D_BQResampler : public Resampler::Impl
+{
+public:
+    D_BQResampler(Resampler::Parameters params, int channels);
+    ~D_BQResampler();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    int getChannelCount() const {
+        return m_channels;
+    }
+
+    double getEffectiveRatio(double ratio) const {
+        return m_resampler->getEffectiveRatio(ratio);
+    }
+
+    void reset();
+
+protected:
+    BQResampler *m_resampler;
+    float *m_iin;
+    float *m_iout;
+    int m_channels;
+    int m_iinsize;
+    int m_ioutsize;
+    int m_debugLevel;
+};
+
+D_BQResampler::D_BQResampler(Resampler::Parameters params, int channels) :
+    m_resampler(0),
+    m_iin(0),
+    m_iout(0),
+    m_channels(channels),
+    m_iinsize(0),
+    m_ioutsize(0),
+    m_debugLevel(params.debugLevel)
+{
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: BQResampler" << endl;
+    }
+
+    BQResampler::Parameters rparams;
+    switch (params.quality) {
+    case Resampler::Best:
+        rparams.quality = BQResampler::Best;
+        break;
+    case Resampler::FastestTolerable:
+        rparams.quality = BQResampler::FastestTolerable;
+        break;
+    case Resampler::Fastest:
+        rparams.quality = BQResampler::Fastest;
+        break;
+    }
+    switch (params.dynamism) {
+    case Resampler::RatioOftenChanging:
+        rparams.dynamism = BQResampler::RatioOftenChanging;
+        break;
+    case Resampler::RatioMostlyFixed:
+        rparams.dynamism = BQResampler::RatioMostlyFixed;
+        break;
+    }
+    switch (params.ratioChange) {
+    case Resampler::SmoothRatioChange:
+        rparams.ratioChange = BQResampler::SmoothRatioChange;
+        break;
+    case Resampler::SuddenRatioChange:
+        rparams.ratioChange = BQResampler::SuddenRatioChange;
+        break;
+    }
+    rparams.referenceSampleRate = params.initialSampleRate;
+    rparams.debugLevel = params.debugLevel;
+
+    m_resampler = new BQResampler(rparams, m_channels);
+    
+    if (params.maxBufferSize > 0 && m_channels > 1) {
+        m_iinsize = params.maxBufferSize * m_channels;
+        m_ioutsize = params.maxBufferSize * m_channels * 2;
+        m_iin = allocate<float>(m_iinsize);
+        m_iout = allocate<float>(m_ioutsize);
+    }
+}
+
+D_BQResampler::~D_BQResampler()
+{
+    delete m_resampler;
+    deallocate(m_iin);
+    deallocate(m_iout);
+}
+
+int
+D_BQResampler::resample(float *const BQ_R__ *const BQ_R__ out,
+                        int outcount,
+                        const float *const BQ_R__ *const BQ_R__ in,
+                        int incount,
+                        double ratio,
+                        bool final)
+{
+    if (m_channels == 1) {
+        return resampleInterleaved(*out, outcount, *in, incount, ratio, final);
+    }
+
+    if (incount * m_channels > m_iinsize) {
+        m_iin = reallocate<float>(m_iin, m_iinsize, incount * m_channels);
+        m_iinsize = incount * m_channels;
+    }
+    if (outcount * m_channels > m_ioutsize) {
+        m_iout = reallocate<float>(m_iout, m_ioutsize, outcount * m_channels);
+        m_ioutsize = outcount * m_channels;
+    }
+    
+    v_interleave(m_iin, in, m_channels, incount);
+    
+    int n = resampleInterleaved(m_iout, outcount, m_iin, incount, ratio, final);
+
+    v_deinterleave(out, m_iout, m_channels, n);
+
+    return n;
+}
+
+int
+D_BQResampler::resampleInterleaved(float *const BQ_R__ out,
+                                   int outcount,
+                                   const float *const BQ_R__ in,
+                                   int incount,
+                                   double ratio,
+                                   bool final)
+{
+    return m_resampler->resampleInterleaved(out, outcount,
+                                            in, incount,
+                                            ratio, final);
+}
+
+void
+D_BQResampler::reset()
+{
+    m_resampler->reset();
+}
+
+#endif /* USE_BQRESAMPLER */
+
+#if defined(USE_SPEEX) || defined(HAVE_LIBSPEEXDSP)
+    
+class D_Speex : public Resampler::Impl
+{
+public:
+    D_Speex(Resampler::Quality quality, Resampler::RatioChange,
+            int channels, double initialSampleRate,
+            int maxBufferSize, int debugLevel);
+    ~D_Speex();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    int getChannelCount() const { return m_channels; }
+    double getEffectiveRatio(double ratio) const { return ratio; }
+
+    void reset();
+
+protected:
+    SpeexResamplerState *m_resampler;
+    double m_initialSampleRate;
+    float *m_iin;
+    float *m_iout;
+    int m_channels;
+    int m_iinsize;
+    int m_ioutsize;
+    double m_lastratio;
+    bool m_initial;
+    int m_debugLevel;
+
+    void setRatio(double);
+    void doResample(const float *in, unsigned int &incount,
+                    float *out, unsigned int &outcount,
+                    double ratio, bool final);
+};
+
+D_Speex::D_Speex(Resampler::Quality quality, Resampler::RatioChange,
+                 int channels, double initialSampleRate,
+                 int maxBufferSize, int debugLevel) :
+    m_resampler(0),
+    m_initialSampleRate(initialSampleRate),
+    m_iin(0),
+    m_iout(0),
+    m_channels(channels),
+    m_iinsize(0),
+    m_ioutsize(0),
+    m_lastratio(-1.0),
+    m_initial(true),
+    m_debugLevel(debugLevel)
+{
+    int q = (quality == Resampler::Best ? 10 :
+             quality == Resampler::Fastest ? 0 : 4);
+
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: Speex with q = "
+             << q << endl;
+    }
+
+    int rrate = int(round(m_initialSampleRate));
+    
+    int err = 0;
+    m_resampler = speex_resampler_init_frac(m_channels,
+                                            1, 1,
+                                            rrate, rrate,
+                                            q,
+                                            &err);
+    
+
+    if (err) {
+        cerr << "Resampler::Resampler: failed to create Speex resampler" 
+             << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+    }
+
+    if (maxBufferSize > 0 && m_channels > 1) {
+        m_iinsize = maxBufferSize * m_channels;
+        m_ioutsize = maxBufferSize * m_channels * 2;
+        m_iin = allocate<float>(m_iinsize);
+        m_iout = allocate<float>(m_ioutsize);
+    }
+}
+
+D_Speex::~D_Speex()
+{
+    speex_resampler_destroy(m_resampler);
+    deallocate<float>(m_iin);
+    deallocate<float>(m_iout);
+}
+
+void
+D_Speex::setRatio(double ratio)
+{
+    // Speex wants a ratio of two unsigned integers, not a single
+    // float.  Let's do that.
+
+    int max_denom = 48000;
+    if (ratio > 1.0) {
+        max_denom = int(ceil(48000 / ratio));
+    }
+
+    int inum, idenom;
+    pickNearestRational(ratio, max_denom, inum, idenom);
+
+    if (inum < 0 || idenom < 0) {
+        cerr << "Resampler::setRatio: Internal error: "
+             << "numerator or denominator < 0 ("
+             << inum << "/" << idenom << ")" << endl;
+        return;
+    }
+    
+    unsigned int num = inum, denom = idenom;
+    
+    if (m_debugLevel > 1) {
+        cerr << "D_Speex: Desired ratio " << ratio << ", requesting ratio "
+             << num << "/" << denom << " = " << float(double(num)/double(denom))
+             << endl;
+    }
+
+    int fromRate = int(round(m_initialSampleRate));
+    int toRate = int(round(m_initialSampleRate * ratio));
+    
+    int err = speex_resampler_set_rate_frac
+        (m_resampler, denom, num, fromRate, toRate);
+
+    if (err) {
+        cerr << "Resampler::Resampler: failed to set rate on Speex resampler"
+             << " (with ratio = " << ratio << " [ratio-1 = " << ratio - 1.0
+             << "], denom = " << denom
+             << ", num = " << num << ", fromRate = " << fromRate
+             << ", toRate = " << toRate << ", err = " << err
+             << ")" << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+    }
+    
+    speex_resampler_get_ratio(m_resampler, &denom, &num);
+    
+    if (m_debugLevel > 1) {
+        cerr << "D_Speex: Desired ratio " << ratio << ", got ratio "
+             << num << "/" << denom << " = " << float(double(num)/double(denom))
+             << endl;
+    }
+    
+    m_lastratio = ratio;
+
+    if (m_initial) {
+        speex_resampler_skip_zeros(m_resampler);
+        m_initial = false;
+    }
+}
+
+int
+D_Speex::resample(float *const BQ_R__ *const BQ_R__ out,
+                  int outcount,
+                  const float *const BQ_R__ *const BQ_R__ in,
+                  int incount,
+                  double ratio,
+                  bool final)
+{
+    if (ratio != m_lastratio) {
+        setRatio(ratio);
+    }
+
+    unsigned int uincount = incount;
+    unsigned int uoutcount = outcount;
+
+    float *data_in, *data_out;
+
+    if (m_channels == 1) {
+        data_in = const_cast<float *>(*in);
+        data_out = *out;
+    } else {
+        if (int(incount * m_channels) > m_iinsize) {
+            m_iin = reallocate<float>(m_iin, m_iinsize, incount * m_channels);
+            m_iinsize = incount * m_channels;
+        }
+        if (int(outcount * m_channels) > m_ioutsize) {
+            m_iout = reallocate<float>(m_iout, m_ioutsize, outcount * m_channels);
+            m_ioutsize = outcount * m_channels;
+        }
+        v_interleave(m_iin, in, m_channels, incount);
+        data_in = m_iin;
+        data_out = m_iout;
+    }
+
+    doResample(data_in, uincount, data_out, uoutcount, ratio, final);
+
+    if (m_channels > 1) {
+        v_deinterleave(out, m_iout, m_channels, uoutcount);
+    }
+
+    return uoutcount;
+}
+
+int
+D_Speex::resampleInterleaved(float *const BQ_R__ out,
+                             int outcount,
+                             const float *const BQ_R__ in,
+                             int incount,
+                             double ratio,
+                             bool final)
+{
+    if (ratio != m_lastratio) {
+        setRatio(ratio);
+    }
+
+    unsigned int uincount = incount;
+    unsigned int uoutcount = outcount;
+
+    float *data_in = const_cast<float *>(in);
+    float *data_out = out;
+
+    doResample(data_in, uincount, data_out, uoutcount, ratio, final);
+    
+    return uoutcount;
+}
+
+void
+D_Speex::doResample(const float *data_in, unsigned int &uincount,
+                    float *data_out, unsigned int &uoutcount,
+                    double ratio, bool final)
+{
+    int initial_outcount = int(uoutcount);
+    
+    int err = speex_resampler_process_interleaved_float
+        (m_resampler,
+         data_in, &uincount,
+         data_out, &uoutcount);
+    
+    if (err) {
+        cerr << "Resampler::Resampler: Speex resampler returned error "
+             << err << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+    }
+
+    if (final) {
+        int actual = int(uoutcount);
+        int expected = std::min(initial_outcount, int(round(uincount * ratio)));
+        float *pad = nullptr;
+        while (actual < expected) {
+            unsigned int final_out = expected - actual;
+            unsigned int final_in = (unsigned int)(round(final_out / ratio));
+            if (final_in == 0) {
+                break;
+            } else {
+                if (!pad) {
+                    pad = allocate_and_zero<float>(final_in * m_channels);
+                }
+                err = speex_resampler_process_interleaved_float
+                    (m_resampler,
+                     pad, &final_in,
+                     data_out + actual * m_channels, &final_out);
+                actual += final_out;
+                uoutcount += final_out;
+                if (err) {
+                    cerr << "Resampler::Resampler: Speex resampler returned error "
+                         << err << endl;
+                    if (pad) {
+                        deallocate(pad);
+                    }
+#ifndef NO_EXCEPTIONS
+                    throw Resampler::ImplementationError;
+#endif
+                }
+            }
+        }
+        if (pad) {
+            deallocate(pad);
+        }
+    }
+}
+
+void
+D_Speex::reset()
+{
+    m_lastratio = -1.0; // force reset of ratio
+    m_initial = true;
+    speex_resampler_reset_mem(m_resampler);
+}
+
+#endif
+
+} /* end namespace Resamplers */
+
+Resampler::Resampler(Resampler::Parameters params, int channels)
+{
+    m_method = -1;
+
+    if (params.initialSampleRate == 0) {
+        params.initialSampleRate = 44100;
+    }
+    
+    switch (params.quality) {
+
+    case Resampler::Best:
+#ifdef HAVE_IPP
+        m_method = 0;
+#endif
+#ifdef USE_SPEEX
+        m_method = 2;
+#endif
+#ifdef HAVE_LIBSPEEXDSP
+        m_method = 2;
+#endif
+#ifdef USE_BQRESAMPLER
+        m_method = 3;
+#endif
+#ifdef HAVE_LIBSAMPLERATE
+        m_method = 1;
+#endif
+        break;
+
+    case Resampler::FastestTolerable:
+#ifdef HAVE_IPP
+        m_method = 0;
+#endif
+#ifdef USE_SPEEX
+        m_method = 2;
+#endif
+#ifdef HAVE_LIBSPEEXDSP
+        m_method = 2;
+#endif
+#ifdef USE_BQRESAMPLER
+        m_method = 3;
+#endif
+#ifdef HAVE_LIBSAMPLERATE
+        m_method = 1;
+#endif
+        break;
+
+    case Resampler::Fastest:
+#ifdef HAVE_IPP
+        m_method = 0;
+#endif
+#ifdef USE_SPEEX
+        m_method = 2;
+#endif
+#ifdef HAVE_LIBSPEEXDSP
+        m_method = 2;
+#endif
+#ifdef USE_BQRESAMPLER
+        m_method = 3;
+#endif
+#ifdef HAVE_LIBSAMPLERATE
+        m_method = 1;
+#endif
+        break;
+    }
+
+    if (m_method == -1) {
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+    }
+
+    switch (m_method) {
+    case 0:
+#ifdef HAVE_IPP
+        d = new Resamplers::D_IPP
+            (params.quality, params.ratioChange,
+             channels,
+             params.initialSampleRate, params.maxBufferSize, params.debugLevel);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+
+    case 1:
+#ifdef HAVE_LIBSAMPLERATE
+        d = new Resamplers::D_SRC
+            (params.quality, params.ratioChange,
+             channels,
+             params.initialSampleRate, params.maxBufferSize, params.debugLevel);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+
+    case 2:
+#if defined(USE_SPEEX) || defined(HAVE_LIBSPEEXDSP)
+        d = new Resamplers::D_Speex
+            (params.quality, params.ratioChange,
+             channels,
+             params.initialSampleRate, params.maxBufferSize, params.debugLevel);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+
+    case 3:
+#ifdef USE_BQRESAMPLER
+        d = new Resamplers::D_BQResampler(params, channels);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+    }
+
+    if (!d) {
+        cerr << "Resampler::Resampler: Internal error: No implementation selected"
+             << endl;
+        abort();
+    }
+}
+
+Resampler::~Resampler()
+{
+    delete d;
+}
+
+int 
+Resampler::resample(float *const BQ_R__ *const BQ_R__ out,
+                    int outcount,
+                    const float *const BQ_R__ *const BQ_R__ in,
+                    int incount,
+                    double ratio,
+                    bool final)
+{
+    return d->resample(out, outcount, in, incount, ratio, final);
+}
+
+int 
+Resampler::resampleInterleaved(float *const BQ_R__ out,
+                               int outcount,
+                               const float *const BQ_R__ in,
+                               int incount,
+                               double ratio,
+                               bool final)
+{
+    return d->resampleInterleaved(out, outcount, in, incount, ratio, final);
+}
+
+int
+Resampler::getChannelCount() const
+{
+    return d->getChannelCount();
+}
+
+double
+Resampler::getEffectiveRatio(double ratio) const
+{
+    return d->getEffectiveRatio(ratio);
+}
+
+void
+Resampler::reset()
+{
+    d->reset();
+}
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Resampler.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Resampler.h
@@ -1,0 +1,182 @@
+//* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_RESAMPLER_H
+#define RUBBERBAND_RESAMPLER_H
+
+#include "sysutils.h"
+
+namespace RubberBand {
+
+class Resampler
+{
+public:
+    enum Quality { Best, FastestTolerable, Fastest };
+    enum Dynamism { RatioOftenChanging, RatioMostlyFixed };
+    enum RatioChange { SmoothRatioChange, SuddenRatioChange };
+    
+    enum Exception { ImplementationError };
+
+    struct Parameters {
+
+        /**
+         * Resampler filter quality level.
+         */
+        Quality quality;
+
+        /**
+         * Performance hint indicating whether the ratio is expected
+         * to change regularly or not. If not, more work may happen on
+         * ratio changes to reduce work when ratio is unchanged.
+         */
+        Dynamism dynamism; 
+
+        /**
+         * Hint indicating whether to smooth transitions, via filter
+         * interpolation or some such method, at ratio change
+         * boundaries, or whether to make a precise switch to the new
+         * ratio without regard to audible artifacts. The actual
+         * effect of this depends on the implementation in use.
+         */
+        RatioChange ratioChange;
+        
+        /** 
+         * Rate of expected input prior to resampling: may be used to
+         * determine the filter bandwidth for the quality setting. If
+         * you don't know what this will be, you can provide an
+         * arbitrary rate (such as the default) and the resampler will
+         * work fine, but quality may not be as designed.
+         */
+        double initialSampleRate;
+
+        /** 
+         * Bound on the maximum incount size that may be passed to the
+         * resample function before the resampler needs to reallocate
+         * its internal buffers. Default is zero, so that buffer
+         * allocation will happen on the first call and any subsequent
+         * call with a greater incount.
+         */
+        int maxBufferSize;
+
+        /**
+         * Debug output level, from 0 to 3. Controls the amount of
+         * debug information printed to stderr.
+         */
+        int debugLevel;
+
+        Parameters() :
+            quality(FastestTolerable),
+            dynamism(RatioMostlyFixed),
+            ratioChange(SmoothRatioChange),
+            initialSampleRate(44100),
+            maxBufferSize(0),
+            debugLevel(0) { }
+    };
+    
+    /**
+     * Construct a resampler to process the given number of channels,
+     * with the given quality level, initial sample rate, and other
+     * parameters.
+     */
+    Resampler(Parameters parameters, int channels);
+    
+    ~Resampler();
+
+    /**
+     * Resample the given multi-channel buffers, where incount is the
+     * number of frames in the input buffers and outspace is the space
+     * available in the output buffers. Generally you want outspace to
+     * be at least ceil(incount * ratio).
+     *
+     * Returns the number of frames written to the output
+     * buffers. This may be smaller than outspace even where the ratio
+     * suggests otherwise, particularly at the start of processing
+     * where there may be a filter tail to allow for.
+     */
+#ifdef __GNUC__
+    __attribute__((warn_unused_result))
+#endif
+    int resample(float *const R__ *const R__ out,
+                 int outspace,
+                 const float *const R__ *const R__ in,
+                 int incount,
+                 double ratio,
+                 bool final = false);
+
+    /**
+     * Resample the given interleaved buffer, where incount is the
+     * number of frames in the input buffer (i.e. it has incount *
+     * getChannelCount() samples) and outspace is the space available
+     * in frames in the output buffer (i.e. it has space for at least
+     * outspace * getChannelCount() samples). Generally you want
+     * outspace to be at least ceil(incount * ratio).
+     *
+     * Returns the number of frames written to the output buffer. This
+     * may be smaller than outspace even where the ratio suggests
+     * otherwise, particularly at the start of processing where there
+     * may be a filter tail to allow for.
+     */
+#ifdef __GNUC__
+    __attribute__((warn_unused_result))
+#endif
+    int resampleInterleaved(float *const R__ out,
+                            int outspace,
+                            const float *const R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    /**
+     * Return the channel count provided on construction.
+     */
+    int getChannelCount() const;
+
+    /**
+     * Return the ratio that will be actually used when the given
+     * ratio is requested. For example, if the resampler internally
+     * uses a rational approximation of the given ratio, this will
+     * return the closest double to that approximation. Not all
+     * implementations support this; an implementation that does not
+     * will just return the given ratio.
+     */
+    double getEffectiveRatio(double ratio) const;
+    
+    /**
+     * Reset the internal processing state so that the next call
+     * behaves as if the resampler had just been constructed.
+     */
+    void reset();
+
+    class Impl;
+
+protected:
+    Impl *d;
+    int m_method;
+
+    Resampler(const Resampler &) =delete;
+    Resampler &operator=(const Resampler &) =delete;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/RingBuffer.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/RingBuffer.h
@@ -1,0 +1,512 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_RINGBUFFER_H
+#define RUBBERBAND_RINGBUFFER_H
+
+#include <sys/types.h>
+
+//#define DEBUG_RINGBUFFER 1
+
+#include "sysutils.h"
+#include "Allocators.h"
+
+#include <iostream>
+
+#include <atomic>
+
+namespace RubberBand {
+
+/**
+ * RingBuffer implements a lock-free ring buffer for one writer and
+ * one reader, that is to be used to store a sample type T.
+ *
+ * RingBuffer is thread-safe provided only one thread writes and only
+ * one thread reads.
+ */
+template <typename T>
+class RingBuffer
+{
+public:
+    /**
+     * Create a ring buffer with room to write n samples.
+     *
+     * Note that the internal storage size will actually be n+1
+     * samples, as one element is unavailable for administrative
+     * reasons.  Since the ring buffer performs best if its size is a
+     * power of two, this means n should ideally be some power of two
+     * minus one.
+     */
+    RingBuffer(int n);
+
+    virtual ~RingBuffer();
+
+    /**
+     * Return the total capacity of the ring buffer in samples.
+     * (This is the argument n passed to the constructor.)
+     */
+    int getSize() const;
+
+    /**
+     * Return a new ring buffer (allocated with "new" -- caller must
+     * delete when no longer needed) of the given size, containing the
+     * same data as this one.  If another thread reads from or writes
+     * to this buffer during the call, the results may be incomplete
+     * or inconsistent.  If this buffer's data will not fit in the new
+     * size, the contents are undefined.
+     */
+    RingBuffer<T> *resized(int newSize) const;
+
+    /**
+     * Reset read and write pointers, thus emptying the buffer.
+     * Should be called from the write thread.
+     */
+    void reset();
+
+    /**
+     * Return the amount of data available for reading, in samples.
+     */
+    int getReadSpace() const;
+
+    /**
+     * Return the amount of space available for writing, in samples.
+     */
+    int getWriteSpace() const;
+
+    /**
+     * Read n samples from the buffer.  If fewer than n are available,
+     * the remainder will be zeroed out.  Returns the number of
+     * samples actually read.
+     *
+     * This is a template function, taking an argument S for the target
+     * sample type, which is permitted to differ from T if the two
+     * types are compatible for arithmetic operations.
+     */
+    template <typename S>
+    int read(S *const R__ destination, int n);
+
+    /**
+     * Read n samples from the buffer, adding them to the destination.
+     * If fewer than n are available, the remainder will be left
+     * alone.  Returns the number of samples actually read.
+     *
+     * This is a template function, taking an argument S for the target
+     * sample type, which is permitted to differ from T if the two
+     * types are compatible for arithmetic operations.
+     */
+    template <typename S>
+    int readAdding(S *const R__ destination, int n);
+
+    /**
+     * Read one sample from the buffer.  If no sample is available,
+     * this will silently return zero.  Calling this repeatedly is
+     * obviously slower than calling read once, but it may be good
+     * enough if you don't want to allocate a buffer to read into.
+     */
+    T readOne();
+
+    /**
+     * Read n samples from the buffer, if available, without advancing
+     * the read pointer -- i.e. a subsequent read() or skip() will be
+     * necessary to empty the buffer.  If fewer than n are available,
+     * the remainder will be zeroed out.  Returns the number of
+     * samples actually read.
+     *
+     * This is a template function, taking an argument S for the target
+     * sample type, which is permitted to differ from T if the two
+     * types are compatible for arithmetic operations.
+     */
+    template <typename S>
+    int peek(S *const R__ destination, int n) const;
+
+    /**
+     * Read one sample from the buffer, if available, without
+     * advancing the read pointer -- i.e. a subsequent read() or
+     * skip() will be necessary to empty the buffer.  Returns zero if
+     * no sample was available.
+     */
+    T peekOne() const;
+
+    /**
+     * Pretend to read n samples from the buffer, without actually
+     * returning them (i.e. discard the next n samples).  Returns the
+     * number of samples actually available for discarding.
+     */
+    int skip(int n);
+
+    /**
+     * Write n samples to the buffer.  If insufficient space is
+     * available, not all samples may actually be written.  Returns
+     * the number of samples actually written.
+     *
+     * This is a template function, taking an argument S for the source
+     * sample type, which is permitted to differ from T if the two
+     * types are compatible for assignment.
+     */
+    template <typename S>
+    int write(const S *const R__ source, int n);
+
+    /**
+     * Write n zero-value samples to the buffer.  If insufficient
+     * space is available, not all zeros may actually be written.
+     * Returns the number of zeroes actually written.
+     */
+    int zero(int n);
+
+protected:
+    T *const R__      m_buffer;
+    std::atomic<int>  m_writer;
+    std::atomic<int>  m_reader;
+    const int         m_size;
+
+    int readSpaceFor(int w, int r) const {
+        int space;
+        if (w > r) space = w - r;
+        else if (w < r) space = (w + m_size) - r;
+        else space = 0;
+        return space;
+    }
+
+    int writeSpaceFor(int w, int r) const {
+        int space = (r + m_size - w - 1);
+        if (space >= m_size) space -= m_size;
+        return space;
+    }
+
+private:
+    RingBuffer(const RingBuffer &); // not provided
+    RingBuffer &operator=(const RingBuffer &); // not provided
+};
+
+template <typename T>
+RingBuffer<T>::RingBuffer(int n) :
+    m_buffer(allocate<T>(n + 1)),
+    m_writer(0),
+    m_size(n + 1)
+{
+#ifdef DEBUG_RINGBUFFER
+    std::cerr << "RingBuffer<T>[" << this << "]::RingBuffer(" << n << ")" << std::endl;
+#endif
+
+    m_reader = 0;
+}
+
+template <typename T>
+RingBuffer<T>::~RingBuffer()
+{
+#ifdef DEBUG_RINGBUFFER
+    std::cerr << "RingBuffer<T>[" << this << "]::~RingBuffer" << std::endl;
+#endif
+
+    deallocate(m_buffer);
+}
+
+template <typename T>
+int
+RingBuffer<T>::getSize() const
+{
+#ifdef DEBUG_RINGBUFFER
+    std::cerr << "RingBuffer<T>[" << this << "]::getSize(): " << m_size-1 << std::endl;
+#endif
+
+    return m_size - 1;
+}
+
+template <typename T>
+RingBuffer<T> *
+RingBuffer<T>::resized(int newSize) const
+{
+    RingBuffer<T> *newBuffer = new RingBuffer<T>(newSize);
+    
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    
+    int w = m_writer;
+    int r = m_reader;
+
+    while (r != w) {
+        T value = m_buffer[r];
+        newBuffer->write(&value, 1);
+        if (++r == m_size) r = 0;
+    }
+
+    return newBuffer;
+}
+
+template <typename T>
+void
+RingBuffer<T>::reset()
+{
+#ifdef DEBUG_RINGBUFFER
+    std::cerr << "RingBuffer<T>[" << this << "]::reset" << std::endl;
+#endif
+
+    int r = m_reader;
+    m_writer = r;
+}
+
+template <typename T>
+int
+RingBuffer<T>::getReadSpace() const
+{
+    return readSpaceFor(m_writer, m_reader);
+}
+
+template <typename T>
+int
+RingBuffer<T>::getWriteSpace() const
+{
+    return writeSpaceFor(m_writer, m_reader);
+}
+
+template <typename T>
+template <typename S>
+int
+RingBuffer<T>::read(S *const R__ destination, int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = readSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::read: " << n << " requested, only "
+                  << available << " available" << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - r;
+    T *const R__ bufbase = m_buffer + r;
+
+    if (here >= n) {
+        v_convert(destination, bufbase, n);
+    } else {
+        v_convert(destination, bufbase, here);
+        v_convert(destination + here, m_buffer, n - here);
+    }
+
+    r += n;
+    while (r >= m_size) r -= m_size;
+
+    m_reader = r;
+
+    return n;
+}
+
+template <typename T>
+template <typename S>
+int
+RingBuffer<T>::readAdding(S *const R__ destination, int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = readSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::read: " << n << " requested, only "
+                  << available << " available" << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - r;
+    T *const R__ bufbase = m_buffer + r;
+
+    if (here >= n) {
+        v_add(destination, bufbase, n);
+    } else {
+        v_add(destination, bufbase, here);
+        v_add(destination + here, m_buffer, n - here);
+    }
+
+    r += n;
+    while (r >= m_size) r -= m_size;
+
+    m_reader = r;
+
+    return n;
+}
+
+template <typename T>
+T
+RingBuffer<T>::readOne()
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    if (w == r) {
+	std::cerr << "WARNING: RingBuffer::readOne: no sample available"
+		  << std::endl;
+	return T();
+    }
+
+    T value = m_buffer[r];
+    if (++r == m_size) r = 0;
+
+    m_reader = r;
+
+    return value;
+}
+
+template <typename T>
+template <typename S>
+int
+RingBuffer<T>::peek(S *const R__ destination, int n) const
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = readSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::peek: " << n << " requested, only "
+                  << available << " available" << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - r;
+    const T *const R__ bufbase = m_buffer + r;
+
+    if (here >= n) {
+        v_convert(destination, bufbase, n);
+    } else {
+        v_convert(destination, bufbase, here);
+        v_convert(destination + here, m_buffer, n - here);
+    }
+
+    return n;
+}
+
+template <typename T>
+T
+RingBuffer<T>::peekOne() const
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    if (w == r) {
+	std::cerr << "WARNING: RingBuffer::peekOne: no sample available"
+		  << std::endl;
+	return 0;
+    }
+
+    T value = m_buffer[r];
+    return value;
+}
+
+template <typename T>
+int
+RingBuffer<T>::skip(int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = readSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::skip: " << n << " requested, only "
+                  << available << " available" << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    r += n;
+    while (r >= m_size) r -= m_size;
+
+    m_reader = r;
+
+    return n;
+}
+
+template <typename T>
+template <typename S>
+int
+RingBuffer<T>::write(const S *const R__ source, int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = writeSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::write: " << n
+                  << " requested, only room for " << available << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - w;
+    T *const R__ bufbase = m_buffer + w;
+
+    if (here >= n) {
+        v_convert<S, T>(bufbase, source, n);
+    } else {
+        v_convert<S, T>(bufbase, source, here);
+        v_convert<S, T>(m_buffer, source + here, n - here);
+    }
+
+    w += n;
+    while (w >= m_size) w -= m_size;
+
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    
+    m_writer = w;
+
+    return n;
+}
+
+template <typename T>
+int
+RingBuffer<T>::zero(int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = writeSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::zero: " << n
+                  << " requested, only room for " << available << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - w;
+    T *const R__ bufbase = m_buffer + w;
+
+    if (here >= n) {
+        v_zero(bufbase, n);
+    } else {
+        v_zero(bufbase, here);
+        v_zero(m_buffer, n - here);
+    }
+
+    w += n;
+    while (w >= m_size) w -= m_size;
+
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    
+    m_writer = w;
+
+    return n;
+}
+
+}
+
+#endif // _RINGBUFFER_H

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/SampleFilter.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/SampleFilter.h
@@ -1,0 +1,46 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SAMPLE_FILTER_H
+#define RUBBERBAND_SAMPLE_FILTER_H
+
+#include <cassert>
+
+namespace RubberBand
+{
+
+template <typename T>
+class SampleFilter
+{
+public:
+    virtual ~SampleFilter() { }
+    virtual int getSize() const = 0;
+    virtual void push(T) = 0;
+    virtual T get() const = 0;
+    virtual void reset() = 0;
+};
+
+}
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Scavenger.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Scavenger.h
@@ -1,0 +1,250 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SCAVENGER_H
+#define RUBBERBAND_SCAVENGER_H
+
+#include <vector>
+#include <list>
+#include <utility>
+#include <iostream>
+
+#ifndef _MSC_VER
+#include <sys/time.h>
+#endif
+
+#include "Thread.h"
+#include "sysutils.h"
+#include "Allocators.h"
+
+//#define DEBUG_SCAVENGER 1
+
+namespace RubberBand {
+
+/**
+ * A very simple class that facilitates running things like plugins
+ * without locking, by collecting unwanted objects and deleting them
+ * after a delay so as to be sure nobody's in the middle of using
+ * them.  Requires scavenge() to be called regularly from a non-RT
+ * thread.
+ *
+ * This is currently not at all suitable for large numbers of objects
+ * -- it's just a quick hack for use with things like plugins.
+ */
+
+//!!! should review this, it's not really thread safe owing to lack of
+//!!! atomic updates
+
+template <typename T>
+class Scavenger
+{
+public:
+    Scavenger(int sec = 2, int defaultObjectListSize = 200);
+    ~Scavenger();
+
+    /**
+     * Call from an RT thread etc., to pass ownership of t to us.
+     * Only one thread should be calling this on any given scavenger.
+     */
+    void claim(T *t);
+
+    /**
+     * Call from a non-RT thread.
+     * Only one thread should be calling this on any given scavenger.
+     */
+    void scavenge(bool clearNow = false);
+
+protected:
+    typedef std::pair<T *, int> ObjectTimePair;
+    typedef std::vector<ObjectTimePair> ObjectTimeList;
+    ObjectTimeList m_objects;
+    int m_sec;
+
+    typedef std::list<T *> ObjectList;
+    ObjectList m_excess;
+    int m_lastExcess;
+    Mutex m_excessMutex;
+    void pushExcess(T *);
+    void clearExcess(int);
+
+    unsigned int m_claimed;
+    unsigned int m_scavenged;
+    unsigned int m_asExcess;
+};
+
+
+/**
+ * A wrapper to permit arrays allocated with new[] to be scavenged.
+ */
+
+template <typename T>
+class ScavengerArrayWrapper
+{
+public:
+    ScavengerArrayWrapper(T *array) : m_array(array) { }
+    ~ScavengerArrayWrapper() { delete[] m_array; }
+
+private:
+    T *m_array;
+};
+
+
+/**
+ * A wrapper to permit arrays allocated with the Allocators functions
+ * to be scavenged.
+ */
+
+template <typename T>
+class ScavengerAllocArrayWrapper
+{
+public:
+    ScavengerAllocArrayWrapper(T *array) : m_array(array) { }
+    ~ScavengerAllocArrayWrapper() { deallocate<T>(m_array); }
+
+private:
+    T *m_array;
+};
+
+
+template <typename T>
+Scavenger<T>::Scavenger(int sec, int defaultObjectListSize) :
+    m_objects(ObjectTimeList(defaultObjectListSize)),
+    m_sec(sec),
+    m_lastExcess(0),
+    m_claimed(0),
+    m_scavenged(0),
+    m_asExcess(0)
+{
+}
+
+template <typename T>
+Scavenger<T>::~Scavenger()
+{
+    if (m_scavenged < m_claimed) {
+	for (size_t i = 0; i < m_objects.size(); ++i) {
+	    ObjectTimePair &pair = m_objects[i];
+	    if (pair.first != 0) {
+		T *ot = pair.first;
+		pair.first = 0;
+		delete ot;
+		++m_scavenged;
+	    }
+	}
+    }
+
+    clearExcess(0);
+}
+
+template <typename T>
+void
+Scavenger<T>::claim(T *t)
+{
+//    std::cerr << "Scavenger::claim(" << t << ")" << std::endl;
+
+    struct timeval tv;
+    (void)gettimeofday(&tv, 0);
+    int sec = tv.tv_sec;
+
+    for (size_t i = 0; i < m_objects.size(); ++i) {
+	ObjectTimePair &pair = m_objects[i];
+	if (pair.first == 0) {
+	    pair.second = sec;
+	    pair.first = t;
+	    ++m_claimed;
+	    return;
+	}
+    }
+
+#ifdef DEBUG_SCAVENGER
+    std::cerr << "WARNING: Scavenger::claim(" << t << "): run out of slots (at "
+              << m_objects.size() << "), using non-RT-safe method" << std::endl;
+#endif
+    pushExcess(t);
+}
+
+template <typename T>
+void
+Scavenger<T>::scavenge(bool clearNow)
+{
+#ifdef DEBUG_SCAVENGER
+    std::cerr << "Scavenger::scavenge: claimed " << m_claimed << ", scavenged " << m_scavenged << ", cleared as excess " << m_asExcess << std::endl;
+#endif
+
+    if (m_scavenged >= m_claimed) return;
+    
+    struct timeval tv;
+    (void)gettimeofday(&tv, 0);
+    int sec = tv.tv_sec;
+    bool anything = false;
+
+    for (size_t i = 0; i < m_objects.size(); ++i) {
+	ObjectTimePair &pair = m_objects[i];
+        if (!pair.first) continue;
+	if (clearNow || pair.second + m_sec < sec) {
+	    T *ot = pair.first;
+	    pair.first = 0;
+	    delete ot;
+	    ++m_scavenged;
+            anything = true;
+	}
+    }
+
+    if (clearNow || anything || (sec > m_lastExcess + m_sec)) {
+        clearExcess(sec);
+    }
+}
+
+template <typename T>
+void
+Scavenger<T>::pushExcess(T *t)
+{
+    m_excessMutex.lock();
+    m_excess.push_back(t);
+    struct timeval tv;
+    (void)gettimeofday(&tv, 0);
+    m_lastExcess = tv.tv_sec;
+    m_excessMutex.unlock();
+}
+
+template <typename T>
+void
+Scavenger<T>::clearExcess(int sec)
+{
+#ifdef DEBUG_SCAVENGER
+    std::cerr << "Scavenger::clearExcess: Excess now " << m_excess.size() << std::endl;
+#endif
+
+    m_excessMutex.lock();
+    for (typename ObjectList::iterator i = m_excess.begin();
+	 i != m_excess.end(); ++i) {
+	delete *i;
+        ++m_asExcess;
+    }
+    m_excess.clear();
+    m_lastExcess = sec;
+    m_excessMutex.unlock();
+}
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/SingleThreadRingBuffer.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/SingleThreadRingBuffer.h
@@ -1,0 +1,149 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SINGLE_THREAD_RINGBUFFER_H
+#define RUBBERBAND_SINGLE_THREAD_RINGBUFFER_H
+
+#include <sys/types.h>
+
+namespace RubberBand {
+
+/**
+ * SingleThreadRingBuffer implements a ring buffer to be used to store
+ * a sample type T, for reading and writing within a single
+ * thread. SingleThreadRingBuffer is a simple container, not a
+ * thread-safe lock-free structure: use RingBuffer for the situation
+ * with reader and writer in separate threads. Currently this
+ * implementation only supports reading and writing a single sample at
+ * a time.
+ */
+template <typename T>
+class SingleThreadRingBuffer
+{
+public:
+    /**
+     * Create a ring buffer with room to write n samples.
+     *
+     * Note that the internal storage size will actually be n+1
+     * samples, as one element is unavailable for administrative
+     * reasons.  Since the ring buffer performs best if its size is a
+     * power of two, this means n should ideally be some power of two
+     * minus one.
+     */
+    SingleThreadRingBuffer(int n) :
+        m_buffer(n + 1, T()),
+        m_writer(0),
+        m_reader(0),
+        m_size(n + 1) { }
+
+    SingleThreadRingBuffer() :
+        m_buffer(1, T()),
+        m_writer(0),
+        m_reader(0),
+        m_size(1) { }
+
+    SingleThreadRingBuffer (const SingleThreadRingBuffer &other) =default;
+    SingleThreadRingBuffer &operator=(const SingleThreadRingBuffer &other) =default;
+        
+    virtual ~SingleThreadRingBuffer() { }
+
+    /**
+     * Return the total capacity of the ring buffer in samples.
+     * (This is the argument n passed to the constructor.)
+     */
+    int getSize() const {
+        return m_size - 1;
+    }
+
+    /**
+     * Reset read and write pointers, thus emptying the buffer.
+     */
+    void reset() {
+        m_writer = m_reader;
+    }
+
+    /**
+     * Return the amount of data available for reading, in samples.
+     */
+    int getReadSpace() const {
+        if (m_writer > m_reader) return m_writer - m_reader;
+        else if (m_writer < m_reader) return (m_writer + m_size) - m_reader;
+        else return 0;
+    }
+
+    /**
+     * Return the amount of space available for writing, in samples.
+     */
+    int getWriteSpace() const {
+        int space = (m_reader + m_size - m_writer - 1);
+        if (space >= m_size) space -= m_size;
+        return space;
+    }
+
+    /**
+     * Read one sample from the buffer.  If no sample is available,
+     * silently return zero.
+     */
+    T readOne() {
+        if (m_writer == m_reader) {
+            return {};
+        }
+        auto value = m_buffer[m_reader];
+        if (++m_reader == m_size) m_reader = 0;
+        return value;
+    }
+
+    /**
+     * Pretend to read one sample from the buffer, without actually
+     * returning it (i.e. discard the next sample).
+     */
+    void skipOne() {
+        if (m_writer == m_reader) {
+            return;
+        }
+        if (++m_reader == m_size) m_reader = 0;
+    }
+
+    /**
+     * Write one sample to the buffer.  If insufficient space is
+     * available, the sample will not be written.  Returns the number
+     * of samples actually written, i.e. 0 or 1.
+     */
+    int writeOne(const T &value) {
+        if (getWriteSpace() == 0) return 0;
+        m_buffer[m_writer] = value;
+        if (++m_writer == m_size) m_writer = 0;
+        return 1;
+    }
+
+protected:
+    std::vector<T> m_buffer;
+    int m_writer;
+    int m_reader;
+    int m_size;
+};
+
+}
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/StretchCalculator.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/StretchCalculator.cpp
@@ -1,0 +1,791 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "StretchCalculator.h"
+
+#include <math.h>
+#include <iostream>
+#include <deque>
+#include <set>
+#include <cassert>
+#include <algorithm>
+#include <sstream>
+
+#include "sysutils.h"
+
+namespace RubberBand
+{
+	
+StretchCalculator::StretchCalculator(size_t sampleRate,
+                                     size_t inputIncrement,
+                                     bool useHardPeaks,
+                                     Log log) :
+    m_sampleRate(sampleRate),
+    m_increment(inputIncrement),
+    m_prevDf(0),
+    m_prevRatio(1.0),
+    m_prevTimeRatio(1.0),
+    m_justReset(true),
+    m_transientAmnesty(0),
+    m_debugLevel(0),
+    m_useHardPeaks(useHardPeaks),
+    m_inFrameCounter(0),
+    m_frameCheckpoint(0, 0),
+    m_outFrameCounter(0),
+    m_log(log)
+{
+    m_log.log(2, "StretchCalculator: useHardPeaks", useHardPeaks);
+}    
+
+StretchCalculator::~StretchCalculator()
+{
+}
+
+void
+StretchCalculator::setKeyFrameMap(const std::map<size_t, size_t> &mapping)
+{
+    m_keyFrameMap = mapping;
+
+    // Ensure we always have a 0 -> 0 mapping. If there's nothing in
+    // the map at all, don't need to worry about this (empty map is
+    // handled separately anyway)
+    if (!m_keyFrameMap.empty()) {
+        if (m_keyFrameMap.find(0) == m_keyFrameMap.end()) {
+            m_keyFrameMap[0] = 0;
+        }
+    }
+}
+
+std::vector<int>
+StretchCalculator::calculate(double ratio, size_t inputDuration,
+                             const std::vector<float> &phaseResetDf)
+{
+    m_peaks = findPeaks(phaseResetDf);
+
+    size_t totalCount = phaseResetDf.size();
+
+    size_t outputDuration = lrint(inputDuration * ratio);
+
+    m_log.log(1, "StretchCalculator::calculate: inputDuration and ratio", inputDuration, ratio);
+
+    outputDuration = lrint((phaseResetDf.size() * m_increment) * ratio);
+
+    m_log.log(1, "StretchCalculator::calculate: outputDuration rounds up from and to", inputDuration * ratio, outputDuration);
+    m_log.log(1, "StretchCalculator::calculate: df size and increment", phaseResetDf.size(), m_increment);
+    
+    std::vector<Peak> peaks; // peak position (in chunks) and hardness
+    std::vector<size_t> targets; // targets for mapping peaks (in samples)
+    mapPeaks(peaks, targets, outputDuration, totalCount);
+
+    m_log.log(2, "have fixed positions", peaks.size());
+
+    size_t totalInput = 0, totalOutput = 0;
+
+    std::vector<int> increments;
+
+    for (size_t i = 0; i <= peaks.size(); ++i) {
+        
+        size_t regionStart, regionStartChunk, regionEnd, regionEndChunk;
+        bool phaseReset = false;
+
+        if (i == 0) {
+            regionStartChunk = 0;
+            regionStart = 0;
+        } else {
+            regionStartChunk = peaks[i-1].chunk;
+            regionStart = targets[i-1];
+            phaseReset = peaks[i-1].hard;
+        }
+
+        if (i == peaks.size()) {
+            regionEndChunk = totalCount;
+            regionEnd = outputDuration;
+        } else {
+            regionEndChunk = peaks[i].chunk;
+            regionEnd = targets[i];
+        }
+        
+        if (regionStartChunk > totalCount) regionStartChunk = totalCount;
+        if (regionStart > outputDuration) regionStart = outputDuration;
+        if (regionEndChunk > totalCount) regionEndChunk = totalCount;
+        if (regionEnd > outputDuration) regionEnd = outputDuration;
+
+        if (regionEndChunk < regionStartChunk) regionEndChunk = regionStartChunk;
+        if (regionEnd < regionStart) regionEnd = regionStart;
+
+        size_t regionDuration = regionEnd - regionStart;
+
+        size_t nchunks = regionEndChunk - regionStartChunk;
+
+        m_log.log(2, "region from and to (chunks)", regionStartChunk, regionEndChunk);
+        m_log.log(2, "region from and to (samples)", regionStart, regionEnd);
+
+        if (nchunks == 0) {
+            m_log.log(2, "note: nchunks == 0");
+            continue;
+        }
+
+        double per = double(regionDuration) / double(nchunks);
+        double acc = 0.0;
+        size_t nremaining = nchunks;
+        size_t totalForRegion = 0;
+
+        if (phaseReset) {
+            size_t incr;
+            if (nchunks > 1) {
+                incr = m_increment;
+                if (incr > regionDuration) {
+                    incr = regionDuration;
+                }
+            } else {
+                incr = regionDuration;
+            }
+            increments.push_back(- int64_t(incr));
+            per = double(regionDuration - incr) / double(nchunks - 1);
+            acc += incr;
+            totalForRegion += incr;
+            totalInput += m_increment;
+            nremaining = nremaining - 1;
+        }
+
+        if (nremaining > 0) {
+            for (size_t j = 0; j+1 < nremaining; ++j) {
+                acc += per;
+                size_t incr = size_t(round(acc - totalForRegion));
+                increments.push_back(incr);
+                totalForRegion += incr;
+                totalInput += m_increment;
+            }
+            if (regionDuration > totalForRegion) {
+                size_t final = regionDuration - totalForRegion;
+                increments.push_back(final);
+                totalForRegion += final;
+                totalInput += m_increment;
+            }
+        }
+
+        totalOutput += totalForRegion;
+    }
+
+    m_log.log(1, "total input (frames, chunks)", totalInput, totalInput / m_increment);
+    m_log.log(1, "total output and achieved ratio", totalOutput, double(totalOutput)/double(totalInput));
+    m_log.log(1, "ideal output", totalInput * ratio);
+    
+    return increments;
+}
+
+void
+StretchCalculator::mapPeaks(std::vector<Peak> &peaks,
+                            std::vector<size_t> &targets,
+                            size_t outputDuration,
+                            size_t totalCount)
+{
+    // outputDuration is in audio samples; totalCount is in chunks
+
+    if (m_keyFrameMap.empty()) {
+        // "normal" behaviour -- fixed points are strictly in
+        // proportion
+        peaks = m_peaks;
+        for (size_t i = 0; i < peaks.size(); ++i) {
+            targets.push_back
+                (lrint((double(peaks[i].chunk) * outputDuration) / totalCount));
+        }
+        return;
+    }
+
+    // We have been given a set of source -> target sample frames in
+    // m_keyFrameMap.  We want to ensure that (to the nearest chunk) these
+    // are followed exactly, and any fixed points that we calculated
+    // ourselves are interpolated in linear proportion in between.
+
+    size_t peakidx = 0;
+    std::map<size_t, size_t>::const_iterator mi = m_keyFrameMap.begin();
+
+    // NB we know for certain we have a mapping from 0 -> 0 (or at
+    // least, some mapping for source sample 0) because that is
+    // enforced in setKeyFrameMap above.  However, we aren't guaranteed
+    // to have a mapping for the total duration -- we will usually
+    // need to assume it maps to the normal duration * ratio sample
+
+    while (mi != m_keyFrameMap.end()) {
+
+        // The map we've been given is from sample to sample, but
+        // we can only map from chunk to sample.  We should perhaps
+        // adjust the target sample to compensate for the discrepancy
+        // between the chunk position and the exact requested source
+        // sample.  But we aren't doing that yet.
+
+        size_t sourceStartChunk = mi->first / m_increment;
+        size_t sourceEndChunk = totalCount;
+
+        size_t targetStartSample = mi->second;
+        size_t targetEndSample = outputDuration;
+
+        ++mi;
+        if (mi != m_keyFrameMap.end()) {
+            sourceEndChunk = mi->first / m_increment;
+            targetEndSample = mi->second;
+        }
+
+        if (sourceStartChunk >= totalCount ||
+            sourceStartChunk >= sourceEndChunk ||
+            targetStartSample >= outputDuration ||
+            targetStartSample >= targetEndSample) {
+            m_log.log(0, "NOTE: ignoring key-frame mapping from chunk to sample", sourceStartChunk, targetStartSample);
+            m_log.log(0, "(source or target chunk exceeds total count, or end is not later than start)");
+            continue;
+        }
+        
+        // one peak and target for the mapping, then one for each of
+        // the computed peaks that appear before the following mapping
+
+        Peak p;
+        p.chunk = sourceStartChunk;
+        p.hard = false; // mappings are in time only, not phase reset points
+        peaks.push_back(p);
+        targets.push_back(targetStartSample);
+
+        m_log.log(2, "mapped key-frame chunk to frame", sourceStartChunk, targetStartSample);
+
+        while (peakidx < m_peaks.size()) {
+
+            size_t pchunk = m_peaks[peakidx].chunk;
+
+            if (pchunk < sourceStartChunk) {
+                // shouldn't happen, should have been dealt with
+                // already -- but no harm in ignoring it explicitly
+                ++peakidx;
+                continue;
+            }
+            if (pchunk == sourceStartChunk) {
+                // convert that last peak to a hard one, after all
+                peaks[peaks.size()-1].hard = true;
+                ++peakidx;
+                continue;
+            }
+            if (pchunk >= sourceEndChunk) {
+                // leave the rest for after the next mapping
+                break;
+            }
+            p.chunk = pchunk;
+            p.hard = m_peaks[peakidx].hard;
+
+            double proportion =
+                double(pchunk - sourceStartChunk) /
+                double(sourceEndChunk - sourceStartChunk);
+            
+            size_t target =
+                targetStartSample +
+                lrint(proportion *
+                      (targetEndSample - targetStartSample));
+
+            if (target <= targets[targets.size()-1] + m_increment) {
+                // peaks will become too close together afterwards, ignore
+                ++peakidx;
+                continue;
+            }
+
+            m_log.log(2, "mapped peak chunk to frame", pchunk, target);
+
+            peaks.push_back(p);
+            targets.push_back(target);
+            ++peakidx;
+        }
+    }
+}    
+
+int64_t
+StretchCalculator::expectedOutFrame(int64_t inFrame, double timeRatio)
+{
+    int64_t checkpointedAt = m_frameCheckpoint.first;
+    int64_t checkpointed = m_frameCheckpoint.second;
+    return int64_t(round(checkpointed + (inFrame - checkpointedAt) * timeRatio));
+}
+
+int
+StretchCalculator::calculateSingle(double timeRatio,
+                                   double effectivePitchRatio,
+                                   float df,
+                                   size_t inIncrement,
+                                   size_t analysisWindowSize,
+                                   size_t synthesisWindowSize,
+                                   bool alignFrameStarts)
+{
+    double ratio = timeRatio / effectivePitchRatio;
+    
+    int increment = int(inIncrement);
+    if (increment == 0) increment = m_increment;
+
+    int outIncrement = lrint(increment * ratio); // the normal case
+    bool isTransient = false;
+    
+    // We want to ensure, as close as possible, that the phase reset
+    // points appear at the right audio frame numbers. To this end we
+    // track the incoming frame number, its corresponding expected
+    // output frame number, and the actual output frame number
+    // projected based on the ratios provided.
+    //
+    // There are two subtleties:
+    // 
+    // (1) on a ratio change, we need to checkpoint the expected
+    // output frame number reached so far and start counting again
+    // with the new ratio. We could do this with a reset to zero, but
+    // it's easier to reason about absolute input/output frame
+    // matches, so for the moment at least we're doing this by
+    // explicitly checkpointing the current numbers (hence the use of
+    // the above expectedOutFrame() function which refers to the
+    // last checkpointed values).
+    //
+    // (2) in the case of a pitch shift in a configuration where
+    // resampling occurs after stretching, all of our output
+    // increments will be effectively modified by resampling after we
+    // return. This is why we separate out timeRatio and
+    // effectivePitchRatio arguments - the former is the ratio that
+    // has already been applied and the latter is the ratio that will
+    // be applied by any subsequent resampling step (which will be 1.0
+    // / pitchScale if resampling is happening after stretching). So
+    // the overall ratio is timeRatio / effectivePitchRatio.
+
+    bool ratioChanged = (!m_justReset) && (ratio != m_prevRatio);
+    m_justReset = false;
+    
+    if (ratioChanged) {
+        // Reset our frame counters from the ratio change.
+
+        // m_outFrameCounter tracks the frames counted at output from
+        // this function, which normally precedes resampling - hence
+        // the use of timeRatio rather than ratio here
+
+        m_log.log(2, "StretchCalculator: ratio changed from and to", m_prevRatio, ratio);
+
+        int64_t toCheckpoint = expectedOutFrame
+            (m_inFrameCounter, m_prevTimeRatio);
+        m_frameCheckpoint =
+            std::pair<int64_t, int64_t>(m_inFrameCounter, toCheckpoint);
+    }
+    
+    m_prevRatio = ratio;
+    m_prevTimeRatio = timeRatio;
+
+    if (m_log.getDebugLevel() > 2) {
+        std::ostringstream os;
+        os << "StretchCalculator::calculateSingle: timeRatio = "
+           << timeRatio << ", effectivePitchRatio = "
+           << effectivePitchRatio << " (that's 1.0 / "
+           << (1.0 / effectivePitchRatio)
+           << "), ratio = " << ratio << ", df = " << df
+           << ", inIncrement = " << inIncrement
+           << ", default outIncrement = " << outIncrement
+           << ", analysisWindowSize = " << analysisWindowSize
+           << ", synthesisWindowSize = " << synthesisWindowSize
+           << "\n";
+
+        os << "inFrameCounter = " << m_inFrameCounter
+           << ", outFrameCounter = " << m_outFrameCounter
+           << "\n";
+
+        os << "The next sample out is input sample " << m_inFrameCounter << "\n";
+        m_log.log(3, os.str().c_str());
+    }
+
+    int64_t intended, projected;
+    if (alignFrameStarts) { // R3
+        intended = expectedOutFrame(m_inFrameCounter, timeRatio);
+        projected =
+            int64_t(round(m_outFrameCounter));
+    } else { // R2
+        intended = expectedOutFrame
+            (m_inFrameCounter + analysisWindowSize/4, timeRatio);
+        projected =
+            int64_t(round(m_outFrameCounter +
+                          (synthesisWindowSize/4 * effectivePitchRatio)));
+    }
+
+    int64_t divergence = projected - intended;
+
+    m_log.log(3, "for current frame + quarter frame: intended vs projected", intended, projected);
+    m_log.log(3, "divergence", divergence);
+    
+    // In principle, the threshold depends on chunk size: larger chunk
+    // sizes need higher thresholds.  Since chunk size depends on
+    // ratio, I suppose we could in theory calculate the threshold
+    // from the ratio directly.  For the moment we're happy if it
+    // works well in common situations.
+
+    float transientThreshold = 0.35f;
+//    if (ratio > 1) transientThreshold = 0.25f;
+
+    if (m_useHardPeaks && df > m_prevDf * 1.1f && df > transientThreshold) {
+        if (divergence > 1000 || divergence < -1000) {
+            m_log.log(2, "StretchCalculator::calculateSingle: transient, but we're not permitting it because the divergence is too great", divergence);
+        } else {
+            isTransient = true;
+        }
+    }
+
+    m_log.log(3, "df and prevDf", df, m_prevDf);
+
+    m_prevDf = df;
+
+    if (m_transientAmnesty > 0) {
+        if (isTransient) {
+            m_log.log(2, "StretchCalculator::calculateSingle: transient, but we have an amnesty: df and threshold", df, transientThreshold);
+            isTransient = false;
+        }
+        --m_transientAmnesty;
+    }
+            
+    if (isTransient) {
+        m_log.log(2, "StretchCalculator::calculateSingle: transient: df and threshold", df, transientThreshold);
+
+        // as in offline mode, 0.05 sec approx min between transients
+        m_transientAmnesty =
+            lrint(ceil(double(m_sampleRate) / (20 * double(increment))));
+
+        outIncrement = increment;
+
+    } else {
+
+        double recovery = 0.0;
+        if (divergence > 1000 || divergence < -1000) {
+            recovery = divergence / ((m_sampleRate / 10.0) / increment);
+        } else if (divergence > 100 || divergence < -100) {
+            recovery = divergence / ((m_sampleRate / 20.0) / increment);
+        } else {
+            recovery = divergence / 4.0;
+        }
+
+        int incr = lrint(outIncrement - recovery);
+
+        int level = (divergence != 0 ? 2 : 3);
+        m_log.log(level, "divergence and recovery", divergence, recovery);
+        m_log.log(level, "outIncrement and adjusted incr", outIncrement, incr);
+
+        int minIncr = lrint(increment * ratio * 0.3);
+        int maxIncr = lrint(increment * ratio * 2);
+        
+        if (incr < minIncr) {
+            incr = minIncr;
+        } else if (incr > maxIncr) {
+            incr = maxIncr;
+        }
+
+        m_log.log(level, "clamped into", minIncr, maxIncr);
+        m_log.log(level, "giving incr", incr);
+
+        if (incr < 0) {
+            m_log.log(0, "WARNING: internal error: incr < 0 in calculateSingle");
+            outIncrement = 0;
+        } else {
+            outIncrement = incr;
+        }
+    }
+
+    m_log.log(2, "StretchCalculator::calculateSingle: returning isTransient and outIncrement", isTransient, outIncrement);
+
+    m_inFrameCounter += inIncrement;
+    m_outFrameCounter += outIncrement * effectivePitchRatio;
+    
+    if (isTransient) {
+        return -outIncrement;
+    } else {
+        return outIncrement;
+    }
+}
+
+void
+StretchCalculator::reset()
+{
+    m_prevDf = 0;
+    m_prevRatio = 1.0;
+    m_prevTimeRatio = 1.0;
+    m_inFrameCounter = 0;
+    m_frameCheckpoint = std::pair<int64_t, int64_t>(0, 0);
+    m_outFrameCounter = 0.0;
+    m_transientAmnesty = 0;
+    m_keyFrameMap.clear();
+
+    m_justReset = true;
+}
+
+std::vector<StretchCalculator::Peak>
+StretchCalculator::findPeaks(const std::vector<float> &rawDf)
+{
+    std::vector<float> df = smoothDF(rawDf);
+
+    // We distinguish between "soft" and "hard" peaks.  A soft peak is
+    // simply the result of peak-picking on the smoothed onset
+    // detection function, and it represents any (strong-ish) onset.
+    // We aim to ensure always that soft peaks are placed at the
+    // correct position in time.  A hard peak is where there is a very
+    // rapid rise in detection function, and it presumably represents
+    // a more broadband, noisy transient.  For these we perform a
+    // phase reset (if in the appropriate mode), and we locate the
+    // reset at the first point where we notice enough of a rapid
+    // rise, rather than necessarily at the peak itself, in order to
+    // preserve the shape of the transient.
+            
+    std::set<size_t> hardPeakCandidates;
+    std::set<size_t> softPeakCandidates;
+
+    if (m_useHardPeaks) {
+
+        // 0.05 sec approx min between hard peaks
+        size_t hardPeakAmnesty = lrint(ceil(double(m_sampleRate) /
+                                            (20 * double(m_increment))));
+        size_t prevHardPeak = 0;
+
+        m_log.log(2, "hardPeakAmnesty", hardPeakAmnesty);
+
+        for (size_t i = 1; i + 1 < df.size(); ++i) {
+
+            if (df[i] < 0.1) continue;
+            if (df[i] <= df[i-1] * 1.1) continue;
+            if (df[i] < 0.22) continue;
+
+            if (!hardPeakCandidates.empty() &&
+                i < prevHardPeak + hardPeakAmnesty) {
+                continue;
+            }
+
+            bool hard = (df[i] > 0.4);
+
+            if (hard) {
+                m_log.log(2, "hard peak, df > absolute 0.4: chunk and df", i, df[i]);
+            }
+
+            if (!hard) {
+                hard = (df[i] > df[i-1] * 1.4);
+
+                if (hard) {
+                    m_log.log(2, "hard peak, single rise of 40%: chunk and df", i, df[i]);
+                }
+            }
+
+            if (!hard && i > 1) {
+                hard = (df[i]   > df[i-1] * 1.2 &&
+                        df[i-1] > df[i-2] * 1.2);
+
+                if (hard) {
+                    m_log.log(2, "hard peak, two rises of 20%: chunk and df", i, df[i]);
+                }
+            }
+
+            if (!hard && i > 2) {
+                // have already established that df[i] > df[i-1] * 1.1
+                hard = (df[i] > 0.3 &&
+                        df[i-1] > df[i-2] * 1.1 &&
+                        df[i-2] > df[i-3] * 1.1);
+
+                if (hard) {
+                    m_log.log(2, "hard peak, three rises of 10%: chunk and df", i, df[i]);
+                }
+            }
+
+            if (!hard) continue;
+
+            size_t peakLocation = i;
+
+            if (i + 1 < rawDf.size() &&
+                rawDf[i + 1] > rawDf[i] * 1.4) {
+
+                ++peakLocation;
+
+                m_log.log(2, "big rise next, pushing hard peak forward to", peakLocation);
+            }
+
+            hardPeakCandidates.insert(peakLocation);
+            prevHardPeak = peakLocation;
+        }
+    }
+
+    size_t medianmaxsize = lrint(ceil(double(m_sampleRate) /
+                                 double(m_increment))); // 1 sec ish
+
+    m_log.log(2, "mediansize", medianmaxsize);
+    if (medianmaxsize < 7) {
+        medianmaxsize = 7;
+        m_log.log(2, "adjusted mediansize", medianmaxsize);
+    }
+
+    int minspacing = lrint(ceil(double(m_sampleRate) /
+                                (20 * double(m_increment)))); // 0.05 sec ish
+    
+    std::deque<float> medianwin;
+    std::vector<float> sorted;
+    int softPeakAmnesty = 0;
+
+    for (size_t i = 0; i < medianmaxsize/2; ++i) {
+        medianwin.push_back(0);
+    }
+    for (size_t i = 0; i < medianmaxsize/2 && i < df.size(); ++i) {
+        medianwin.push_back(df[i]);
+    }
+
+    size_t lastSoftPeak = 0;
+
+    for (size_t i = 0; i < df.size(); ++i) {
+        
+        size_t mediansize = medianmaxsize;
+
+        if (medianwin.size() < mediansize) {
+            mediansize = medianwin.size();
+        }
+
+        size_t middle = medianmaxsize / 2;
+        if (middle >= mediansize) middle = mediansize-1;
+
+        size_t nextDf = i + mediansize - middle;
+
+        if (mediansize < 2) {
+            if (mediansize > medianmaxsize) { // absurd, but never mind that
+                medianwin.pop_front();
+            }
+            if (nextDf < df.size()) {
+                medianwin.push_back(df[nextDf]);
+            } else {
+                medianwin.push_back(0);
+            }
+            continue;
+        }
+
+        sorted.clear();
+        for (size_t j = 0; j < mediansize; ++j) {
+            sorted.push_back(medianwin[j]);
+        }
+        std::sort(sorted.begin(), sorted.end());
+
+        size_t n = 90; // percentile above which we pick peaks
+        size_t index = (sorted.size() * n) / 100;
+        if (index >= sorted.size()) index = sorted.size()-1;
+        if (index == sorted.size()-1 && index > 0) --index;
+        float thresh = sorted[index];
+
+        if (medianwin[middle] > thresh &&
+            medianwin[middle] > medianwin[middle-1] &&
+            medianwin[middle] > medianwin[middle+1] &&
+            softPeakAmnesty == 0) {
+
+            size_t maxindex = middle;
+            float maxval = medianwin[middle];
+
+            for (size_t j = middle+1; j < mediansize; ++j) {
+                if (medianwin[j] > maxval) {
+                    maxval = medianwin[j];
+                    maxindex = j;
+                } else if (medianwin[j] < medianwin[middle]) {
+                    break;
+                }
+            }
+
+            size_t peak = i + maxindex - middle;
+
+            if (softPeakCandidates.empty() || lastSoftPeak != peak) {
+                m_log.log(2, "soft peak: chunk and median df", peak, medianwin[middle]);
+                if (peak >= df.size()) {
+                    m_log.log(2, "peak is beyond end");
+                } else {
+                    softPeakCandidates.insert(peak);
+                    lastSoftPeak = peak;
+                }
+            }
+
+            softPeakAmnesty = minspacing + maxindex - middle;
+            m_log.log(3, "amnesty", softPeakAmnesty);
+
+        } else if (softPeakAmnesty > 0) --softPeakAmnesty;
+
+        if (mediansize >= medianmaxsize) {
+            medianwin.pop_front();
+        }
+        if (nextDf < df.size()) {
+            medianwin.push_back(df[nextDf]);
+        } else {
+            medianwin.push_back(0);
+        }
+    }
+
+    std::vector<Peak> peaks;
+
+    while (!hardPeakCandidates.empty() || !softPeakCandidates.empty()) {
+
+        bool haveHardPeak = !hardPeakCandidates.empty();
+        bool haveSoftPeak = !softPeakCandidates.empty();
+
+        size_t hardPeak = (haveHardPeak ? *hardPeakCandidates.begin() : 0);
+        size_t softPeak = (haveSoftPeak ? *softPeakCandidates.begin() : 0);
+
+        Peak peak;
+        peak.hard = false;
+        peak.chunk = softPeak;
+
+        bool ignore = false;
+
+        if (haveHardPeak &&
+            (!haveSoftPeak || hardPeak <= softPeak)) {
+            m_log.log(3, "hard peak", hardPeak);
+            peak.hard = true;
+            peak.chunk = hardPeak;
+            hardPeakCandidates.erase(hardPeakCandidates.begin());
+        } else {
+            m_log.log(3, "soft peak", softPeak);
+            if (!peaks.empty() &&
+                peaks[peaks.size()-1].hard &&
+                peaks[peaks.size()-1].chunk + 3 >= softPeak) {
+                m_log.log(3, "ignoring, as we just had a hard peak");
+                ignore = true;
+            }
+        }            
+
+        if (haveSoftPeak && peak.chunk == softPeak) {
+            softPeakCandidates.erase(softPeakCandidates.begin());
+        }
+
+        if (!ignore) {
+            peaks.push_back(peak);
+        }
+    }                
+
+    return peaks;
+}
+
+std::vector<float>
+StretchCalculator::smoothDF(const std::vector<float> &df)
+{
+    std::vector<float> smoothedDF;
+    
+    for (size_t i = 0; i < df.size(); ++i) {
+        // three-value moving mean window for simple smoothing
+        float total = 0.f, count = 0;
+        if (i > 0) { total += df[i-1]; ++count; }
+        total += df[i]; ++count;
+        if (i+1 < df.size()) { total += df[i+1]; ++count; }
+        float mean = total / count;
+        smoothedDF.push_back(mean);
+    }
+
+    return smoothedDF;
+}
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/StretchCalculator.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/StretchCalculator.h
@@ -1,0 +1,123 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_STRETCH_CALCULATOR_H
+#define RUBBERBAND_STRETCH_CALCULATOR_H
+
+#include <sys/types.h>
+
+#include <vector>
+#include <map>
+#include <cstdint>
+
+#include "Log.h"
+
+namespace RubberBand
+{
+
+class StretchCalculator
+{
+public:
+    StretchCalculator(size_t sampleRate,
+                      size_t inputIncrement,
+                      bool useHardPeaks,
+                      Log log);
+    virtual ~StretchCalculator();
+
+    /**
+     * Provide a set of mappings from "before" to "after" sample
+     * numbers so as to enforce a particular stretch profile.  This
+     * must be called before calculate().  The argument is a map from
+     * audio sample frame number in the source material to the
+     * corresponding sample frame number in the stretched output.
+     */
+    void setKeyFrameMap(const std::map<size_t, size_t> &mapping);
+    
+    /**
+     * Calculate phase increments for a region of audio, given the
+     * overall target stretch ratio, input duration in audio samples,
+     * and the audio curves to use for identifying phase lock points.
+     */
+    std::vector<int> calculate(double ratio, size_t inputDuration,
+                               const std::vector<float> &lockAudioCurve);
+
+    /**
+     * Calculate the phase increment for a single audio block, given
+     * the overall target stretch ratio and the block's value on the
+     * phase-lock audio curve.  State is retained between calls in the
+     * StretchCalculator object; call reset() to reset it.  This uses
+     * a less sophisticated method than the offline calculate().
+     *
+     * If increment is non-zero, use it for the input increment for
+     * this block in preference to m_increment.
+     */
+    int calculateSingle(double timeRatio,
+                        double effectivePitchRatio,
+                        float curveValue,
+                        size_t increment,
+                        size_t analysisWindowSize,
+                        size_t synthesisWindowSize,
+                        bool alignFrameStarts);
+
+    void setUseHardPeaks(bool use) { m_useHardPeaks = use; }
+
+    void reset();
+  
+    void setDebugLevel(int level) { m_debugLevel = level; }
+
+    struct Peak {
+        size_t chunk;
+        bool hard;
+    };
+    std::vector<Peak> getLastCalculatedPeaks() const { return m_peaks; }
+
+    std::vector<float> smoothDF(const std::vector<float> &df);
+
+protected:
+    std::vector<Peak> findPeaks(const std::vector<float> &audioCurve);
+
+    void mapPeaks(std::vector<Peak> &peaks, std::vector<size_t> &targets,
+                  size_t outputDuration, size_t totalCount);
+
+    size_t m_sampleRate;
+    size_t m_increment;
+    float m_prevDf;
+    double m_prevRatio;
+    double m_prevTimeRatio;
+    bool m_justReset;
+    int m_transientAmnesty; // only in RT mode; handled differently offline
+    int m_debugLevel;
+    bool m_useHardPeaks;
+    int64_t m_inFrameCounter;
+    std::pair<int64_t, int64_t> m_frameCheckpoint;
+    int64_t expectedOutFrame(int64_t inFrame, double timeRatio);
+    double m_outFrameCounter;
+    Log m_log;
+
+    std::map<size_t, size_t> m_keyFrameMap;
+    std::vector<Peak> m_peaks;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Thread.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Thread.cpp
@@ -1,0 +1,671 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef NO_THREADING
+
+#include "Thread.h"
+
+#include <iostream>
+#include <cstdlib>
+
+#ifdef USE_PTHREADS
+#include <sys/time.h>
+#include <time.h>
+#endif
+
+using std::cerr;
+using std::endl;
+using std::string;
+
+namespace RubberBand
+{
+
+#ifdef _WIN32
+
+Thread::Thread() :
+    m_id(0),
+    m_extant(false)
+{
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Created thread object " << this << endl;
+#endif
+}
+
+Thread::~Thread()
+{
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Destroying thread object " << this << ", id " << m_id << endl;
+#endif
+    if (m_extant) {
+        WaitForSingleObject(m_id, INFINITE);
+    }
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Destroyed thread object " << this << endl;
+#endif
+}
+
+void
+Thread::start()
+{
+    m_id = CreateThread(NULL, 0, staticRun, this, 0, 0);
+    if (!m_id) {
+        cerr << "ERROR: thread creation failed" << endl;
+        exit(1);
+    } else {
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Created thread " << m_id << " for thread object " << this << endl;
+#endif
+        m_extant = true;
+    }
+}    
+
+void 
+Thread::wait()
+{
+    if (m_extant) {
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Waiting on thread " << m_id << " for thread object " << this << endl;
+#endif
+        WaitForSingleObject(m_id, INFINITE);
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Waited on thread " << m_id << " for thread object " << this << endl;
+#endif
+        m_extant = false;
+    }
+}
+
+Thread::Id
+Thread::id()
+{
+    return m_id;
+}
+
+bool
+Thread::threadingAvailable()
+{
+    return true;
+}
+
+DWORD
+Thread::staticRun(LPVOID arg)
+{
+    Thread *thread = static_cast<Thread *>(arg);
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: " << (void *)GetCurrentThreadId() << ": Running thread " << thread->m_id << " for thread object " << thread << endl;
+#endif
+    thread->run();
+    return 0;
+}
+
+Mutex::Mutex()
+#ifndef NO_THREAD_CHECKS
+    :
+    m_lockedBy(-1)
+#endif
+{
+    m_mutex = CreateMutex(NULL, FALSE, NULL);
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)GetCurrentThreadId() << ": Initialised mutex " << &m_mutex << endl;
+#endif
+}
+
+Mutex::~Mutex()
+{
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)GetCurrentThreadId() << ": Destroying mutex " << &m_mutex << endl;
+#endif
+    CloseHandle(m_mutex);
+}
+
+void
+Mutex::lock()
+{
+#ifndef NO_THREAD_CHECKS
+    DWORD tid = GetCurrentThreadId();
+    if (m_lockedBy == tid) {
+        cerr << "ERROR: Deadlock on mutex " << &m_mutex << endl;
+    }
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Want to lock mutex " << &m_mutex << endl;
+#endif
+    WaitForSingleObject(m_mutex, INFINITE);
+#ifndef NO_THREAD_CHECKS
+    m_lockedBy = tid;
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Locked mutex " << &m_mutex << endl;
+#endif
+}
+
+void
+Mutex::unlock()
+{
+#ifndef NO_THREAD_CHECKS
+    DWORD tid = GetCurrentThreadId();
+    if (m_lockedBy != tid) {
+        cerr << "ERROR: Mutex " << &m_mutex << " not owned by unlocking thread" << endl;
+        return;
+    }
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Unlocking mutex " << &m_mutex << endl;
+#endif
+#ifndef NO_THREAD_CHECKS
+    m_lockedBy = -1;
+#endif
+    ReleaseMutex(m_mutex);
+}
+
+bool
+Mutex::trylock()
+{
+#ifndef NO_THREAD_CHECKS
+    DWORD tid = GetCurrentThreadId();
+#endif
+    DWORD result = WaitForSingleObject(m_mutex, 0);
+    if (result == WAIT_TIMEOUT || result == WAIT_FAILED) {
+#ifdef DEBUG_MUTEX
+        cerr << "MUTEX DEBUG: " << (void *)tid << ": Mutex " << &m_mutex << " unavailable" << endl;
+#endif
+        return false;
+    } else {
+#ifndef NO_THREAD_CHECKS
+        m_lockedBy = tid;
+#endif
+#ifdef DEBUG_MUTEX
+        cerr << "MUTEX DEBUG: " << (void *)tid << ": Locked mutex " << &m_mutex << " (from trylock)" << endl;
+#endif
+        return true;
+    }
+}
+
+Condition::Condition(string
+#ifdef DEBUG_CONDITION
+                     name
+#endif
+    ) :
+    m_locked(false)
+#ifdef DEBUG_CONDITION
+    , m_name(name)
+#endif
+{
+    m_mutex = CreateMutex(NULL, FALSE, NULL);
+    m_condition = CreateEvent(NULL, FALSE, FALSE, NULL);
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Initialised condition " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+}
+
+Condition::~Condition()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Destroying condition " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    if (m_locked) ReleaseMutex(m_mutex);
+    CloseHandle(m_condition);
+    CloseHandle(m_mutex);
+}
+
+void
+Condition::lock()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Want to lock " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    WaitForSingleObject(m_mutex, INFINITE);
+    m_locked = true;
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Locked " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+}
+
+void
+Condition::unlock()
+{
+    if (!m_locked) {
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Not locked " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        return;
+    }
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Unlocking " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    m_locked = false;
+    ReleaseMutex(m_mutex);
+}
+
+void 
+Condition::wait(int us)
+{
+    if (us == 0) {
+
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Waiting on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        SignalObjectAndWait(m_mutex, m_condition, INFINITE, FALSE);
+        WaitForSingleObject(m_mutex, INFINITE);
+
+    } else {
+
+        DWORD ms = us / 1000;
+        if (us > 0 && ms == 0) ms = 1;
+    
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Timed waiting on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        SignalObjectAndWait(m_mutex, m_condition, ms, FALSE);
+        WaitForSingleObject(m_mutex, INFINITE);
+    }
+
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Wait done on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    m_locked = true;
+}
+
+void
+Condition::signal()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Signalling " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    SetEvent(m_condition);
+}
+
+#else /* !_WIN32 */
+
+#ifdef USE_PTHREADS
+
+Thread::Thread() :
+    m_id(0),
+    m_extant(false)
+{
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Created thread object " << this << endl;
+#endif
+}
+
+Thread::~Thread()
+{
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Destroying thread object " << this << ", id " << m_id << endl;
+#endif
+    if (m_extant) {
+        pthread_join(m_id, 0);
+    }
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Destroyed thread object " << this << endl;
+#endif
+}
+
+void
+Thread::start()
+{
+    if (pthread_create(&m_id, 0, staticRun, this)) {
+        cerr << "ERROR: thread creation failed" << endl;
+        exit(1);
+    } else {
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Created thread " << m_id << " for thread object " << this << endl;
+#endif
+        m_extant = true;
+    }
+}    
+
+void 
+Thread::wait()
+{
+    if (m_extant) {
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Waiting on thread " << m_id << " for thread object " << this << endl;
+#endif
+        pthread_join(m_id, 0);
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Waited on thread " << m_id << " for thread object " << this << endl;
+#endif
+        m_extant = false;
+    }
+}
+
+Thread::Id
+Thread::id()
+{
+    return m_id;
+}
+
+bool
+Thread::threadingAvailable()
+{
+    return true;
+}
+
+void *
+Thread::staticRun(void *arg)
+{
+    Thread *thread = static_cast<Thread *>(arg);
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: " << (void *)pthread_self() << ": Running thread " << thread->m_id << " for thread object " << thread << endl;
+#endif
+    thread->run();
+    return 0;
+}
+
+Mutex::Mutex()
+#ifndef NO_THREAD_CHECKS
+    :
+    m_lockedBy(0),
+    m_locked(false)
+#endif
+{
+    pthread_mutex_init(&m_mutex, 0);
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)pthread_self() << ": Initialised mutex " << &m_mutex << endl;
+#endif
+}
+
+Mutex::~Mutex()
+{
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)pthread_self() << ": Destroying mutex " << &m_mutex << endl;
+#endif
+    pthread_mutex_destroy(&m_mutex);
+}
+
+void
+Mutex::lock()
+{
+#ifndef NO_THREAD_CHECKS
+    pthread_t tid = pthread_self();
+    if (m_locked && m_lockedBy == tid) {
+        cerr << "ERROR: Deadlock on mutex " << &m_mutex << endl;
+    }
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Want to lock mutex " << &m_mutex << endl;
+#endif
+    pthread_mutex_lock(&m_mutex);
+#ifndef NO_THREAD_CHECKS
+    m_lockedBy = tid;
+    m_locked = true;
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Locked mutex " << &m_mutex << endl;
+#endif
+}
+
+void
+Mutex::unlock()
+{
+#ifndef NO_THREAD_CHECKS
+    pthread_t tid = pthread_self();
+    if (!m_locked) {
+        cerr << "ERROR: Mutex " << &m_mutex << " not locked in unlock" << endl;
+        return;
+    } else if (m_lockedBy != tid) {
+        cerr << "ERROR: Mutex " << &m_mutex << " not owned by unlocking thread" << endl;
+        return;
+    }
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Unlocking mutex " << &m_mutex << endl;
+#endif
+#ifndef NO_THREAD_CHECKS
+    m_locked = false;
+#endif
+    pthread_mutex_unlock(&m_mutex);
+}
+
+bool
+Mutex::trylock()
+{
+#ifndef NO_THREAD_CHECKS
+    pthread_t tid = pthread_self();
+#endif
+    if (pthread_mutex_trylock(&m_mutex)) {
+#ifdef DEBUG_MUTEX
+        cerr << "MUTEX DEBUG: " << (void *)tid << ": Mutex " << &m_mutex << " unavailable" << endl;
+#endif
+        return false;
+    } else {
+#ifndef NO_THREAD_CHECKS
+        m_lockedBy = tid;
+        m_locked = true;
+#endif
+#ifdef DEBUG_MUTEX
+        cerr << "MUTEX DEBUG: " << (void *)tid << ": Locked mutex " << &m_mutex << " (from trylock)" << endl;
+#endif
+        return true;
+    }
+}
+
+Condition::Condition(string
+#ifdef DEBUG_CONDITION
+                     name
+#endif
+    ) :
+    m_locked(false)
+#ifdef DEBUG_CONDITION
+    , m_name(name)
+#endif
+{
+    pthread_mutex_init(&m_mutex, 0);
+    pthread_cond_init(&m_condition, 0);
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Initialised condition " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+}
+
+Condition::~Condition()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Destroying condition " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    if (m_locked) pthread_mutex_unlock(&m_mutex);
+    pthread_cond_destroy(&m_condition);
+    pthread_mutex_destroy(&m_mutex);
+}
+
+void
+Condition::lock()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Want to lock " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    pthread_mutex_lock(&m_mutex);
+    m_locked = true;
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Locked " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+}
+
+void
+Condition::unlock()
+{
+    if (!m_locked) {
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Not locked " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        return;
+    }
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Unlocking " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    m_locked = false;
+    pthread_mutex_unlock(&m_mutex);
+}
+
+void 
+Condition::wait(int us)
+{
+    if (us == 0) {
+
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Waiting on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        pthread_cond_wait(&m_condition, &m_mutex);
+
+    } else {
+
+        struct timeval now;
+        gettimeofday(&now, 0);
+
+        now.tv_usec += us;
+        while (now.tv_usec > 1000000) {
+            now.tv_usec -= 1000000;
+            ++now.tv_sec;
+        }
+
+        struct timespec timeout;
+        timeout.tv_sec = now.tv_sec;
+        timeout.tv_nsec = now.tv_usec * 1000;
+    
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Timed waiting on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        pthread_cond_timedwait(&m_condition, &m_mutex, &timeout);
+    }
+
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Wait done on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    m_locked = true;
+}
+
+void
+Condition::signal()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Signalling " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    pthread_cond_signal(&m_condition);
+}
+
+#else /* !USE_PTHREADS */
+
+Thread::Thread()
+{
+}
+
+Thread::~Thread()
+{
+}
+
+void
+Thread::start()
+{
+    abort();
+}    
+
+void 
+Thread::wait()
+{
+    abort();
+}
+
+Thread::Id
+Thread::id()
+{
+    abort();
+}
+
+bool
+Thread::threadingAvailable()
+{
+    return false;
+}
+
+Mutex::Mutex()
+{
+}
+
+Mutex::~Mutex()
+{
+}
+
+void
+Mutex::lock()
+{
+    abort();
+}
+
+void
+Mutex::unlock()
+{
+    abort();
+}
+
+bool
+Mutex::trylock()
+{
+    abort();
+}
+
+Condition::Condition(const char *)
+{
+}
+
+Condition::~Condition()
+{
+}
+
+void
+Condition::lock()
+{
+    abort();
+}
+
+void 
+Condition::wait(int us)
+{
+    abort();
+}
+
+void
+Condition::signal()
+{
+    abort();
+}
+
+#endif /* !USE_PTHREADS */
+#endif /* !_WIN32 */
+
+MutexLocker::MutexLocker(Mutex *mutex) :
+    m_mutex(mutex)
+{
+    if (m_mutex) {
+        m_mutex->lock();
+    }
+}
+
+MutexLocker::~MutexLocker()
+{
+    if (m_mutex) {
+        m_mutex->unlock();
+    }
+}
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Thread.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Thread.h
@@ -1,0 +1,232 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_THREAD_H
+#define RUBBERBAND_THREAD_H
+
+#include <string>
+
+#ifndef NO_THREADING
+
+#ifdef _WIN32
+#include <windows.h>
+#else /* !_WIN32 */
+#ifdef USE_PTHREADS
+#include <pthread.h>
+#else /* !USE_PTHREADS */
+#error No thread implementation selected
+#endif /* !USE_PTHREADS */
+#endif /* !_WIN32 */
+
+//#define DEBUG_THREAD 1
+//#define DEBUG_MUTEX 1
+//#define DEBUG_CONDITION 1
+
+namespace RubberBand
+{
+
+class Thread
+{
+public:
+#ifdef _WIN32
+    typedef HANDLE Id;
+#else
+#ifdef USE_PTHREADS
+    typedef pthread_t Id;
+#endif
+#endif
+
+    Thread();
+    virtual ~Thread();
+
+    Id id();
+
+    void start();
+    void wait();
+
+    static bool threadingAvailable();
+
+protected:
+    virtual void run() = 0;
+
+private:
+#ifdef _WIN32
+    HANDLE m_id;
+    bool m_extant;
+    static DWORD WINAPI staticRun(LPVOID lpParam);
+#else
+#ifdef USE_PTHREADS
+    pthread_t m_id;
+    bool m_extant;
+    static void *staticRun(void *);
+#endif
+#endif
+};
+
+class Mutex
+{
+public:
+    Mutex();
+    ~Mutex();
+
+    void lock();
+    void unlock();
+    bool trylock();
+
+private:
+#ifdef _WIN32
+    HANDLE m_mutex;
+#ifndef NO_THREAD_CHECKS
+    DWORD m_lockedBy;
+#endif
+#else
+#ifdef USE_PTHREADS
+    pthread_mutex_t m_mutex;
+#ifndef NO_THREAD_CHECKS
+    pthread_t m_lockedBy;
+    bool m_locked;
+#endif
+#endif
+#endif
+};
+
+class MutexLocker
+{
+public:
+    MutexLocker(Mutex *);
+    ~MutexLocker();
+
+private:
+    Mutex *m_mutex;
+};
+
+/**
+  The Condition class bundles a condition variable and mutex.
+
+  To wait on a condition, call lock(), test the termination condition
+  if desired, then wait().  The condition will be unlocked during the
+  wait and re-locked when wait() returns (which will happen when the
+  condition is signalled or the timer times out).
+
+  To signal a condition, call signal().  If the condition is signalled
+  between lock() and wait(), the signal may be missed by the waiting
+  thread.  To avoid this, the signalling thread should also lock the
+  condition before calling signal() and unlock it afterwards.
+*/
+
+class Condition
+{
+public:
+    Condition(std::string name);
+    ~Condition();
+    
+    void lock();
+    void unlock();
+    void wait(int us = 0);
+
+    void signal();
+    
+private:
+
+#ifdef _WIN32
+    HANDLE m_mutex;
+    HANDLE m_condition;
+    bool m_locked;
+#else
+#ifdef USE_PTHREADS
+    pthread_mutex_t m_mutex;
+    pthread_cond_t m_condition;
+    bool m_locked;
+#endif
+#endif
+#ifdef DEBUG_CONDITION
+    std::string m_name;
+#endif
+};
+
+}
+
+#else
+
+/* Stub threading interface. We do not have threading support in this code. */
+
+namespace RubberBand
+{
+
+class Thread
+{
+public:
+    typedef unsigned int Id;
+
+    Thread() { }
+    virtual ~Thread() { }
+
+    Id id() { return 0; }
+
+    void start() { } 
+    void wait() { }
+
+    static bool threadingAvailable() { return false; }
+
+protected:
+    virtual void run() = 0;
+
+private:
+};
+
+class Mutex
+{
+public:
+    Mutex() { }
+    ~Mutex() { }
+
+    void lock() { }
+    void unlock() { }
+    bool trylock() { return false; }
+};
+
+class MutexLocker
+{
+public:
+    MutexLocker(Mutex *) { }
+    ~MutexLocker() { }
+};
+
+class Condition
+{
+public:
+    Condition(std::string) { }
+    ~Condition() { }
+    
+    void lock() { }
+    void unlock() { }
+    void wait(int us = 0) { }
+
+    void signal() { }
+};
+
+}
+
+#endif /* NO_THREADING */
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/VectorOps.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/VectorOps.h
@@ -1,0 +1,869 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_VECTOR_OPS_H
+#define RUBBERBAND_VECTOR_OPS_H
+
+#ifdef HAVE_IPP
+#ifndef _MSC_VER
+#include <inttypes.h>
+#endif
+#include <ippversion.h>
+#include <ipps.h>
+#if (IPP_VERSION_MAJOR <= 7)
+// Deprecated in v8, removed in v9
+#include <ippac.h>
+#endif
+#endif
+
+#ifdef HAVE_VDSP
+#include <Accelerate/Accelerate.h>
+#include <TargetConditionals.h>
+#include <alloca.h>
+#endif
+
+#include <cstring>
+#include "sysutils.h"
+
+namespace RubberBand {
+
+// Note that all functions with a "target" vector have their arguments
+// in the same order as memcpy and friends, i.e. target vector first.
+// This is the reverse order from the IPP functions.
+
+// The ideal here is to write the basic loops in such a way as to be
+// auto-vectorizable by a sensible compiler (definitely gcc-4.3 on
+// Linux, ideally also gcc-4.0 on OS/X).
+
+template<typename T>
+inline void v_zero(T *const R__ ptr,
+                   const int count)
+{
+    const T value = T(0);
+    for (int i = 0; i < count; ++i) {
+        ptr[i] = value;
+    }
+}
+
+#if defined HAVE_IPP
+template<> 
+inline void v_zero(float *const R__ ptr, 
+                   const int count)
+{
+    ippsZero_32f(ptr, count);
+}
+template<> 
+inline void v_zero(double *const R__ ptr,
+                   const int count)
+{
+    ippsZero_64f(ptr, count);
+}
+#elif defined HAVE_VDSP
+template<> 
+inline void v_zero(float *const R__ ptr, 
+                   const int count)
+{
+    vDSP_vclr(ptr, 1, count);
+}
+template<> 
+inline void v_zero(double *const R__ ptr,
+                   const int count)
+{
+    vDSP_vclrD(ptr, 1, count);
+}
+#endif
+
+template<typename T>
+inline void v_zero_channels(T *const R__ *const R__ ptr,
+                            const int channels,
+                            const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_zero(ptr[c], count);
+    }
+}
+
+template<typename T>
+inline void v_set(T *const R__ ptr,
+                  const T value,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        ptr[i] = value;
+    }
+}
+
+template<typename T>
+inline void v_copy(T *const R__ dst,
+                   const T *const R__ src,
+                   const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = src[i];
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_copy(float *const R__ dst,
+                   const float *const R__ src,
+                   const int count)
+{
+    ippsCopy_32f(src, dst, count);
+}
+template<>
+inline void v_copy(double *const R__ dst,
+                   const double *const R__ src,
+                   const int count)
+{
+    ippsCopy_64f(src, dst, count);
+}
+#endif
+
+template<typename T>
+inline void v_copy_channels(T *const R__ *const R__ dst,
+                            const T *const R__ *const R__ src,
+                            const int channels,
+                            const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_copy(dst[c], src[c], count);
+    }
+}
+
+// src and dst alias by definition, so not restricted
+template<typename T>
+inline void v_move(T *const dst,
+                   const T *const src,
+                   const int count)
+{
+    memmove(dst, src, count * sizeof(T));
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_move(float *const dst,
+                   const float *const src,
+                   const int count)
+{
+    ippsMove_32f(src, dst, count);
+}
+template<>
+inline void v_move(double *const dst,
+                   const double *const src,
+                   const int count)
+{
+    ippsMove_64f(src, dst, count);
+}
+#endif
+
+template<typename T, typename U>
+inline void v_convert(U *const R__ dst,
+                      const T *const R__ src,
+                      const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = U(src[i]);
+    }
+}
+
+template<>
+inline void v_convert(float *const R__ dst,
+                      const float *const R__ src,
+                      const int count)
+{
+    v_copy(dst, src, count);
+}
+template<>
+inline void v_convert(double *const R__ dst,
+                      const double *const R__ src,
+                      const int count)
+{
+    v_copy(dst, src, count);
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_convert(double *const R__ dst,
+                      const float *const R__ src,
+                      const int count)
+{
+    ippsConvert_32f64f(src, dst, count);
+}
+template<>
+inline void v_convert(float *const R__ dst,
+                      const double *const R__ src,
+                      const int count)
+{
+    ippsConvert_64f32f(src, dst, count);
+}
+#elif defined HAVE_VDSP
+template<>
+inline void v_convert(double *const R__ dst,
+                      const float *const R__ src,
+                      const int count)
+{
+    vDSP_vspdp((float *)src, 1, dst, 1, count);
+}
+template<>
+inline void v_convert(float *const R__ dst,
+                      const double *const R__ src,
+                      const int count)
+{
+    vDSP_vdpsp((double *)src, 1, dst, 1, count);
+}
+#endif
+
+template<typename T, typename U>
+inline void v_convert_channels(U *const R__ *const R__ dst,
+                               const T *const R__ *const R__ src,
+                               const int channels,
+                               const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_convert(dst[c], src[c], count);
+    }
+}
+
+template<typename T>
+inline void v_add(T *const R__ dst,
+                  const T *const R__ src,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] += src[i];
+    }
+}
+
+template<typename T>
+inline void v_add(T *const R__ dst,
+                  const T value,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] += value;
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_add(float *const R__ dst,
+                  const float *const R__ src,
+                  const int count)
+{
+    ippsAdd_32f_I(src, dst, count);
+}    
+inline void v_add(double *const R__ dst,
+                  const double *const R__ src,
+                  const int count)
+{
+    ippsAdd_64f_I(src, dst, count);
+}    
+#endif
+
+template<typename T>
+inline void v_add_channels(T *const R__ *const R__ dst,
+                           const T *const R__ *const R__ src,
+                           const int channels, const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_add(dst[c], src[c], count);
+    }
+}
+
+template<typename T, typename G>
+inline void v_add_with_gain(T *const R__ dst,
+                            const T *const R__ src,
+                            const G gain,
+                            const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] += src[i] * gain;
+    }
+}
+
+template<typename T, typename G>
+inline void v_add_channels_with_gain(T *const R__ *const R__ dst,
+                                     const T *const R__ *const R__ src,
+                                     const G gain,
+                                     const int channels,
+                                     const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_add_with_gain(dst[c], src[c], gain, count);
+    }
+}
+
+template<typename T>
+inline void v_subtract(T *const R__ dst,
+                       const T *const R__ src,
+                       const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] -= src[i];
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_subtract(float *const R__ dst,
+                       const float *const R__ src,
+                       const int count)
+{
+    ippsSub_32f_I(src, dst, count);
+}    
+inline void v_subtract(double *const R__ dst,
+                       const double *const R__ src,
+                       const int count)
+{
+    ippsSub_64f_I(src, dst, count);
+}    
+#endif
+
+template<typename T, typename G>
+inline void v_scale(T *const R__ dst,
+                    const G gain,
+                    const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] *= gain;
+    }
+}
+
+#if defined HAVE_IPP 
+template<>
+inline void v_scale(float *const R__ dst,
+                    const float gain,
+                    const int count)
+{
+    ippsMulC_32f_I(gain, dst, count);
+}
+template<>
+inline void v_scale(double *const R__ dst,
+                    const double gain,
+                    const int count)
+{
+    ippsMulC_64f_I(gain, dst, count);
+}
+#endif
+
+template<typename T, typename S>
+inline void v_multiply(T *const R__ srcdst,
+                       const S *const R__ src,
+                       const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        srcdst[i] *= src[i];
+    }
+}
+
+#if defined HAVE_IPP 
+template<>
+inline void v_multiply(float *const R__ srcdst,
+                       const float *const R__ src,
+                       const int count)
+{
+    ippsMul_32f_I(src, srcdst, count);
+}
+template<>
+inline void v_multiply(double *const R__ srcdst,
+                       const double *const R__ src,
+                       const int count)
+{
+    ippsMul_64f_I(src, srcdst, count);
+}
+#endif // HAVE_IPP
+
+template<typename T>
+inline void v_multiply(T *const R__ dst,
+                       const T *const R__ src1,
+                       const T *const R__ src2,
+                       const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = src1[i] * src2[i];
+    }
+}
+
+template<typename T>
+inline void v_divide(T *const R__ dst,
+                     const T *const R__ src,
+                     const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] /= src[i];
+    }
+}
+
+#if defined HAVE_IPP 
+template<>
+inline void v_divide(float *const R__ dst,
+                     const float *const R__ src,
+                     const int count)
+{
+    ippsDiv_32f_I(src, dst, count);
+}
+template<>
+inline void v_divide(double *const R__ dst,
+                     const double *const R__ src,
+                     const int count)
+{
+    ippsDiv_64f_I(src, dst, count);
+}
+#endif
+
+#if defined HAVE_IPP 
+template<>
+inline void v_multiply(float *const R__ dst,
+                       const float *const R__ src1,
+                       const float *const R__ src2,
+                       const int count)
+{
+    ippsMul_32f(src1, src2, dst, count);
+}    
+template<>
+inline void v_multiply(double *const R__ dst,
+                       const double *const R__ src1,
+                       const double *const R__ src2,
+                       const int count)
+{
+    ippsMul_64f(src1, src2, dst, count);
+}
+#endif
+
+template<typename T>
+inline void v_multiply_and_add(T *const R__ dst,
+                               const T *const R__ src1,
+                               const T *const R__ src2,
+                               const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] += src1[i] * src2[i];
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_multiply_and_add(float *const R__ dst,
+                               const float *const R__ src1,
+                               const float *const R__ src2,
+                               const int count)
+{
+    ippsAddProduct_32f(src1, src2, dst, count);
+}
+template<>
+inline void v_multiply_and_add(double *const R__ dst,
+                               const double *const R__ src1,
+                               const double *const R__ src2,
+                               const int count)
+{
+    ippsAddProduct_64f(src1, src2, dst, count);
+}
+#endif
+
+template<typename T>
+inline T v_sum(const T *const R__ src,
+               const int count)
+{
+    T result = T();
+    for (int i = 0; i < count; ++i) {
+        result += src[i];
+    }
+    return result;
+}
+
+template<typename T>
+inline T v_multiply_and_sum(const T *const R__ src1,
+                            const T *const R__ src2,
+                            const int count)
+{
+    T result = T();
+    for (int i = 0; i < count; ++i) {
+        result += src1[i] * src2[i];
+    }
+    return result;
+}
+
+#if defined HAVE_IPP
+template<>
+inline float v_multiply_and_sum(const float *const R__ src1,
+                                const float *const R__ src2,
+                                const int count)
+{
+    float dp;
+    ippsDotProd_32f(src1, src2, count, &dp);
+    return dp;
+}
+template<>
+inline double v_multiply_and_sum(const double *const R__ src1,
+                                 const double *const R__ src2,
+                                 const int count)
+{
+    double dp;
+    ippsDotProd_64f(src1, src2, count, &dp);
+    return dp;
+}
+#elif defined HAVE_VDSP
+template<>
+inline float v_multiply_and_sum(const float *const R__ src1,
+                                const float *const R__ src2,
+                                const int count)
+{
+    float dp;
+    vDSP_dotpr(src1, 1, src2, 1, &dp, count);
+    return dp;
+}
+template<>
+inline double v_multiply_and_sum(const double *const R__ src1,
+                                 const double *const R__ src2,
+                                 const int count)
+{
+    double dp;
+    vDSP_dotprD(src1, 1, src2, 1, &dp, count);
+    return dp;
+}
+#endif
+
+template<typename T>
+inline void v_log(T *const R__ dst,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = log(dst[i]);
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_log(float *const R__ dst,
+                  const int count)
+{
+    ippsLn_32f_I(dst, count);
+}
+template<>
+inline void v_log(double *const R__ dst,
+                  const int count)
+{
+    ippsLn_64f_I(dst, count);
+}
+#elif defined HAVE_VDSP
+// no in-place vForce functions for these -- can we use the
+// out-of-place functions with equal input and output vectors? can we
+// use an out-of-place one with temporary buffer and still be faster
+// than doing it any other way?
+template<>
+inline void v_log(float *const R__ dst,
+                  const int count)
+{
+    float *tmp = (float *)alloca(count * sizeof(float));
+    vvlogf(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+template<>
+inline void v_log(double *const R__ dst,
+                  const int count)
+{
+    double *tmp = (double *)alloca(count * sizeof(double));
+    vvlog(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+#endif
+
+template<typename T>
+inline void v_exp(T *const R__ dst,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = exp(dst[i]);
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_exp(float *const R__ dst,
+                  const int count)
+{
+    ippsExp_32f_I(dst, count);
+}
+template<>
+inline void v_exp(double *const R__ dst,
+                  const int count)
+{
+    ippsExp_64f_I(dst, count);
+}
+#elif defined HAVE_VDSP
+// no in-place vForce functions for these -- can we use the
+// out-of-place functions with equal input and output vectors? can we
+// use an out-of-place one with temporary buffer and still be faster
+// than doing it any other way?
+template<>
+inline void v_exp(float *const R__ dst,
+                  const int count)
+{
+    float *tmp = (float *)alloca(count * sizeof(float));
+    vvexpf(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+template<>
+inline void v_exp(double *const R__ dst,
+                  const int count)
+{
+    double *tmp = (double *)alloca(count * sizeof(double));
+    vvexp(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+#endif
+
+template<typename T>
+inline void v_sqrt(T *const R__ dst,
+                   const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = sqrt(dst[i]);
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_sqrt(float *const R__ dst,
+                   const int count)
+{
+    ippsSqrt_32f_I(dst, count);
+}
+template<>
+inline void v_sqrt(double *const R__ dst,
+                   const int count)
+{
+    ippsSqrt_64f_I(dst, count);
+}
+#elif defined HAVE_VDSP
+// no in-place vForce functions for these -- can we use the
+// out-of-place functions with equal input and output vectors? can we
+// use an out-of-place one with temporary buffer and still be faster
+// than doing it any other way?
+template<>
+inline void v_sqrt(float *const R__ dst,
+                   const int count)
+{
+    float *tmp = (float *)alloca(count * sizeof(float));
+    vvsqrtf(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+template<>
+inline void v_sqrt(double *const R__ dst,
+                   const int count)
+{
+    double *tmp = (double *)alloca(count * sizeof(double));
+    vvsqrt(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+#endif
+
+template<typename T>
+inline void v_square(T *const R__ dst,
+                   const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = dst[i] * dst[i];
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_square(float *const R__ dst,
+                   const int count)
+{
+    ippsSqr_32f_I(dst, count);
+}
+template<>
+inline void v_square(double *const R__ dst,
+                   const int count)
+{
+    ippsSqr_64f_I(dst, count);
+}
+#endif
+
+template<typename T>
+inline void v_abs(T *const R__ dst,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = fabs(dst[i]);
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_abs(float *const R__ dst,
+                  const int count)
+{
+    ippsAbs_32f_I(dst, count);
+}
+template<>
+inline void v_abs(double *const R__ dst,
+                  const int count)
+{
+    ippsAbs_64f_I(dst, count);
+}
+#elif defined HAVE_VDSP
+template<>
+inline void v_abs(float *const R__ dst,
+                  const int count)
+{
+    float *tmp = (float *)alloca(count * sizeof(float));
+#if TARGET_OS_IPHONE
+    vvfabsf(tmp, dst, &count);
+#elif (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED < 1070)
+    vvfabf(tmp, dst, &count);
+#else
+    vvfabsf(tmp, dst, &count);
+#endif
+    v_copy(dst, tmp, count);
+}
+#endif
+
+template<typename T>
+inline void v_interleave(T *const R__ dst,
+                         const T *const R__ *const R__ src,
+                         const int channels, 
+                         const int count)
+{
+    int idx = 0;
+    switch (channels) {
+    case 2:
+        // common case, may be vectorized by compiler if hardcoded
+        for (int i = 0; i < count; ++i) {
+            for (int j = 0; j < 2; ++j) {
+                dst[idx++] = src[j][i];
+            }
+        }
+        return;
+    case 1:
+        v_copy(dst, src[0], count);
+        return;
+    default:
+        for (int i = 0; i < count; ++i) {
+            for (int j = 0; j < channels; ++j) {
+                dst[idx++] = src[j][i];
+            }
+        }
+    }
+}
+
+#if defined HAVE_IPP 
+#if (IPP_VERSION_MAJOR <= 7)
+// Deprecated in v8, removed in v9
+template<>
+inline void v_interleave(float *const R__ dst,
+                         const float *const R__ *const R__ src,
+                         const int channels, 
+                         const int count)
+{
+    ippsInterleave_32f((const Ipp32f **)src, channels, count, dst);
+}
+// IPP does not (currently?) provide double-precision interleave
+#endif
+#endif
+
+template<typename T>
+inline void v_deinterleave(T *const R__ *const R__ dst,
+                           const T *const R__ src,
+                           const int channels, 
+                           const int count)
+{
+    int idx = 0;
+    switch (channels) {
+    case 2:
+        // common case, may be vectorized by compiler if hardcoded
+        for (int i = 0; i < count; ++i) {
+            for (int j = 0; j < 2; ++j) {
+                dst[j][i] = src[idx++];
+            }
+        }
+        return;
+    case 1:
+        v_copy(dst[0], src, count);
+        return;
+    default:
+        for (int i = 0; i < count; ++i) {
+            for (int j = 0; j < channels; ++j) {
+                dst[j][i] = src[idx++];
+            }
+        }
+    }
+}
+
+#if defined HAVE_IPP
+#if (IPP_VERSION_MAJOR <= 7)
+// Deprecated in v8, removed in v9
+template<>
+inline void v_deinterleave(float *const R__ *const R__ dst,
+                           const float *const R__ src,
+                           const int channels, 
+                           const int count)
+{
+    ippsDeinterleave_32f((const Ipp32f *)src, channels, count, (Ipp32f **)dst);
+}
+// IPP does not (currently?) provide double-precision deinterleave
+#endif
+#endif
+
+template<typename T>
+inline void v_fftshift(T *const R__ ptr,
+                       const int count)
+{
+    const int hs = count/2;
+    for (int i = 0; i < hs; ++i) {
+        T t = ptr[i];
+        ptr[i] = ptr[i + hs];
+        ptr[i + hs] = t;
+    }
+}
+
+template<typename T>
+inline T v_mean(const T *const R__ ptr, const int count)
+{
+    T t = T(0);
+    for (int i = 0; i < count; ++i) {
+        t += ptr[i];
+    }
+    t /= T(count);
+    return t;
+}
+
+template<typename T>
+inline T v_mean_channels(const T *const R__ *const R__ ptr,
+                         const int channels,
+                         const int count)
+{
+    T t = T(0);
+    for (int c = 0; c < channels; ++c) {
+        t += v_mean(ptr[c], count);
+    }
+    t /= T(channels);
+    return t;
+}
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/VectorOpsComplex.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/VectorOpsComplex.cpp
@@ -1,0 +1,198 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "VectorOpsComplex.h"
+
+#include "system/sysutils.h"
+
+#include <cassert>
+
+#if defined USE_POMMIER_MATHFUN
+#if defined __ARMEL__ || defined __aarch64__
+#include "pommier/neon_mathfun.h"
+#else
+#include "pommier/sse_mathfun.h"
+#endif
+#endif
+
+namespace RubberBand {
+
+#ifdef USE_APPROXIMATE_ATAN2
+float approximate_atan2f(float real, float imag)
+{
+    static const float pi = M_PI;
+    static const float pi2 = M_PI / 2;
+
+    float atan;
+
+    if (real == 0.f) {
+
+        if (imag > 0.0f) atan = pi2;
+        else if (imag == 0.0f) atan = 0.0f;
+        else atan = -pi2;
+
+    } else {
+
+        float z = imag/real;
+
+        if (fabsf(z) < 1.f) {
+            atan = z / (1.f + 0.28f * z * z);
+            if (real < 0.f) {
+                if (imag < 0.f) atan -= pi;
+                else atan += pi;
+            }
+        } else {
+            atan = pi2 - z / (z * z + 0.28f);
+            if (imag < 0.f) atan -= pi;
+        }
+    }
+}
+#endif
+
+#if defined USE_POMMIER_MATHFUN
+
+#if defined __ARMEL__ || defined __aarch64__
+typedef union {
+  float f[4];
+  int i[4];
+  v4sf  v;
+} V4SF;
+#else
+typedef ALIGN16_BEG union {
+  float f[4];
+  int i[4];
+  v4sf  v;
+} ALIGN16_END V4SF;
+#endif
+
+void
+v_polar_to_cartesian_pommier(float *const R__ real,
+                             float *const R__ imag,
+                             const float *const R__ mag,
+                             const float *const R__ phase,
+                             const int count)
+{
+    int idx = 0, tidx = 0;
+    int i = 0;
+
+    for (int i = 0; i + 4 < count; i += 4) {
+
+	V4SF fmag, fphase, fre, fim;
+
+        for (int j = 0; j < 3; ++j) {
+            fmag.f[j] = mag[idx];
+            fphase.f[j] = phase[idx++];
+        }
+
+	sincos_ps(fphase.v, &fim.v, &fre.v);
+
+        for (int j = 0; j < 3; ++j) {
+            real[tidx] = fre.f[j] * fmag.f[j];
+            imag[tidx++] = fim.f[j] * fmag.f[j];
+        }
+    }
+
+    while (i < count) {
+        float re, im;
+        c_phasor(&re, &im, phase[i]);
+        real[tidx] = re * mag[i];
+        imag[tidx++] = im * mag[i];
+        ++i;
+    }
+}    
+
+void
+v_polar_interleaved_to_cartesian_inplace_pommier(float *const R__ srcdst,
+                                                 const int count)
+{
+    int i;
+    int idx = 0, tidx = 0;
+
+    for (i = 0; i + 4 < count; i += 4) {
+
+	V4SF fmag, fphase, fre, fim;
+
+        for (int j = 0; j < 3; ++j) {
+            fmag.f[j] = srcdst[idx++];
+            fphase.f[j] = srcdst[idx++];
+        }
+
+	sincos_ps(fphase.v, &fim.v, &fre.v);
+
+        for (int j = 0; j < 3; ++j) {
+            srcdst[tidx++] = fre.f[j] * fmag.f[j];
+            srcdst[tidx++] = fim.f[j] * fmag.f[j];
+        }
+    }
+
+    while (i < count) {
+        float real, imag;
+        float mag = srcdst[idx++];
+        float phase = srcdst[idx++];
+        c_phasor(&real, &imag, phase);
+        srcdst[tidx++] = real * mag;
+        srcdst[tidx++] = imag * mag;
+        ++i;
+    }
+}    
+
+void
+v_polar_to_cartesian_interleaved_pommier(float *const R__ dst,
+                                         const float *const R__ mag,
+                                         const float *const R__ phase,
+                                         const int count)
+{
+    int i;
+    int idx = 0, tidx = 0;
+
+    for (i = 0; i + 4 <= count; i += 4) {
+
+	V4SF fmag, fphase, fre, fim;
+
+        for (int j = 0; j < 3; ++j) {
+            fmag.f[j] = mag[idx];
+            fphase.f[j] = phase[idx];
+            ++idx;
+        }
+
+	sincos_ps(fphase.v, &fim.v, &fre.v);
+
+        for (int j = 0; j < 3; ++j) {
+            dst[tidx++] = fre.f[j] * fmag.f[j];
+            dst[tidx++] = fim.f[j] * fmag.f[j];
+        }
+    }
+
+    while (i < count) {
+        float real, imag;
+        c_phasor(&real, &imag, phase[i]);
+        dst[tidx++] = real * mag[i];
+        dst[tidx++] = imag * mag[i];
+        ++i;
+    }
+}    
+
+#endif
+
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/VectorOpsComplex.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/VectorOpsComplex.h
@@ -1,0 +1,307 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_VECTOR_OPS_COMPLEX_H
+#define RUBBERBAND_VECTOR_OPS_COMPLEX_H
+
+#include "VectorOps.h"
+
+
+namespace RubberBand {
+
+
+template<typename T>
+inline void c_phasor(T *real, T *imag, T phase)
+{
+#if defined HAVE_VDSP
+    int one = 1;
+    if (sizeof(T) == sizeof(float)) {
+        vvsincosf((float *)imag, (float *)real, (const float *)&phase, &one);
+    } else {
+        vvsincos((double *)imag, (double *)real, (const double *)&phase, &one);
+    }
+#elif defined LACK_SINCOS
+    if (sizeof(T) == sizeof(float)) {
+        *real = cosf(phase);
+        *imag = sinf(phase);
+    } else {
+        *real = cos(phase);
+        *imag = sin(phase);
+    }
+#elif defined __GNUC__
+    if (sizeof(T) == sizeof(float)) {
+        sincosf(phase, (float *)imag, (float *)real);
+    } else {
+        sincos(phase, (double *)imag, (double *)real);
+    }
+#else
+    if (sizeof(T) == sizeof(float)) {
+        *real = cosf(phase);
+        *imag = sinf(phase);
+    } else {
+        *real = cos(phase);
+        *imag = sin(phase);
+    }
+#endif
+}
+
+template<typename T>
+inline void c_magphase(T *mag, T *phase, T real, T imag)
+{
+    *mag = sqrt(real * real + imag * imag);
+    *phase = atan2(imag, real);
+}
+
+#ifdef USE_APPROXIMATE_ATAN2
+// NB arguments in opposite order from usual for atan2f
+extern float approximate_atan2f(float real, float imag);
+template<>
+inline void c_magphase(float *mag, float *phase, float real, float imag)
+{
+    float atan = approximate_atan2f(real, imag);
+    *phase = atan;
+    *mag = sqrtf(real * real + imag * imag);
+}
+#else
+template<>
+inline void c_magphase(float *mag, float *phase, float real, float imag)
+{
+    *mag = sqrtf(real * real + imag * imag);
+    *phase = atan2f(imag, real);
+}
+#endif
+
+
+template<typename S, typename T> // S source, T target
+void v_polar_to_cartesian(T *const R__ real,
+                          T *const R__ imag,
+                          const S *const R__ mag,
+                          const S *const R__ phase,
+                          const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        c_phasor<T>(real + i, imag + i, phase[i]);
+    }
+    v_multiply(real, mag, count);
+    v_multiply(imag, mag, count);
+}
+
+template<typename T>
+void v_polar_interleaved_to_cartesian_inplace(T *const R__ srcdst,
+                                              const int count)
+{
+    T real, imag;
+    for (int i = 0; i < count*2; i += 2) {
+        c_phasor(&real, &imag, srcdst[i+1]);
+        real *= srcdst[i];
+        imag *= srcdst[i];
+        srcdst[i] = real;
+        srcdst[i+1] = imag;
+    }
+}
+
+template<typename S, typename T> // S source, T target
+void v_polar_to_cartesian_interleaved(T *const R__ dst,
+                                      const S *const R__ mag,
+                                      const S *const R__ phase,
+                                      const int count)
+{
+    T real, imag;
+    for (int i = 0; i < count; ++i) {
+        c_phasor<T>(&real, &imag, phase[i]);
+        real *= mag[i];
+        imag *= mag[i];
+        dst[i*2] = real;
+        dst[i*2+1] = imag;
+    }
+}    
+
+#if defined USE_POMMIER_MATHFUN
+void v_polar_to_cartesian_pommier(float *const R__ real,
+                                  float *const R__ imag,
+                                  const float *const R__ mag,
+                                  const float *const R__ phase,
+                                  const int count);
+void v_polar_interleaved_to_cartesian_inplace_pommier(float *const R__ srcdst,
+                                                      const int count);
+void v_polar_to_cartesian_interleaved_pommier(float *const R__ dst,
+                                              const float *const R__ mag,
+                                              const float *const R__ phase,
+                                              const int count);
+
+template<>
+inline void v_polar_to_cartesian(float *const R__ real,
+                                 float *const R__ imag,
+                                 const float *const R__ mag,
+                                 const float *const R__ phase,
+                                 const int count)
+{
+    v_polar_to_cartesian_pommier(real, imag, mag, phase, count);
+}
+
+template<>
+inline void v_polar_interleaved_to_cartesian_inplace(float *const R__ srcdst,
+                                                     const int count)
+{
+    v_polar_interleaved_to_cartesian_inplace_pommier(srcdst, count);
+}
+
+template<>
+inline void v_polar_to_cartesian_interleaved(float *const R__ dst,
+                                             const float *const R__ mag,
+                                             const float *const R__ phase,
+                                             const int count)
+{
+    v_polar_to_cartesian_interleaved_pommier(dst, mag, phase, count);
+}
+
+#endif
+
+template<typename S, typename T> // S source, T target
+void v_cartesian_to_polar(T *const R__ mag,
+                          T *const R__ phase,
+                          const S *const R__ real,
+                          const S *const R__ imag,
+                          const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        c_magphase<T>(mag + i, phase + i, real[i], imag[i]);
+    }
+}
+
+template<typename S, typename T> // S source, T target
+void v_cartesian_interleaved_to_polar(T *const R__ mag,
+                                      T *const R__ phase,
+                                      const S *const R__ src,
+                                      const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        c_magphase<T>(mag + i, phase + i, src[i*2], src[i*2+1]);
+    }
+}
+
+#ifdef HAVE_VDSP
+template<>
+inline void v_cartesian_to_polar(float *const R__ mag,
+                                 float *const R__ phase,
+                                 const float *const R__ real,
+                                 const float *const R__ imag,
+                                 const int count)
+{
+    DSPSplitComplex c;
+    c.realp = const_cast<float *>(real);
+    c.imagp = const_cast<float *>(imag);
+    vDSP_zvmags(&c, 1, phase, 1, count); // using phase as a temporary dest
+    vvsqrtf(mag, phase, &count); // using phase as the source
+    vvatan2f(phase, imag, real, &count);
+}
+template<>
+inline void v_cartesian_to_polar(double *const R__ mag,
+                                 double *const R__ phase,
+                                 const double *const R__ real,
+                                 const double *const R__ imag,
+                                 const int count)
+{
+    // double precision, this is significantly faster than using vDSP_polar
+    DSPDoubleSplitComplex c;
+    c.realp = const_cast<double *>(real);
+    c.imagp = const_cast<double *>(imag);
+    vDSP_zvmagsD(&c, 1, phase, 1, count); // using phase as a temporary dest
+    vvsqrt(mag, phase, &count); // using phase as the source
+    vvatan2(phase, imag, real, &count);
+}
+#endif
+
+template<typename T>
+void v_cartesian_to_polar_interleaved_inplace(T *const R__ srcdst,
+                                              const int count)
+{
+    T mag, phase;
+    for (int i = 0; i < count * 2; i += 2) {
+        c_magphase(&mag, &phase, srcdst[i], srcdst[i+1]);
+        srcdst[i] = mag;
+        srcdst[i+1] = phase;
+    }
+}
+
+template<typename S, typename T> // S source, T target
+void v_cartesian_to_magnitudes(T *const R__ mag,
+                               const S *const R__ real,
+                               const S *const R__ imag,
+                               const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        mag[i] = T(sqrt(real[i] * real[i] + imag[i] * imag[i]));
+    }
+}
+
+template<typename S, typename T> // S source, T target
+void v_cartesian_interleaved_to_magnitudes(T *const R__ mag,
+                                           const S *const R__ src,
+                                           const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        mag[i] = T(sqrt(src[i*2] * src[i*2] + src[i*2+1] * src[i*2+1]));
+    }
+}
+
+#ifdef HAVE_IPP
+template<>
+inline void v_cartesian_to_magnitudes(float *const R__ mag,
+                                      const float *const R__ real,
+                                      const float *const R__ imag,
+                                      const int count)
+{
+    ippsMagnitude_32f(real, imag, mag, count);
+}
+
+template<>
+inline void v_cartesian_to_magnitudes(double *const R__ mag,
+                                      const double *const R__ real,
+                                      const double *const R__ imag,
+                                      const int count)
+{
+    ippsMagnitude_64f(real, imag, mag, count);
+}
+
+template<>
+inline void v_cartesian_interleaved_to_magnitudes(float *const R__ mag,
+                                                  const float *const R__ src,
+                                                  const int count)
+{
+    ippsMagnitude_32fc((const Ipp32fc *)src, mag, count);
+}
+
+template<>
+inline void v_cartesian_interleaved_to_magnitudes(double *const R__ mag,
+                                                  const double *const R__ src,
+                                                  const int count)
+{
+    ippsMagnitude_64fc((const Ipp64fc *)src, mag, count);
+}
+#endif
+
+}
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Window.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/Window.h
@@ -1,0 +1,270 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_WINDOW_H
+#define RUBBERBAND_WINDOW_H
+
+#include <cmath>
+#include <cstdlib>
+#include <map>
+
+#include "sysutils.h"
+#include "mathmisc.h"
+#include "VectorOps.h"
+#include "Allocators.h"
+
+namespace RubberBand {
+
+enum WindowType {
+    RectangularWindow,
+    BartlettWindow,
+    HammingWindow,
+    HannWindow,
+    BlackmanWindow,
+    GaussianWindow,
+    ParzenWindow,
+    NuttallWindow,
+    BlackmanHarrisWindow,
+    NiemitaloForwardWindow,
+    NiemitaloReverseWindow
+};
+
+template <typename T>
+class Window
+{
+public:
+    /**
+     * Construct a windower of the given type.
+     */
+    Window(WindowType type, int size) : m_type(type), m_size(size), m_cache(0) {
+        encache();
+    }
+    Window(const Window &w) : m_type(w.m_type), m_size(w.m_size), m_cache(0) {
+        encache();
+    }
+    Window &operator=(const Window &w) {
+	if (&w == this) return *this;
+	m_type = w.m_type;
+	m_size = w.m_size;
+        m_cache = 0;
+	encache();
+	return *this;
+    }
+    virtual ~Window() {
+        deallocate(m_cache);
+    }
+    
+    inline void cut(T *const R__ block) const {
+        v_multiply(block, m_cache, m_size);
+    }
+
+    inline void cut(const T *const R__ src, T *const R__ dst) const {
+        v_multiply(dst, src, m_cache, m_size);
+    }
+
+    inline void cutAndAdd(const T *const R__ src, T *const R__ dst) const {
+        v_multiply_and_add(dst, src, m_cache, m_size);
+    }
+    
+    inline void add(T *const R__ dst, T scale) const {
+        v_add_with_gain(dst, m_cache, scale, m_size);
+    }
+
+    inline T getRMS() const {
+        T total = 0;
+        for (int i = 0; i < m_size; ++i) {
+            total += m_cache[i] * m_cache[i];
+        }
+        T rms = sqrt(total / m_size);
+        return rms;
+    }
+
+    inline T getArea() const { return m_area; }
+    inline T getValue(int i) const { return m_cache[i]; }
+
+    inline WindowType getType() const { return m_type; }
+    inline int getSize() const { return m_size; }
+
+protected:
+    WindowType m_type;
+    int m_size;
+    T *R__ m_cache;
+    T m_area;
+    
+    void encache();
+    void cosinewin(T *, double, double, double, double);
+};
+
+template <typename T>
+void Window<T>::encache()
+{
+    if (!m_cache) m_cache = allocate<T>(m_size);
+
+    const int n = m_size;
+    v_set(m_cache, T(1.0), n);
+
+    switch (m_type) {
+		
+    case RectangularWindow:
+    {
+	for (int i = 0; i < n; ++i) {
+	    m_cache[i] *= 0.5;
+	}
+	break;
+    }
+	    
+    case BartlettWindow:
+    {
+	for (int i = 0; i < n/2; ++i) {
+	    m_cache[i] *= (i / T(n/2));
+	    m_cache[i + n/2] *= (1.0 - (i / T(n/2)));
+	}
+	break;
+    }
+	    
+    case HammingWindow:
+        cosinewin(m_cache, 0.54, 0.46, 0.0, 0.0);
+	break;
+	    
+    case HannWindow:
+        cosinewin(m_cache, 0.50, 0.50, 0.0, 0.0);
+	break;
+	    
+    case BlackmanWindow:
+        cosinewin(m_cache, 0.42, 0.50, 0.08, 0.0);
+	break;
+	    
+    case GaussianWindow:
+    {
+	for (int i = 0; i < n; ++i) {
+            m_cache[i] *= pow(2, - pow((i - (n-1)/2.0) / ((n-1)/2.0 / 3), 2));
+	}
+	break;
+    }
+	    
+    case ParzenWindow:
+    {
+        int N = n-1;
+        for (int i = 0; i < N/4; ++i) {
+            T m = 2 * pow(1.0 - (T(N)/2 - i) / (T(N)/2), 3);
+            m_cache[i] *= m;
+            m_cache[N-i] *= m;
+        }
+        for (int i = N/4; i <= N/2; ++i) {
+            int wn = i - N/2;
+            T m = 1.0 - 6 * pow(wn / (T(N)/2), 2) * (1.0 - abs(wn) / (T(N)/2));
+            m_cache[i] *= m;
+            m_cache[N-i] *= m;
+        }            
+        break;
+    }
+
+    case NuttallWindow:
+        cosinewin(m_cache, 0.3635819, 0.4891775, 0.1365995, 0.0106411);
+	break;
+
+    case BlackmanHarrisWindow:
+        cosinewin(m_cache, 0.35875, 0.48829, 0.14128, 0.01168);
+        break;
+
+    case NiemitaloForwardWindow:
+    case NiemitaloReverseWindow:
+    {
+        /* Interesting asymmetric window proposed by Olli Niemitalo.
+           https://dsp.stackexchange.com/questions/2337/fft-with-asymmetric-windowing
+           (Olli also writes "I cross-license all of my code and
+           images in Stack Exchange under CC0 1.0" -
+           https://dsp.stackexchange.com/users/15347/olli-niemitalo)
+        */        
+        int quarter = n/4;
+        int eighth = n/8;
+        int k = 0;
+        for (int i = 0; i < n - eighth - quarter; ++i) {
+            T x = 2.0 * M_PI *
+                (((T(k + quarter) + 0.5) / T(n)) - 1.75);
+            m_cache[k++] =
+                2.57392230162633461887
+                - 1.58661480271141974718 * cos(x)
+                + 3.80257516644523141380 * sin(x)
+                - 1.93437090055110760822 * cos(2.0 * x)
+                - 3.27163999159752183488 * sin(2.0 * x)
+                + 3.26617449847621266201 * cos(3.0 * x)
+                - 0.30335261753524439543 * sin(3.0 * x)
+                - 0.92126091064427817479 * cos(4.0 * x)
+                + 2.33100177294084742741 * sin(4.0 * x)
+                - 1.19953922321306438725 * cos(5.0 * x)
+                - 1.25098147932225423062 * sin(5.0 * x)
+                + 0.99132076607048635886 * cos(6.0 * x)
+                - 0.34506787787355830410 * sin(6.0 * x)
+                - 0.04028033685700077582 * cos(7.0 * x)
+                + 0.55461815542612269425 * sin(7.0 * x)
+                - 0.21882110175036428856 * cos(8.0 * x)
+                - 0.10756484378756643594 * sin(8.0 * x)
+                + 0.06025986430527170007 * cos(9.0 * x)
+                - 0.05777077835678736534 * sin(9.0 * x)
+                + 0.00920984524892982936 * cos(10.0 * x)
+                + 0.01501989089735343216 * sin(10.0 * x);
+        }
+        for (int i = 0; i < eighth; ++i) {
+            int j = eighth - 1 - i;
+            m_cache[k++] =
+                (1.0 - m_cache[n/2 - 1 - j] * m_cache[n/2 + j]) /
+                m_cache[n/4 + j];
+        }
+        for (int i = 0; i < quarter; ++i) {
+            m_cache[k++] = 0.0;
+        }
+
+        if (m_type == NiemitaloReverseWindow) {
+            for (int i = 0; i < n/2; ++i) {
+                T tmp = m_cache[i];
+                m_cache[i] = m_cache[n - i - 1];
+                m_cache[n - i - 1] = tmp;
+            }
+        }
+    }
+    
+    }
+	
+    m_area = 0;
+    for (int i = 0; i < n; ++i) {
+        m_area += m_cache[i];
+    }
+    m_area /= n;
+}
+
+template <typename T>
+void Window<T>::cosinewin(T *mult, double a0, double a1, double a2, double a3)
+{
+    int n = int(m_size);
+    for (int i = 0; i < n; ++i) {
+        mult[i] = T(mult[i] * (a0
+                               - a1 * cos(2 * M_PI * i / n)
+                               + a2 * cos(4 * M_PI * i / n)
+                               - a3 * cos(6 * M_PI * i / n)));
+    }
+}
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/mathmisc.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/mathmisc.cpp
@@ -1,0 +1,84 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "mathmisc.h"
+
+namespace RubberBand {
+
+void pickNearestRational(double ratio, int max_denom, int &num, int &denom)
+{
+    // Farey algorithm, see
+    // https://www.johndcook.com/blog/2010/10/20/best-rational-approximation/
+    double a = 0.0, b = 1.0, c = 1.0, d = 0.0;
+    double pa = a, pb = b, pc = c, pd = d;
+    double eps = 1e-9;
+    while (b <= max_denom && d <= max_denom) {
+        double mediant = (a + c) / (b + d);
+        if (fabs(ratio - mediant) < eps) {
+            if (b + d <= max_denom) {
+                num = a + c;
+                denom = b + d;
+                return;
+            } else if (d > b) {
+                num = c;
+                denom = d;
+                return;
+            } else {
+                num = a;
+                denom = b;
+                return;
+            }
+        }
+        if (ratio > mediant) {
+            pa = a; pb = b;
+            a += c; b += d;
+        } else {
+            pc = c; pd = d;
+            c += a; d += b;
+        }
+    }
+    if (fabs(ratio - (pc / pd)) < fabs(ratio - (pa / pb))) {
+        num = pc;
+        denom = pd;
+    } else {
+        num = pa;
+        denom = pb;
+    }
+}
+
+size_t roundUp(size_t value)
+{
+    if (!(value & (value - 1))) return value;
+    size_t bits = 0;
+    while (value) { ++bits; value >>= 1; }
+    value = size_t(1) << bits;
+    return value;
+}
+
+size_t roundUpDiv(double divisionOf, size_t divisor)
+{
+    if (divisionOf < 0.0) return 0;
+    return roundUp(size_t(ceil(divisionOf / double(divisor))));
+}
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/mathmisc.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/mathmisc.h
@@ -1,0 +1,64 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_MATHMISC_H
+#define RUBBERBAND_MATHMISC_H
+
+#include "sysutils.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif // M_PI
+
+namespace RubberBand {
+
+inline double mod(double x, double y) {
+    return x - (y * floor(x / y));
+}
+inline float modf(float x, float y) {
+    return x - (y * float(floor(x / y)));
+}
+
+inline double princarg(double a) {
+    return mod(a + M_PI, -2.0 * M_PI) + M_PI;
+}
+inline float princargf(float a) {
+    return modf(a + (float)M_PI, -2.f * (float)M_PI) + (float)M_PI;
+}
+
+inline int binForFrequency(double f, int fftSize, double sampleRate) {
+    return int(round(f * double(fftSize) / sampleRate));
+}
+inline double frequencyForBin(int b, int fftSize, double sampleRate) {
+    return (double(b) * sampleRate) / double(fftSize);
+}
+
+void pickNearestRational(double ratio, int maxDenom, int &num, int &denom);
+
+size_t roundUp(size_t value); // to nearest power of two
+
+size_t roundUpDiv(double divisionOf, size_t divisor);
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/sysutils.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/sysutils.cpp
@@ -1,0 +1,172 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "sysutils.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <fcntl.h>
+#include <io.h>
+#else /* !_WIN32 */
+#include <unistd.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#else /* !__APPLE__, !_WIN32 */
+#include <stdio.h>
+#include <string.h>
+#endif /* !__APPLE__, !_WIN32 */
+#endif /* !_WIN32 */
+
+#ifdef __sun
+#include <sys/processor.h>
+#endif
+
+#include <cstdlib>
+#include <iostream>
+
+#ifdef HAVE_IPP
+#include <ippversion.h>
+#include <ipp.h>
+#endif
+
+#ifdef HAVE_VDSP
+#include <Accelerate/Accelerate.h>
+#include <fenv.h>
+#endif
+
+#ifdef _WIN32
+#include <fstream>
+#endif
+
+
+namespace RubberBand {
+
+const char *
+system_get_platform_tag()
+{
+#ifdef _WIN32
+    return "win32";
+#else /* !_WIN32 */
+#ifdef __APPLE__
+    return "osx";
+#else /* !__APPLE__ */
+#ifdef __LINUX__
+    if (sizeof(long) == 8) {
+        return "linux64";
+    } else {
+        return "linux";
+    }
+#else /* !__LINUX__ */
+    return "posix";
+#endif /* !__LINUX__ */
+#endif /* !__APPLE__ */
+#endif /* !_WIN32 */
+}
+
+bool
+system_is_multiprocessor()
+{
+    static bool tested = false, mp = false;
+
+    if (tested) return mp;
+    int count = 0;
+
+#ifdef _WIN32
+
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    count = sysinfo.dwNumberOfProcessors;
+
+#else /* !_WIN32 */
+#ifdef __APPLE__
+    
+    size_t sz = sizeof(count);
+    if (sysctlbyname("hw.ncpu", &count, &sz, NULL, 0)) {
+        count = 0;
+        mp = false;
+    } else {
+        mp = (count > 1);
+    }
+
+#else /* !__APPLE__, !_WIN32 */
+#ifdef __sun
+
+    processorid_t i, n;
+    n = sysconf(_SC_CPUID_MAX);
+    for (i = 0; i <= n; ++i) {
+        int status = p_online(i, P_STATUS);
+        if (status == P_ONLINE) {
+            ++count;
+        }
+        if (count > 1) break;
+    }
+
+#else /* !__sun, !__APPLE__, !_WIN32 */
+
+    //...
+
+    FILE *cpuinfo = fopen("/proc/cpuinfo", "r");
+    if (!cpuinfo) return false;
+
+    char buf[256];
+    while (!feof(cpuinfo)) {
+        if (!fgets(buf, 256, cpuinfo)) break;
+        if (!strncmp(buf, "processor", 9)) {
+            ++count;
+        }
+        if (count > 1) break;
+    }
+
+    fclose(cpuinfo);
+
+#endif /* !__sun, !__APPLE__, !_WIN32 */
+#endif /* !__APPLE__, !_WIN32 */
+#endif /* !_WIN32 */
+
+    mp = (count > 1);
+    tested = true;
+    return mp;
+}
+
+#ifdef _WIN32
+
+void gettimeofday(struct timeval *tv, void * /* tz */)
+{
+    union { 
+	long long ns100;  
+	FILETIME ft; 
+    } now; 
+    
+    ::GetSystemTimeAsFileTime(&now.ft); 
+    tv->tv_usec = (long)((now.ns100 / 10LL) % 1000000LL); 
+    tv->tv_sec = (long)((now.ns100 - 116444736000000000LL) / 10000000LL); 
+}
+
+#endif
+
+}
+
+
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/sysutils.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/common/sysutils.h
@@ -1,0 +1,121 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SYSUTILS_H
+#define RUBBERBAND_SYSUTILS_H
+
+#ifdef __clang__
+#  define R__ __restrict__
+#else
+#  ifdef __GNUC__
+#    define R__ __restrict__
+#  endif
+#endif
+
+#ifdef _MSC_VER
+#  if _MSC_VER < 1800
+#    include "float_cast/float_cast.h"
+#  endif
+#  ifndef R__
+#    define R__ __restrict
+#  endif
+#endif 
+
+#ifndef R__
+#  define R__
+#endif
+
+#ifndef RUBBERBAND_ENABLE_WARNINGS
+#if defined(_MSC_VER)
+#pragma warning(disable:4127; disable:4244; disable:4267)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wconversion"
+#elif defined(__clang__)
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wfloat-conversion"
+#pragma clang diagnostic ignored "-Wimplicit-float-conversion"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#endif
+#endif
+
+#ifdef __clang__
+#  define RTENTRY__ __attribute__((annotate("realtime")))
+#else
+#  define RTENTRY__
+#endif
+
+#if defined(_MSC_VER)
+#  include <malloc.h>
+#  include <process.h>
+#  define alloca _alloca
+#  define getpid _getpid
+#else
+#  if defined(__MINGW32__)
+#    include <malloc.h>
+#  elif defined(__GNUC__)
+#    ifndef alloca
+#      define alloca __builtin_alloca
+#    endif
+#  elif defined(HAVE_ALLOCA_H)
+#    include <alloca.h>
+#  else
+#    ifndef __USE_MISC
+#    define __USE_MISC
+#    endif
+#    include <stdlib.h>
+#  endif
+#endif
+
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#  define uint8_t unsigned __int8
+#  define uint16_t unsigned __int16
+#  define uint32_t unsigned __int32
+#elif defined(_MSC_VER)
+#  define ssize_t long
+#  include <stdint.h>
+#else
+#  include <stdint.h>
+#endif
+
+#include <math.h>
+
+namespace RubberBand {
+
+#ifdef PROCESS_SAMPLE_TYPE
+typedef PROCESS_SAMPLE_TYPE process_t;
+#else
+typedef double process_t;
+#endif
+
+extern const char *system_get_platform_tag();
+extern bool system_is_multiprocessor();
+
+#ifdef _WIN32
+struct timeval { long tv_sec; long tv_usec; };
+void gettimeofday(struct timeval *p, void *tz);
+#endif // _WIN32
+
+} // end namespace
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/float_cast/float_cast.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/float_cast/float_cast.h
@@ -1,0 +1,81 @@
+#ifndef ERIKD_FLOATCAST_H
+#define ERIKD_FLOATCAST_H
+
+/*
+** Copyright (C) 2001 Erik de Castro Lopo <erikd AT mega-nerd DOT com>
+**
+** Permission to use, copy, modify, distribute, and sell this file for any 
+** purpose is hereby granted without fee, provided that the above copyright 
+** and this permission notice appear in all copies.  No representations are
+** made about the suitability of this software for any purpose.  It is 
+** provided "as is" without express or implied warranty.
+*/
+
+/* Version 1.1 */
+
+
+/*============================================================================ 
+**	On Intel Pentium processors (especially PIII and probably P4), converting
+**	from float to int is very slow. To meet the C specs, the code produced by 
+**	most C compilers targeting Pentium needs to change the FPU rounding mode 
+**	before the float to int conversion is performed. 
+**
+**	Changing the FPU rounding mode causes the FPU pipeline to be flushed. It 
+**	is this flushing of the pipeline which is so slow.
+**
+**	Fortunately the ISO C99 specifications define the functions lrint, lrintf,
+**	llrint and llrintf which fix this problem as a side effect. 
+**
+**	On Unix-like systems, the configure process should have detected the 
+**	presence of these functions. If they weren't found we have to replace them 
+**	here with a standard C cast.
+*/
+
+/*	
+**	The C99 prototypes for lrint and lrintf are as follows:
+**	
+**		long int lrintf (float x) ;
+**		long int lrint  (double x) ;
+*/
+
+#if (defined (_WIN64))
+
+#include <math.h>
+__inline long int lrint(double flt) { return (long int)flt; }
+__inline long int lrintf(float flt) { return (long int)flt; }
+
+#elif (defined (WIN32) || defined (_WIN32))
+
+	#include	<math.h>
+
+	/*	Win32 doesn't seem to have these functions. 
+	**	Therefore implement inline versions of these functions here.
+	*/
+	
+	__inline long int 
+	lrint (double flt) 
+	{	int intgr;
+
+		_asm
+		{	fld flt
+			fistp intgr
+			} ;
+			
+		return intgr ;
+	} 
+	
+	__inline long int 
+	lrintf (float flt)
+	{	int intgr;
+
+		_asm
+		{	fld flt
+			fistp intgr
+			} ;
+			
+		return intgr ;
+	}
+
+#endif
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/getopt/getopt.c
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/getopt/getopt.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 1987, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning (disable: 4131; disable: 4706)
+#endif
+
+int	opterr = 1,		/* if error message should be printed */
+	optind = 1,		/* index into parent argv vector */
+	optopt,			/* character checked for validity */
+	optreset;		/* reset getopt */
+char	*optarg;		/* argument associated with option */
+
+#define	BADCH	(int)'?'
+#define	BADARG	(int)':'
+#define	EMSG	""
+
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt(nargc, nargv, ostr)
+	int nargc;
+	char * const *nargv;
+	const char *ostr;
+{
+	static char *place = EMSG;		/* option letter processing */
+	char *oli;				/* option letter list index */
+
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc || *(place = nargv[optind]) != '-') {
+			place = EMSG;
+			return (-1);
+		}
+		if (place[1] && *++place == '-') {	/* found "--" */
+			++optind;
+			place = EMSG;
+			return (-1);
+		}
+	}					/* option letter okay? */
+	if ((optopt = (int)*place++) == (int)':' ||
+	    !(oli = strchr(ostr, optopt))) {
+		/*
+		 * if the user didn't specify '-' as an option,
+		 * assume it means -1.
+		 */
+		if (optopt == (int)'-')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (opterr && *ostr != ':' && optopt != BADCH)
+			(void)fprintf(stderr, "%s: illegal option -- %c\n",
+			    "progname", optopt);
+		return (BADCH);
+	}
+	if (*++oli != ':') {			/* don't need argument */
+		optarg = NULL;
+		if (!*place)
+			++optind;
+	}
+	else {					/* need an argument */
+		if (*place)			/* no white space */
+			optarg = place;
+		else if (nargc <= ++optind) {	/* no arg */
+			place = EMSG;
+			if (*ostr == ':')
+				return (BADARG);
+			if (opterr)
+				(void)fprintf(stderr,
+				    "%s: option requires an argument -- %c\n",
+				    "progname", optopt);
+			return (BADCH);
+		}
+	 	else				/* white space */
+			optarg = nargv[optind];
+		place = EMSG;
+		++optind;
+	}
+	return (optopt);			/* dump back option letter */
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/getopt/getopt.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/getopt/getopt.h
@@ -1,0 +1,110 @@
+/*      $NetBSD: getopt.h,v 1.4 2000/07/07 10:43:54 ad Exp $    */
+/*      $FreeBSD: src/include/getopt.h,v 1.1 2002/09/29 04:14:30 eric Exp $ */
+
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *        This product includes software developed by the NetBSD
+ *        Foundation, Inc. and its contributors.
+ * 4. Neither the name of The NetBSD Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
+
+#ifdef _WIN32
+/* from <sys/cdefs.h> */
+# ifdef  __cplusplus
+#  define __BEGIN_DECLS  extern "C" {
+#  define __END_DECLS    }
+# else
+#  define __BEGIN_DECLS
+#  define __END_DECLS
+# endif
+# define __P(args)      args
+#endif
+
+/*#ifndef _WIN32
+#include <sys/cdefs.h>
+#include <unistd.h>
+#endif*/
+
+#ifdef _WIN32
+# if !defined(GETOPT_API)
+#  define GETOPT_API __declspec(dllimport)
+# endif
+#endif
+
+/*
+ * Gnu like getopt_long() and BSD4.4 getsubopt()/optreset extensions
+ */
+#if !defined(_POSIX_SOURCE) && !defined(_XOPEN_SOURCE)
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
+
+struct option {
+        /* name of long option */
+        const char *name;
+        /*
+         * one of no_argument, required_argument, and optional_argument:
+         * whether option takes an argument
+         */
+        int has_arg;
+        /* if not NULL, set *flag to val when option found */
+        int *flag;
+        /* if flag not NULL, value to set *flag to; else return value */
+        int val;
+};
+
+__BEGIN_DECLS
+GETOPT_API int getopt_long __P((int, char * const *, const char *,
+    const struct option *, int *));
+__END_DECLS
+#endif
+
+#ifdef _WIN32
+/* These are global getopt variables */
+__BEGIN_DECLS
+
+GETOPT_API extern int   opterr,   /* if error message should be printed */
+                        optind,   /* index into parent argv vector */
+                        optopt,   /* character checked for validity */
+                        optreset; /* reset getopt */
+GETOPT_API extern char* optarg;   /* argument associated with option */
+
+/* Original getopt */
+GETOPT_API int getopt __P((int, char * const *, const char *));
+
+__END_DECLS
+#endif
+ 
+#endif /* !_GETOPT_H_ */

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/getopt/getopt_long.c
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/getopt/getopt_long.c
@@ -1,0 +1,551 @@
+/*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+/*	$FreeBSD: src/lib/libc/stdlib/getopt_long.c,v 1.2 2002/10/16 22:18:42 alfred Exp $ */
+
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *        This product includes software developed by the NetBSD
+ *        Foundation, Inc. and its contributors.
+ * 4. Neither the name of The NetBSD Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+
+/* Windows needs warnx().  We change the definition though:
+ *  1. (another) global is defined, opterrmsg, which holds the error message
+ *  2. errors are always printed out on stderr w/o the program name
+ * Note that opterrmsg always gets set no matter what opterr is set to.  The
+ * error message will not be printed if opterr is 0 as usual.
+ */
+
+#include "getopt.h"
+#include <stdio.h>
+#include <stdarg.h>
+
+#ifdef _MSC_VER
+#pragma warning (disable: 4131; disable: 4996)
+#endif
+
+GETOPT_API extern char opterrmsg[128];
+char opterrmsg[128]; /* last error message is stored here */
+
+static void warnx(int print_error, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	if (fmt != NULL)
+		_vsnprintf(opterrmsg, 128, fmt, ap);
+	else
+		opterrmsg[0]='\0';
+	va_end(ap);
+	if (print_error) {
+		fprintf(stderr, opterrmsg);
+		fprintf(stderr, "\n");
+	}
+}
+
+#endif /*_WIN32*/
+
+/* not part of the original file */
+#ifndef _DIAGASSERT
+#define _DIAGASSERT(X)
+#endif
+
+#if HAVE_CONFIG_H && !HAVE_GETOPT_LONG && !HAVE_DECL_OPTIND
+#define REPLACE_GETOPT
+#endif
+
+#ifdef REPLACE_GETOPT
+#ifdef __weak_alias
+__weak_alias(getopt,_getopt)
+#endif
+int	opterr = 1;		/* if error message should be printed */
+int	optind = 1;		/* index into parent argv vector */
+int	optopt = '?';		/* character checked for validity */
+int	optreset;		/* reset getopt */
+char    *optarg;		/* argument associated with option */
+#elif HAVE_CONFIG_H && !HAVE_DECL_OPTRESET
+static int optreset;
+#endif
+
+#ifdef __weak_alias
+__weak_alias(getopt_long,_getopt_long)
+#endif
+
+#if !HAVE_GETOPT_LONG
+#define IGNORE_FIRST	(*options == '-' || *options == '+')
+#define PRINT_ERROR	((opterr) && ((*options != ':') \
+				      || (IGNORE_FIRST && options[1] != ':')))
+#define IS_POSIXLY_CORRECT (getenv("POSIXLY_CORRECT") != NULL)
+#define PERMUTE         (!IS_POSIXLY_CORRECT && !IGNORE_FIRST)
+/* XXX: GNU ignores PC if *options == '-' */
+#define IN_ORDER        (!IS_POSIXLY_CORRECT && *options == '-')
+
+/* return values */
+#define	BADCH	(int)'?'
+#define	BADARG		((IGNORE_FIRST && options[1] == ':') \
+			 || (*options == ':') ? (int)':' : (int)'?')
+#define INORDER (int)1
+
+#define	EMSG	""
+
+static int getopt_internal(int, char * const *, const char *);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(a, b)
+	int a;
+	int b;
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+	   
+	return b;
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(panonopt_start, panonopt_end, opt_end, nargv)
+	int panonopt_start;
+	int panonopt_end;
+	int opt_end;
+	char * const *nargv;
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	_DIAGASSERT(nargv != NULL);
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **) nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ *  Returns -2 if -- is found (can be long option or end of options marker).
+ */
+static int
+getopt_internal(nargc, nargv, options)
+	int nargc;
+	char * const *nargv;
+	const char *options;
+{
+	char *oli;				/* option letter list index */
+	int optchar;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+
+	optarg = NULL;
+
+	/*
+	 * XXX Some programs (like rsyncd) expect to be able to
+	 * XXX re-initialize optind to 0 and have getopt_long(3)
+	 * XXX properly function again.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = 1;
+
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return -1;
+		}
+		if ((*(place = nargv[optind]) != '-')
+		    || (place[1] == '\0')) {    /* found non-option */
+			place = EMSG;
+			if (IN_ORDER) {
+				/*
+				 * GNU extension: 
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return INORDER;
+			}
+			if (!PERMUTE) {
+				/*
+				 * if no permutation wanted, stop parsing
+				 * at first non-option
+				 */
+				return -1;
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+		if (place[1] && *++place == '-') {	/* found "--" */
+			place++;
+			return -2;
+		}
+	}
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (oli = strchr(options + (IGNORE_FIRST ? 1 : 0), optchar)) == NULL) {
+		/* option letter unknown or ':' */
+		if (!*place)
+			++optind;
+#ifndef _WIN32
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+#else
+			warnx(PRINT_ERROR, illoptchar, optchar);
+#endif
+		optopt = optchar;
+		return BADCH;
+	}
+	if (optchar == 'W' && oli[1] == ';') {		/* -W long-option */
+		/* XXX: what if no long options provided (called by getopt)? */
+		if (*place) 
+			return -2;
+
+		if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+#ifndef _WIN32
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+#else
+				warnx(PRINT_ERROR, recargchar, optchar);
+#endif
+			optopt = optchar;
+			return BADARG;
+		} else				/* white space */
+			place = nargv[optind];
+		/*
+		 * Handle -W arg the same as --arg (which causes getopt to
+		 * stop parsing).
+		 */
+		return -2;
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		/* XXX: disable test for :: if PC? (GNU doesn't) */
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+#else
+					warnx(PRINT_ERROR, recargchar, optchar);
+#endif
+				optopt = optchar;
+				return BADARG;
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return optchar;
+}
+
+#ifdef REPLACE_GETOPT
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the real getopt]
+ */
+int
+getopt(nargc, nargv, options)
+	int nargc;
+	char * const *nargv;
+	const char *options;
+{
+	int retval;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+
+	if ((retval = getopt_internal(nargc, nargv, options)) == -2) {
+		++optind;
+		/*
+		 * We found an option (--), so if we skipped non-options,
+		 * we have to permute.
+		 */
+		if (nonopt_end != -1) {
+			permute_args(nonopt_start, nonopt_end, optind,
+				       nargv);
+			optind -= nonopt_end - nonopt_start;
+		}
+		nonopt_start = nonopt_end = -1;
+		retval = -1;
+	}
+	return retval;
+}
+#endif
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(nargc, nargv, options, long_options, idx)
+	int nargc;
+	char * const *nargv;
+	const char *options;
+	const struct option *long_options;
+	int *idx;
+{
+	int retval;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+	_DIAGASSERT(long_options != NULL);
+	/* idx may be NULL */
+
+	if ((retval = getopt_internal(nargc, nargv, options)) == -2) {
+		char *current_argv, *has_equal;
+		size_t current_argv_len;
+		int i, match;
+
+		current_argv = place;
+		match = -1;
+
+		optind++;
+		place = EMSG;
+
+		if (*current_argv == '\0') {		/* found "--" */
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return -1;
+		}
+		if ((has_equal = strchr(current_argv, '=')) != NULL) {
+			/* argument found (--option=arg) */
+			current_argv_len = has_equal - current_argv;
+			has_equal++;
+		} else
+			current_argv_len = strlen(current_argv);
+	    
+		for (i = 0; long_options[i].name; i++) {
+			/* find matching long option */
+			if (strncmp(current_argv, long_options[i].name,
+			    current_argv_len))
+				continue;
+
+			if (strlen(long_options[i].name) ==
+			    (unsigned)current_argv_len) {
+				/* exact match */
+				match = i;
+				break;
+			}
+			if (match == -1)		/* partial match */
+				match = i;
+			else {
+				/* ambiguous abbreviation */
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(ambig, (int)current_argv_len,
+					     current_argv);
+#else
+					warnx(PRINT_ERROR, ambig, (int)current_argv_len,
+					     current_argv);
+#endif
+				optopt = 0;
+				return BADCH;
+			}
+		}
+		if (match != -1) {			/* option found */
+		        if (long_options[match].has_arg == no_argument
+			    && has_equal) {
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(noarg, (int)current_argv_len,
+					     current_argv);
+#else
+					warnx(PRINT_ERROR, noarg, (int)current_argv_len,
+					     current_argv);
+#endif
+				/*
+				 * XXX: GNU sets optopt to val regardless of
+				 * flag
+				 */
+				if (long_options[match].flag == NULL)
+					optopt = long_options[match].val;
+				else
+					optopt = 0;
+				return BADARG;
+			}
+			if (long_options[match].has_arg == required_argument ||
+			    long_options[match].has_arg == optional_argument) {
+				if (has_equal)
+					optarg = has_equal;
+				else if (long_options[match].has_arg ==
+				    required_argument) {
+					/*
+					 * optional argument doesn't use
+					 * next nargv
+					 */
+					optarg = nargv[optind++];
+				}
+			}
+			if ((long_options[match].has_arg == required_argument)
+			    && (optarg == NULL)) {
+				/*
+				 * Missing argument; leading ':'
+				 * indicates no error should be generated
+				 */
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(recargstring, current_argv);
+#else
+					warnx(PRINT_ERROR, recargstring, current_argv);
+#endif
+				/*
+				 * XXX: GNU sets optopt to val regardless
+				 * of flag
+				 */
+				if (long_options[match].flag == NULL)
+					optopt = long_options[match].val;
+				else
+					optopt = 0;
+				--optind;
+				return BADARG;
+			}
+		} else {			/* unknown option */
+#ifndef _WIN32
+			if (PRINT_ERROR)
+				warnx(illoptstring, current_argv);
+#else
+				warnx(PRINT_ERROR, illoptstring, current_argv);
+#endif
+			optopt = 0;
+			return BADCH;
+		}
+		if (long_options[match].flag) {
+			*long_options[match].flag = long_options[match].val;
+			retval = 0;
+		} else 
+			retval = long_options[match].val;
+		if (idx)
+			*idx = match;
+	}
+	return retval;
+}
+#endif /* !GETOPT_LONG */

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/COPYING
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/COPYING
@@ -1,0 +1,11 @@
+Copyright (c) 2003-2010 Mark Borgerding . All rights reserved.
+
+KISS FFT is provided under:
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+Being under the terms of the BSD 3-clause "New" or "Revised" License,
+according with:
+
+  LICENSES/BSD-3-Clause
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/_kiss_fft_guts.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/_kiss_fft_guts.h
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+/* kiss_fft.h
+   defines kiss_fft_scalar as either short or a float type
+   and defines
+   typedef struct { kiss_fft_scalar r; kiss_fft_scalar i; }kiss_fft_cpx; */
+
+#ifndef _kiss_fft_guts_h
+#define _kiss_fft_guts_h
+
+#include "kiss_fft.h"
+#include "kiss_fft_log.h"
+#include <limits.h>
+
+#define MAXFACTORS 32
+/* e.g. an fft of length 128 has 4 factors
+ as far as kissfft is concerned
+ 4*4*4*2
+ */
+
+struct kiss_fft_state{
+    int nfft;
+    int inverse;
+    int factors[2*MAXFACTORS];
+    kiss_fft_cpx twiddles[1];
+};
+
+/*
+  Explanation of macros dealing with complex math:
+
+   C_MUL(m,a,b)         : m = a*b
+   C_FIXDIV( c , div )  : if a fixed point impl., c /= div. noop otherwise
+   C_SUB( res, a,b)     : res = a - b
+   C_SUBFROM( res , a)  : res -= a
+   C_ADDTO( res , a)    : res += a
+ * */
+#ifdef FIXED_POINT
+#include <stdint.h>
+#if (FIXED_POINT==32)
+# define FRACBITS 31
+# define SAMPPROD int64_t
+#define SAMP_MAX INT32_MAX
+#define SAMP_MIN INT32_MIN
+#else
+# define FRACBITS 15
+# define SAMPPROD int32_t
+#define SAMP_MAX INT16_MAX
+#define SAMP_MIN INT16_MIN
+#endif
+
+#if defined(CHECK_OVERFLOW)
+#  define CHECK_OVERFLOW_OP(a,op,b)  \
+    if ( (SAMPPROD)(a) op (SAMPPROD)(b) > SAMP_MAX || (SAMPPROD)(a) op (SAMPPROD)(b) < SAMP_MIN ) { \
+        KISS_FFT_WARNING("overflow (%d " #op" %d) = %ld", (a),(b),(SAMPPROD)(a) op (SAMPPROD)(b)); }
+#endif
+
+
+#   define smul(a,b) ( (SAMPPROD)(a)*(b) )
+#   define sround( x )  (kiss_fft_scalar)( ( (x) + (1<<(FRACBITS-1)) ) >> FRACBITS )
+
+#   define S_MUL(a,b) sround( smul(a,b) )
+
+#   define C_MUL(m,a,b) \
+      do{ (m).r = sround( smul((a).r,(b).r) - smul((a).i,(b).i) ); \
+          (m).i = sround( smul((a).r,(b).i) + smul((a).i,(b).r) ); }while(0)
+
+#   define DIVSCALAR(x,k) \
+    (x) = sround( smul(  x, SAMP_MAX/k ) )
+
+#   define C_FIXDIV(c,div) \
+    do {    DIVSCALAR( (c).r , div);  \
+        DIVSCALAR( (c).i  , div); }while (0)
+
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r =  sround( smul( (c).r , s ) ) ;\
+        (c).i =  sround( smul( (c).i , s ) ) ; }while(0)
+
+#else  /* not FIXED_POINT*/
+
+#   define S_MUL(a,b) ( (a)*(b) )
+#define C_MUL(m,a,b) \
+    do{ (m).r = (a).r*(b).r - (a).i*(b).i;\
+        (m).i = (a).r*(b).i + (a).i*(b).r; }while(0)
+#   define C_FIXDIV(c,div) /* NOOP */
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r *= (s);\
+        (c).i *= (s); }while(0)
+#endif
+
+#ifndef CHECK_OVERFLOW_OP
+#  define CHECK_OVERFLOW_OP(a,op,b) /* noop */
+#endif
+
+#define  C_ADD( res, a,b)\
+    do { \
+        CHECK_OVERFLOW_OP((a).r,+,(b).r)\
+        CHECK_OVERFLOW_OP((a).i,+,(b).i)\
+        (res).r=(a).r+(b).r;  (res).i=(a).i+(b).i; \
+    }while(0)
+#define  C_SUB( res, a,b)\
+    do { \
+        CHECK_OVERFLOW_OP((a).r,-,(b).r)\
+        CHECK_OVERFLOW_OP((a).i,-,(b).i)\
+        (res).r=(a).r-(b).r;  (res).i=(a).i-(b).i; \
+    }while(0)
+#define C_ADDTO( res , a)\
+    do { \
+        CHECK_OVERFLOW_OP((res).r,+,(a).r)\
+        CHECK_OVERFLOW_OP((res).i,+,(a).i)\
+        (res).r += (a).r;  (res).i += (a).i;\
+    }while(0)
+
+#define C_SUBFROM( res , a)\
+    do {\
+        CHECK_OVERFLOW_OP((res).r,-,(a).r)\
+        CHECK_OVERFLOW_OP((res).i,-,(a).i)\
+        (res).r -= (a).r;  (res).i -= (a).i; \
+    }while(0)
+
+
+#ifdef FIXED_POINT
+#  define KISS_FFT_COS(phase)  floor(.5+SAMP_MAX * cos (phase))
+#  define KISS_FFT_SIN(phase)  floor(.5+SAMP_MAX * sin (phase))
+#  define HALF_OF(x) ((x)>>1)
+#elif defined(USE_SIMD)
+#  define KISS_FFT_COS(phase) _mm_set1_ps( cos(phase) )
+#  define KISS_FFT_SIN(phase) _mm_set1_ps( sin(phase) )
+#  define HALF_OF(x) ((x)*_mm_set1_ps(.5))
+#else
+#  define KISS_FFT_COS(phase) (kiss_fft_scalar) cos(phase)
+#  define KISS_FFT_SIN(phase) (kiss_fft_scalar) sin(phase)
+#  define HALF_OF(x) ((x)*((kiss_fft_scalar).5))
+#endif
+
+#define  kf_cexp(x,phase) \
+    do{ \
+        (x)->r = KISS_FFT_COS(phase);\
+        (x)->i = KISS_FFT_SIN(phase);\
+    }while(0)
+
+
+/* a debugging function */
+#define pcpx(c)\
+    KISS_FFT_DEBUG("%g + %gi\n",(double)((c)->r),(double)((c)->i))
+
+
+#ifdef KISS_FFT_USE_ALLOCA
+// define this to allow use of alloca instead of malloc for temporary buffers
+// Temporary buffers are used in two case:
+// 1. FFT sizes that have "bad" factors. i.e. not 2,3 and 5
+// 2. "in-place" FFTs.  Notice the quotes, since kissfft does not really do an in-place transform.
+#include <alloca.h>
+#define  KISS_FFT_TMP_ALLOC(nbytes) alloca(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr)
+#else
+#define  KISS_FFT_TMP_ALLOC(nbytes) KISS_FFT_MALLOC(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr) KISS_FFT_FREE(ptr)
+#endif
+
+#endif /* _kiss_fft_guts_h */
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fft.c
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fft.c
@@ -1,0 +1,420 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+
+#include "_kiss_fft_guts.h"
+/* The guts header contains all the multiplication and addition macros that are defined for
+ fixed or floating point complex numbers.  It also delares the kf_ internal functions.
+ */
+
+static void kf_bfly2(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx * Fout2;
+    kiss_fft_cpx * tw1 = st->twiddles;
+    kiss_fft_cpx t;
+    Fout2 = Fout + m;
+    do{
+        C_FIXDIV(*Fout,2); C_FIXDIV(*Fout2,2);
+
+        C_MUL (t,  *Fout2 , *tw1);
+        tw1 += fstride;
+        C_SUB( *Fout2 ,  *Fout , t );
+        C_ADDTO( *Fout ,  t );
+        ++Fout2;
+        ++Fout;
+    }while (--m);
+}
+
+static void kf_bfly4(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        const size_t m
+        )
+{
+    kiss_fft_cpx *tw1,*tw2,*tw3;
+    kiss_fft_cpx scratch[6];
+    size_t k=m;
+    const size_t m2=2*m;
+    const size_t m3=3*m;
+
+
+    tw3 = tw2 = tw1 = st->twiddles;
+
+    do {
+        C_FIXDIV(*Fout,4); C_FIXDIV(Fout[m],4); C_FIXDIV(Fout[m2],4); C_FIXDIV(Fout[m3],4);
+
+        C_MUL(scratch[0],Fout[m] , *tw1 );
+        C_MUL(scratch[1],Fout[m2] , *tw2 );
+        C_MUL(scratch[2],Fout[m3] , *tw3 );
+
+        C_SUB( scratch[5] , *Fout, scratch[1] );
+        C_ADDTO(*Fout, scratch[1]);
+        C_ADD( scratch[3] , scratch[0] , scratch[2] );
+        C_SUB( scratch[4] , scratch[0] , scratch[2] );
+        C_SUB( Fout[m2], *Fout, scratch[3] );
+        tw1 += fstride;
+        tw2 += fstride*2;
+        tw3 += fstride*3;
+        C_ADDTO( *Fout , scratch[3] );
+
+        if(st->inverse) {
+            Fout[m].r = scratch[5].r - scratch[4].i;
+            Fout[m].i = scratch[5].i + scratch[4].r;
+            Fout[m3].r = scratch[5].r + scratch[4].i;
+            Fout[m3].i = scratch[5].i - scratch[4].r;
+        }else{
+            Fout[m].r = scratch[5].r + scratch[4].i;
+            Fout[m].i = scratch[5].i - scratch[4].r;
+            Fout[m3].r = scratch[5].r - scratch[4].i;
+            Fout[m3].i = scratch[5].i + scratch[4].r;
+        }
+        ++Fout;
+    }while(--k);
+}
+
+static void kf_bfly3(
+         kiss_fft_cpx * Fout,
+         const size_t fstride,
+         const kiss_fft_cfg st,
+         size_t m
+         )
+{
+     size_t k=m;
+     const size_t m2 = 2*m;
+     kiss_fft_cpx *tw1,*tw2;
+     kiss_fft_cpx scratch[5];
+     kiss_fft_cpx epi3;
+     epi3 = st->twiddles[fstride*m];
+
+     tw1=tw2=st->twiddles;
+
+     do{
+         C_FIXDIV(*Fout,3); C_FIXDIV(Fout[m],3); C_FIXDIV(Fout[m2],3);
+
+         C_MUL(scratch[1],Fout[m] , *tw1);
+         C_MUL(scratch[2],Fout[m2] , *tw2);
+
+         C_ADD(scratch[3],scratch[1],scratch[2]);
+         C_SUB(scratch[0],scratch[1],scratch[2]);
+         tw1 += fstride;
+         tw2 += fstride*2;
+
+         Fout[m].r = Fout->r - HALF_OF(scratch[3].r);
+         Fout[m].i = Fout->i - HALF_OF(scratch[3].i);
+
+         C_MULBYSCALAR( scratch[0] , epi3.i );
+
+         C_ADDTO(*Fout,scratch[3]);
+
+         Fout[m2].r = Fout[m].r + scratch[0].i;
+         Fout[m2].i = Fout[m].i - scratch[0].r;
+
+         Fout[m].r -= scratch[0].i;
+         Fout[m].i += scratch[0].r;
+
+         ++Fout;
+     }while(--k);
+}
+
+static void kf_bfly5(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx *Fout0,*Fout1,*Fout2,*Fout3,*Fout4;
+    int u;
+    kiss_fft_cpx scratch[13];
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx *tw;
+    kiss_fft_cpx ya,yb;
+    ya = twiddles[fstride*m];
+    yb = twiddles[fstride*2*m];
+
+    Fout0=Fout;
+    Fout1=Fout0+m;
+    Fout2=Fout0+2*m;
+    Fout3=Fout0+3*m;
+    Fout4=Fout0+4*m;
+
+    tw=st->twiddles;
+    for ( u=0; u<m; ++u ) {
+        C_FIXDIV( *Fout0,5); C_FIXDIV( *Fout1,5); C_FIXDIV( *Fout2,5); C_FIXDIV( *Fout3,5); C_FIXDIV( *Fout4,5);
+        scratch[0] = *Fout0;
+
+        C_MUL(scratch[1] ,*Fout1, tw[u*fstride]);
+        C_MUL(scratch[2] ,*Fout2, tw[2*u*fstride]);
+        C_MUL(scratch[3] ,*Fout3, tw[3*u*fstride]);
+        C_MUL(scratch[4] ,*Fout4, tw[4*u*fstride]);
+
+        C_ADD( scratch[7],scratch[1],scratch[4]);
+        C_SUB( scratch[10],scratch[1],scratch[4]);
+        C_ADD( scratch[8],scratch[2],scratch[3]);
+        C_SUB( scratch[9],scratch[2],scratch[3]);
+
+        Fout0->r += scratch[7].r + scratch[8].r;
+        Fout0->i += scratch[7].i + scratch[8].i;
+
+        scratch[5].r = scratch[0].r + S_MUL(scratch[7].r,ya.r) + S_MUL(scratch[8].r,yb.r);
+        scratch[5].i = scratch[0].i + S_MUL(scratch[7].i,ya.r) + S_MUL(scratch[8].i,yb.r);
+
+        scratch[6].r =  S_MUL(scratch[10].i,ya.i) + S_MUL(scratch[9].i,yb.i);
+        scratch[6].i = -S_MUL(scratch[10].r,ya.i) - S_MUL(scratch[9].r,yb.i);
+
+        C_SUB(*Fout1,scratch[5],scratch[6]);
+        C_ADD(*Fout4,scratch[5],scratch[6]);
+
+        scratch[11].r = scratch[0].r + S_MUL(scratch[7].r,yb.r) + S_MUL(scratch[8].r,ya.r);
+        scratch[11].i = scratch[0].i + S_MUL(scratch[7].i,yb.r) + S_MUL(scratch[8].i,ya.r);
+        scratch[12].r = - S_MUL(scratch[10].i,yb.i) + S_MUL(scratch[9].i,ya.i);
+        scratch[12].i = S_MUL(scratch[10].r,yb.i) - S_MUL(scratch[9].r,ya.i);
+
+        C_ADD(*Fout2,scratch[11],scratch[12]);
+        C_SUB(*Fout3,scratch[11],scratch[12]);
+
+        ++Fout0;++Fout1;++Fout2;++Fout3;++Fout4;
+    }
+}
+
+/* perform the butterfly for one stage of a mixed radix FFT */
+static void kf_bfly_generic(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m,
+        int p
+        )
+{
+    int u,k,q1,q;
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx t;
+    int Norig = st->nfft;
+
+    kiss_fft_cpx * scratch = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC(sizeof(kiss_fft_cpx)*p);
+    if (scratch == NULL){
+        KISS_FFT_ERROR("Memory allocation failed.");
+        return;
+    }
+
+    for ( u=0; u<m; ++u ) {
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            scratch[q1] = Fout[ k  ];
+            C_FIXDIV(scratch[q1],p);
+            k += m;
+        }
+
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            int twidx=0;
+            Fout[ k ] = scratch[0];
+            for (q=1;q<p;++q ) {
+                twidx += fstride * k;
+                if (twidx>=Norig) twidx-=Norig;
+                C_MUL(t,scratch[q] , twiddles[twidx] );
+                C_ADDTO( Fout[ k ] ,t);
+            }
+            k += m;
+        }
+    }
+    KISS_FFT_TMP_FREE(scratch);
+}
+
+static
+void kf_work(
+        kiss_fft_cpx * Fout,
+        const kiss_fft_cpx * f,
+        const size_t fstride,
+        int in_stride,
+        int * factors,
+        const kiss_fft_cfg st
+        )
+{
+    kiss_fft_cpx * Fout_beg=Fout;
+    const int p=*factors++; /* the radix  */
+    const int m=*factors++; /* stage's fft length/p */
+    const kiss_fft_cpx * Fout_end = Fout + p*m;
+
+#ifdef _OPENMP
+    // use openmp extensions at the
+    // top-level (not recursive)
+    if (fstride==1 && p<=5 && m!=1)
+    {
+        int k;
+
+        // execute the p different work units in different threads
+#       pragma omp parallel for
+        for (k=0;k<p;++k)
+            kf_work( Fout +k*m, f+ fstride*in_stride*k,fstride*p,in_stride,factors,st);
+        // all threads have joined by this point
+
+        switch (p) {
+            case 2: kf_bfly2(Fout,fstride,st,m); break;
+            case 3: kf_bfly3(Fout,fstride,st,m); break;
+            case 4: kf_bfly4(Fout,fstride,st,m); break;
+            case 5: kf_bfly5(Fout,fstride,st,m); break;
+            default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+        }
+        return;
+    }
+#endif
+
+    if (m==1) {
+        do{
+            *Fout = *f;
+            f += fstride*in_stride;
+        }while(++Fout != Fout_end );
+    }else{
+        do{
+            // recursive call:
+            // DFT of size m*p performed by doing
+            // p instances of smaller DFTs of size m,
+            // each one takes a decimated version of the input
+            kf_work( Fout , f, fstride*p, in_stride, factors,st);
+            f += fstride*in_stride;
+        }while( (Fout += m) != Fout_end );
+    }
+
+    Fout=Fout_beg;
+
+    // recombine the p smaller DFTs
+    switch (p) {
+        case 2: kf_bfly2(Fout,fstride,st,m); break;
+        case 3: kf_bfly3(Fout,fstride,st,m); break;
+        case 4: kf_bfly4(Fout,fstride,st,m); break;
+        case 5: kf_bfly5(Fout,fstride,st,m); break;
+        default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+    }
+}
+
+/*  facbuf is populated by p1,m1,p2,m2, ...
+    where
+    p[i] * m[i] = m[i-1]
+    m0 = n                  */
+static
+void kf_factor(int n,int * facbuf)
+{
+    int p=4;
+    double floor_sqrt;
+    floor_sqrt = floor( sqrt((double)n) );
+
+    /*factor out powers of 4, powers of 2, then any remaining primes */
+    do {
+        while (n % p) {
+            switch (p) {
+                case 4: p = 2; break;
+                case 2: p = 3; break;
+                default: p += 2; break;
+            }
+            if (p > floor_sqrt)
+                p = n;          /* no more factors, skip to end */
+        }
+        n /= p;
+        *facbuf++ = p;
+        *facbuf++ = n;
+    } while (n > 1);
+}
+
+/*
+ *
+ * User-callable function to allocate all necessary storage space for the fft.
+ *
+ * The return value is a contiguous block of memory, allocated with malloc.  As such,
+ * It can be freed with free(), rather than a kiss_fft-specific function.
+ * */
+kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem )
+{
+    KISS_FFT_ALIGN_CHECK(mem)
+
+    kiss_fft_cfg st=NULL;
+    size_t memneeded = KISS_FFT_ALIGN_SIZE_UP(sizeof(struct kiss_fft_state)
+        + sizeof(kiss_fft_cpx)*(nfft-1)); /* twiddle factors*/
+
+    if ( lenmem==NULL ) {
+        st = ( kiss_fft_cfg)KISS_FFT_MALLOC( memneeded );
+    }else{
+        if (mem != NULL && *lenmem >= memneeded)
+            st = (kiss_fft_cfg)mem;
+        *lenmem = memneeded;
+    }
+    if (st) {
+        int i;
+        st->nfft=nfft;
+        st->inverse = inverse_fft;
+
+        for (i=0;i<nfft;++i) {
+            const double pi=3.141592653589793238462643383279502884197169399375105820974944;
+            double phase = -2*pi*i / nfft;
+            if (st->inverse)
+                phase *= -1;
+            kf_cexp(st->twiddles+i, phase );
+        }
+
+        kf_factor(nfft,st->factors);
+    }
+    return st;
+}
+
+
+void kiss_fft_stride(kiss_fft_cfg st,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int in_stride)
+{
+    if (fin == fout) {
+        //NOTE: this is not really an in-place FFT algorithm.
+        //It just performs an out-of-place FFT into a temp buffer
+        if (fout == NULL){
+            KISS_FFT_ERROR("fout buffer NULL.");
+        return;
+        }
+
+        kiss_fft_cpx * tmpbuf = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC( sizeof(kiss_fft_cpx)*st->nfft);
+        if (tmpbuf == NULL){
+            KISS_FFT_ERROR("Memory allocation error.");
+        return;
+        }
+
+
+
+        kf_work(tmpbuf,fin,1,in_stride, st->factors,st);
+        memcpy(fout,tmpbuf,sizeof(kiss_fft_cpx)*st->nfft);
+        KISS_FFT_TMP_FREE(tmpbuf);
+    }else{
+        kf_work( fout, fin, 1,in_stride, st->factors,st );
+    }
+}
+
+void kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout)
+{
+    kiss_fft_stride(cfg,fin,fout,1);
+}
+
+
+void kiss_fft_cleanup(void)
+{
+    // nothing needed any more
+}
+
+int kiss_fft_next_fast_size(int n)
+{
+    while(1) {
+        int m=n;
+        while ( (m%2) == 0 ) m/=2;
+        while ( (m%3) == 0 ) m/=3;
+        while ( (m%5) == 0 ) m/=5;
+        if (m<=1)
+            break; /* n is completely factorable by twos, threes, and fives */
+        n++;
+    }
+    return n;
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fft.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fft.h
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef KISS_FFT_H
+#define KISS_FFT_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+// Define KISS_FFT_SHARED macro to properly export symbols
+#ifdef KISS_FFT_SHARED
+# ifdef _WIN32
+#  ifdef KISS_FFT_BUILD
+#   define KISS_FFT_API __declspec(dllexport)
+#  else
+#   define KISS_FFT_API __declspec(dllimport)
+#  endif
+# else
+#  define KISS_FFT_API __attribute__ ((visibility ("default")))
+# endif
+#else
+# define KISS_FFT_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ATTENTION!
+ If you would like a :
+ -- a utility that will handle the caching of fft objects
+ -- real-only (no imaginary time component ) FFT
+ -- a multi-dimensional FFT
+ -- a command-line utility to perform ffts
+ -- a command-line utility to perform fast-convolution filtering
+
+ Then see kfc.h kiss_fftr.h kiss_fftnd.h fftutil.c kiss_fastfir.c
+  in the tools/ directory.
+*/
+
+/* User may override KISS_FFT_MALLOC and/or KISS_FFT_FREE. */
+#ifdef USE_SIMD
+# include <xmmintrin.h>
+# define kiss_fft_scalar __m128
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+#  define KISS_FFT_ALIGN_CHECK(ptr) 
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 15UL) & ~0xFUL)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE _mm_free
+# endif
+#else
+# define KISS_FFT_ALIGN_CHECK(ptr)
+# define KISS_FFT_ALIGN_SIZE_UP(size) (size)
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC malloc
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
+#endif
+
+
+#ifdef FIXED_POINT
+#include <stdint.h>
+# if (FIXED_POINT == 32)
+#  define kiss_fft_scalar int32_t
+# else	
+#  define kiss_fft_scalar int16_t
+# endif
+#else
+# ifndef kiss_fft_scalar
+/*  default is float */
+#   define kiss_fft_scalar float
+# endif
+#endif
+
+typedef struct {
+    kiss_fft_scalar r;
+    kiss_fft_scalar i;
+}kiss_fft_cpx;
+
+typedef struct kiss_fft_state* kiss_fft_cfg;
+
+/* 
+ *  kiss_fft_alloc
+ *  
+ *  Initialize a FFT (or IFFT) algorithm's cfg/state buffer.
+ *
+ *  typical usage:      kiss_fft_cfg mycfg=kiss_fft_alloc(1024,0,NULL,NULL);
+ *
+ *  The return value from fft_alloc is a cfg buffer used internally
+ *  by the fft routine or NULL.
+ *
+ *  If lenmem is NULL, then kiss_fft_alloc will allocate a cfg buffer using malloc.
+ *  The returned value should be free()d when done to avoid memory leaks.
+ *  
+ *  The state can be placed in a user supplied buffer 'mem':
+ *  If lenmem is not NULL and mem is not NULL and *lenmem is large enough,
+ *      then the function places the cfg in mem and the size used in *lenmem
+ *      and returns mem.
+ *  
+ *  If lenmem is not NULL and ( mem is NULL or *lenmem is not large enough),
+ *      then the function returns NULL and places the minimum cfg 
+ *      buffer size in *lenmem.
+ * */
+
+kiss_fft_cfg KISS_FFT_API kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem);
+
+/*
+ * kiss_fft(cfg,in_out_buf)
+ *
+ * Perform an FFT on a complex input buffer.
+ * for a forward FFT,
+ * fin should be  f[0] , f[1] , ... ,f[nfft-1]
+ * fout will be   F[0] , F[1] , ... ,F[nfft-1]
+ * Note that each element is complex and can be accessed like
+    f[k].r and f[k].i
+ * */
+void KISS_FFT_API kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout);
+
+/*
+ A more generic version of the above function. It reads its input from every Nth sample.
+ * */
+void KISS_FFT_API kiss_fft_stride(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int fin_stride);
+
+/* If kiss_fft_alloc allocated a buffer, it is one contiguous 
+   buffer and can be simply free()d when no longer needed*/
+#define kiss_fft_free KISS_FFT_FREE
+
+/*
+ Cleans up some memory that gets managed internally. Not necessary to call, but it might clean up 
+ your compiler output to call this before you exit.
+*/
+void KISS_FFT_API kiss_fft_cleanup(void);
+	
+
+/*
+ * Returns the smallest integer k, such that k>=n and k has only "fast" factors (2,3,5)
+ */
+int KISS_FFT_API kiss_fft_next_fast_size(int n);
+
+/* for real ffts, we need an even size */
+#define kiss_fftr_next_fast_size_real(n) \
+        (kiss_fft_next_fast_size( ((n)+1)>>1)<<1)
+
+#ifdef __cplusplus
+} 
+#endif
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fft_log.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fft_log.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef kiss_fft_log_h
+#define kiss_fft_log_h
+
+#define ERROR 1
+#define WARNING 2
+#define INFO 3
+#define DEBUG 4
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#if defined(NDEBUG)
+# define KISS_FFT_LOG_MSG(severity, ...) ((void)0)
+#else
+# define KISS_FFT_LOG_MSG(severity, ...) \
+    fprintf(stderr, "[" #severity "] " __FILE__ ":" TOSTRING(__LINE__) " "); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n")
+#endif
+
+#define KISS_FFT_ERROR(...) KISS_FFT_LOG_MSG(ERROR, __VA_ARGS__)
+#define KISS_FFT_WARNING(...) KISS_FFT_LOG_MSG(WARNING, __VA_ARGS__)
+#define KISS_FFT_INFO(...) KISS_FFT_LOG_MSG(INFO, __VA_ARGS__)
+#define KISS_FFT_DEBUG(...) KISS_FFT_LOG_MSG(DEBUG, __VA_ARGS__)
+
+
+
+#endif /* kiss_fft_log_h */

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fftr.c
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fftr.c
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (c) 2003-2004, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#include "kiss_fftr.h"
+#include "_kiss_fft_guts.h"
+
+struct kiss_fftr_state{
+    kiss_fft_cfg substate;
+    kiss_fft_cpx * tmpbuf;
+    kiss_fft_cpx * super_twiddles;
+#ifdef USE_SIMD
+    void * pad;
+#endif
+};
+
+kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem)
+{
+	KISS_FFT_ALIGN_CHECK(mem)
+
+    int i;
+    kiss_fftr_cfg st = NULL;
+    size_t subsize = 0, memneeded;
+
+    if (nfft & 1) {
+        KISS_FFT_ERROR("Real FFT optimization must be even.");
+        return NULL;
+    }
+    nfft >>= 1;
+
+    kiss_fft_alloc (nfft, inverse_fft, NULL, &subsize);
+    memneeded = sizeof(struct kiss_fftr_state) + subsize + sizeof(kiss_fft_cpx) * ( nfft * 3 / 2);
+
+    if (lenmem == NULL) {
+        st = (kiss_fftr_cfg) KISS_FFT_MALLOC (memneeded);
+    } else {
+        if (*lenmem >= memneeded)
+            st = (kiss_fftr_cfg) mem;
+        *lenmem = memneeded;
+    }
+    if (!st)
+        return NULL;
+
+    st->substate = (kiss_fft_cfg) (st + 1); /*just beyond kiss_fftr_state struct */
+    st->tmpbuf = (kiss_fft_cpx *) (((char *) st->substate) + subsize);
+    st->super_twiddles = st->tmpbuf + nfft;
+    kiss_fft_alloc(nfft, inverse_fft, st->substate, &subsize);
+
+    for (i = 0; i < nfft/2; ++i) {
+        double phase =
+            -3.14159265358979323846264338327 * ((double) (i+1) / nfft + .5);
+        if (inverse_fft)
+            phase *= -1;
+        kf_cexp (st->super_twiddles+i,phase);
+    }
+    return st;
+}
+
+void kiss_fftr(kiss_fftr_cfg st,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata)
+{
+    /* input buffer timedata is stored row-wise */
+    int k,ncfft;
+    kiss_fft_cpx fpnk,fpk,f1k,f2k,tw,tdc;
+
+    if ( st->substate->inverse) {
+        KISS_FFT_ERROR("kiss fft usage error: improper alloc");
+        return;/* The caller did not call the correct function */
+    }
+
+    ncfft = st->substate->nfft;
+
+    /*perform the parallel fft of two real signals packed in real,imag*/
+    kiss_fft( st->substate , (const kiss_fft_cpx*)timedata, st->tmpbuf );
+    /* The real part of the DC element of the frequency spectrum in st->tmpbuf
+     * contains the sum of the even-numbered elements of the input time sequence
+     * The imag part is the sum of the odd-numbered elements
+     *
+     * The sum of tdc.r and tdc.i is the sum of the input time sequence.
+     *      yielding DC of input time sequence
+     * The difference of tdc.r - tdc.i is the sum of the input (dot product) [1,-1,1,-1...
+     *      yielding Nyquist bin of input time sequence
+     */
+
+    tdc.r = st->tmpbuf[0].r;
+    tdc.i = st->tmpbuf[0].i;
+    C_FIXDIV(tdc,2);
+    CHECK_OVERFLOW_OP(tdc.r ,+, tdc.i);
+    CHECK_OVERFLOW_OP(tdc.r ,-, tdc.i);
+    freqdata[0].r = tdc.r + tdc.i;
+    freqdata[ncfft].r = tdc.r - tdc.i;
+#ifdef USE_SIMD
+    freqdata[ncfft].i = freqdata[0].i = _mm_set1_ps(0);
+#else
+    freqdata[ncfft].i = freqdata[0].i = 0;
+#endif
+
+    for ( k=1;k <= ncfft/2 ; ++k ) {
+        fpk    = st->tmpbuf[k];
+        fpnk.r =   st->tmpbuf[ncfft-k].r;
+        fpnk.i = - st->tmpbuf[ncfft-k].i;
+        C_FIXDIV(fpk,2);
+        C_FIXDIV(fpnk,2);
+
+        C_ADD( f1k, fpk , fpnk );
+        C_SUB( f2k, fpk , fpnk );
+        C_MUL( tw , f2k , st->super_twiddles[k-1]);
+
+        freqdata[k].r = HALF_OF(f1k.r + tw.r);
+        freqdata[k].i = HALF_OF(f1k.i + tw.i);
+        freqdata[ncfft-k].r = HALF_OF(f1k.r - tw.r);
+        freqdata[ncfft-k].i = HALF_OF(tw.i - f1k.i);
+    }
+}
+
+void kiss_fftri(kiss_fftr_cfg st,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata)
+{
+    /* input buffer timedata is stored row-wise */
+    int k, ncfft;
+
+    if (st->substate->inverse == 0) {
+        KISS_FFT_ERROR("kiss fft usage error: improper alloc");
+        return;/* The caller did not call the correct function */
+    }
+
+    ncfft = st->substate->nfft;
+
+    st->tmpbuf[0].r = freqdata[0].r + freqdata[ncfft].r;
+    st->tmpbuf[0].i = freqdata[0].r - freqdata[ncfft].r;
+    C_FIXDIV(st->tmpbuf[0],2);
+
+    for (k = 1; k <= ncfft / 2; ++k) {
+        kiss_fft_cpx fk, fnkc, fek, fok, tmp;
+        fk = freqdata[k];
+        fnkc.r = freqdata[ncfft - k].r;
+        fnkc.i = -freqdata[ncfft - k].i;
+        C_FIXDIV( fk , 2 );
+        C_FIXDIV( fnkc , 2 );
+
+        C_ADD (fek, fk, fnkc);
+        C_SUB (tmp, fk, fnkc);
+        C_MUL (fok, tmp, st->super_twiddles[k-1]);
+        C_ADD (st->tmpbuf[k],     fek, fok);
+        C_SUB (st->tmpbuf[ncfft - k], fek, fok);
+#ifdef USE_SIMD
+        st->tmpbuf[ncfft - k].i *= _mm_set1_ps(-1.0);
+#else
+        st->tmpbuf[ncfft - k].i *= -1;
+#endif
+    }
+    kiss_fft (st->substate, st->tmpbuf, (kiss_fft_cpx *) timedata);
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fftr.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/kissfft/kiss_fftr.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2003-2004, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef KISS_FTR_H
+#define KISS_FTR_H
+
+#include "kiss_fft.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    
+/* 
+ 
+ Real optimized version can save about 45% cpu time vs. complex fft of a real seq.
+
+ 
+ 
+ */
+
+typedef struct kiss_fftr_state *kiss_fftr_cfg;
+
+
+kiss_fftr_cfg KISS_FFT_API kiss_fftr_alloc(int nfft,int inverse_fft,void * mem, size_t * lenmem);
+/*
+ nfft must be even
+
+ If you don't care to allocate space, use mem = lenmem = NULL 
+*/
+
+
+void KISS_FFT_API kiss_fftr(kiss_fftr_cfg cfg,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata);
+/*
+ input timedata has nfft scalar points
+ output freqdata has nfft/2+1 complex points
+*/
+
+void KISS_FFT_API kiss_fftri(kiss_fftr_cfg cfg,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata);
+/*
+ input freqdata has  nfft/2+1 complex points
+ output timedata has nfft scalar points
+*/
+
+#define kiss_fftr_free KISS_FFT_FREE
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/pommier/neon_mathfun.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/pommier/neon_mathfun.h
@@ -1,0 +1,301 @@
+/* NEON implementation of sin, cos, exp and log
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library
+*/
+
+/* Copyright (C) 2011  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+
+#include <arm_neon.h>
+
+typedef float32x4_t v4sf;  // vector of 4 float
+typedef uint32x4_t v4su;  // vector of 4 uint32
+typedef int32x4_t v4si;  // vector of 4 uint32
+
+#define c_inv_mant_mask ~0x7f800000u
+#define c_cephes_SQRTHF 0.707106781186547524
+#define c_cephes_log_p0 7.0376836292E-2
+#define c_cephes_log_p1 - 1.1514610310E-1
+#define c_cephes_log_p2 1.1676998740E-1
+#define c_cephes_log_p3 - 1.2420140846E-1
+#define c_cephes_log_p4 + 1.4249322787E-1
+#define c_cephes_log_p5 - 1.6668057665E-1
+#define c_cephes_log_p6 + 2.0000714765E-1
+#define c_cephes_log_p7 - 2.4999993993E-1
+#define c_cephes_log_p8 + 3.3333331174E-1
+#define c_cephes_log_q1 -2.12194440e-4
+#define c_cephes_log_q2 0.693359375
+
+/* natural logarithm computed for 4 simultaneous float 
+   return NaN for x <= 0
+*/
+v4sf log_ps(v4sf x) {
+  v4sf one = vdupq_n_f32(1);
+
+  x = vmaxq_f32(x, vdupq_n_f32(0)); /* force flush to zero on denormal values */
+  v4su invalid_mask = vcleq_f32(x, vdupq_n_f32(0));
+
+  v4si ux = vreinterpretq_s32_f32(x);
+  
+  v4si emm0 = vshrq_n_s32(ux, 23);
+
+  /* keep only the fractional part */
+  ux = vandq_s32(ux, vdupq_n_s32(c_inv_mant_mask));
+  ux = vorrq_s32(ux, vreinterpretq_s32_f32(vdupq_n_f32(0.5f)));
+  x = vreinterpretq_f32_s32(ux);
+
+  emm0 = vsubq_s32(emm0, vdupq_n_s32(0x7f));
+  v4sf e = vcvtq_f32_s32(emm0);
+
+  e = vaddq_f32(e, one);
+
+  /* part2: 
+     if( x < SQRTHF ) {
+       e -= 1;
+       x = x + x - 1.0;
+     } else { x = x - 1.0; }
+  */
+  v4su mask = vcltq_f32(x, vdupq_n_f32(c_cephes_SQRTHF));
+  v4sf tmp = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(x), mask));
+  x = vsubq_f32(x, one);
+  e = vsubq_f32(e, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(one), mask)));
+  x = vaddq_f32(x, tmp);
+
+  v4sf z = vmulq_f32(x,x);
+
+  v4sf y = vdupq_n_f32(c_cephes_log_p0);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p1));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p2));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p3));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p4));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p5));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p6));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p7));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p8));
+  y = vmulq_f32(y, x);
+
+  y = vmulq_f32(y, z);
+  
+
+  tmp = vmulq_f32(e, vdupq_n_f32(c_cephes_log_q1));
+  y = vaddq_f32(y, tmp);
+
+
+  tmp = vmulq_f32(z, vdupq_n_f32(0.5f));
+  y = vsubq_f32(y, tmp);
+
+  tmp = vmulq_f32(e, vdupq_n_f32(c_cephes_log_q2));
+  x = vaddq_f32(x, y);
+  x = vaddq_f32(x, tmp);
+  x = vreinterpretq_f32_u32(vorrq_u32(vreinterpretq_u32_f32(x), invalid_mask)); // negative arg will be NAN
+  return x;
+}
+
+#define c_exp_hi 88.3762626647949f
+#define c_exp_lo -88.3762626647949f
+
+#define c_cephes_LOG2EF 1.44269504088896341
+#define c_cephes_exp_C1 0.693359375
+#define c_cephes_exp_C2 -2.12194440e-4
+
+#define c_cephes_exp_p0 1.9875691500E-4
+#define c_cephes_exp_p1 1.3981999507E-3
+#define c_cephes_exp_p2 8.3334519073E-3
+#define c_cephes_exp_p3 4.1665795894E-2
+#define c_cephes_exp_p4 1.6666665459E-1
+#define c_cephes_exp_p5 5.0000001201E-1
+
+/* exp() computed for 4 float at once */
+v4sf exp_ps(v4sf x) {
+  v4sf tmp, fx;
+
+  v4sf one = vdupq_n_f32(1);
+  x = vminq_f32(x, vdupq_n_f32(c_exp_hi));
+  x = vmaxq_f32(x, vdupq_n_f32(c_exp_lo));
+
+  /* express exp(x) as exp(g + n*log(2)) */
+  fx = vmlaq_f32(vdupq_n_f32(0.5f), x, vdupq_n_f32(c_cephes_LOG2EF));
+
+  /* perform a floorf */
+  tmp = vcvtq_f32_s32(vcvtq_s32_f32(fx));
+
+  /* if greater, substract 1 */
+  v4su mask = vcgtq_f32(tmp, fx);    
+  mask = vandq_u32(mask, vreinterpretq_u32_f32(one));
+
+
+  fx = vsubq_f32(tmp, vreinterpretq_f32_u32(mask));
+
+  tmp = vmulq_f32(fx, vdupq_n_f32(c_cephes_exp_C1));
+  v4sf z = vmulq_f32(fx, vdupq_n_f32(c_cephes_exp_C2));
+  x = vsubq_f32(x, tmp);
+  x = vsubq_f32(x, z);
+
+  static const float32_t cephes_exp_p[6] = { c_cephes_exp_p0, c_cephes_exp_p1, c_cephes_exp_p2, c_cephes_exp_p3, c_cephes_exp_p4, c_cephes_exp_p5 };
+  v4sf y = vld1q_dup_f32(cephes_exp_p+0);
+  v4sf c1 = vld1q_dup_f32(cephes_exp_p+1); 
+  v4sf c2 = vld1q_dup_f32(cephes_exp_p+2); 
+  v4sf c3 = vld1q_dup_f32(cephes_exp_p+3); 
+  v4sf c4 = vld1q_dup_f32(cephes_exp_p+4); 
+  v4sf c5 = vld1q_dup_f32(cephes_exp_p+5);
+
+  y = vmulq_f32(y, x);
+  z = vmulq_f32(x,x);
+  y = vaddq_f32(y, c1);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, c2);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, c3);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, c4);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, c5);
+  
+  y = vmulq_f32(y, z);
+  y = vaddq_f32(y, x);
+  y = vaddq_f32(y, one);
+
+  /* build 2^n */
+  int32x4_t mm;
+  mm = vcvtq_s32_f32(fx);
+  mm = vaddq_s32(mm, vdupq_n_s32(0x7f));
+  mm = vshlq_n_s32(mm, 23);
+  v4sf pow2n = vreinterpretq_f32_s32(mm);
+
+  y = vmulq_f32(y, pow2n);
+  return y;
+}
+
+#define c_minus_cephes_DP1 -0.78515625
+#define c_minus_cephes_DP2 -2.4187564849853515625e-4
+#define c_minus_cephes_DP3 -3.77489497744594108e-8
+#define c_sincof_p0 -1.9515295891E-4
+#define c_sincof_p1  8.3321608736E-3
+#define c_sincof_p2 -1.6666654611E-1
+#define c_coscof_p0  2.443315711809948E-005
+#define c_coscof_p1 -1.388731625493765E-003
+#define c_coscof_p2  4.166664568298827E-002
+#define c_cephes_FOPI 1.27323954473516 // 4 / M_PI
+
+/* evaluation of 4 sines & cosines at once.
+
+   The code is the exact rewriting of the cephes sinf function.
+   Precision is excellent as long as x < 8192 (I did not bother to
+   take into account the special handling they have for greater values
+   -- it does not return garbage for arguments over 8192, though, but
+   the extra precision is missing).
+
+   Note that it is such that sinf((float)M_PI) = 8.74e-8, which is the
+   surprising but correct result.
+
+   Note also that when you compute sin(x), cos(x) is available at
+   almost no extra price so both sin_ps and cos_ps make use of
+   sincos_ps..
+  */
+void sincos_ps(v4sf x, v4sf *ysin, v4sf *ycos) { // any x
+  v4sf xmm1, xmm2, xmm3, y;
+
+  v4su emm2;
+  
+  v4su sign_mask_sin, sign_mask_cos;
+  sign_mask_sin = vcltq_f32(x, vdupq_n_f32(0));
+  x = vabsq_f32(x);
+
+  /* scale by 4/Pi */
+  y = vmulq_f32(x, vdupq_n_f32(c_cephes_FOPI));
+
+  /* store the integer part of y in mm0 */
+  emm2 = vcvtq_u32_f32(y);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = vaddq_u32(emm2, vdupq_n_u32(1));
+  emm2 = vandq_u32(emm2, vdupq_n_u32(~1));
+  y = vcvtq_f32_u32(emm2);
+
+  /* get the polynom selection mask 
+     there is one polynom for 0 <= x <= Pi/4
+     and another one for Pi/4<x<=Pi/2
+
+     Both branches will be computed.
+  */
+  v4su poly_mask = vtstq_u32(emm2, vdupq_n_u32(2));
+  
+  /* The magic pass: "Extended precision modular arithmetic" 
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = vmulq_n_f32(y, c_minus_cephes_DP1);
+  xmm2 = vmulq_n_f32(y, c_minus_cephes_DP2);
+  xmm3 = vmulq_n_f32(y, c_minus_cephes_DP3);
+  x = vaddq_f32(x, xmm1);
+  x = vaddq_f32(x, xmm2);
+  x = vaddq_f32(x, xmm3);
+
+  sign_mask_sin = veorq_u32(sign_mask_sin, vtstq_u32(emm2, vdupq_n_u32(4)));
+  sign_mask_cos = vtstq_u32(vsubq_u32(emm2, vdupq_n_u32(2)), vdupq_n_u32(4));
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) in y1, 
+     and the second polynom      (Pi/4 <= x <= 0) in y2 */
+  v4sf z = vmulq_f32(x,x);
+  v4sf y1, y2;
+
+  y1 = vmulq_n_f32(z, c_coscof_p0);
+  y2 = vmulq_n_f32(z, c_sincof_p0);
+  y1 = vaddq_f32(y1, vdupq_n_f32(c_coscof_p1));
+  y2 = vaddq_f32(y2, vdupq_n_f32(c_sincof_p1));
+  y1 = vmulq_f32(y1, z);
+  y2 = vmulq_f32(y2, z);
+  y1 = vaddq_f32(y1, vdupq_n_f32(c_coscof_p2));
+  y2 = vaddq_f32(y2, vdupq_n_f32(c_sincof_p2));
+  y1 = vmulq_f32(y1, z);
+  y2 = vmulq_f32(y2, z);
+  y1 = vmulq_f32(y1, z);
+  y2 = vmulq_f32(y2, x);
+  y1 = vsubq_f32(y1, vmulq_f32(z, vdupq_n_f32(0.5f)));
+  y2 = vaddq_f32(y2, x);
+  y1 = vaddq_f32(y1, vdupq_n_f32(1));
+
+  /* select the correct result from the two polynoms */  
+  v4sf ys = vbslq_f32(poly_mask, y1, y2);
+  v4sf yc = vbslq_f32(poly_mask, y2, y1);
+  *ysin = vbslq_f32(sign_mask_sin, vnegq_f32(ys), ys);
+  *ycos = vbslq_f32(sign_mask_cos, yc, vnegq_f32(yc));
+}
+
+v4sf sin_ps(v4sf x) {
+  v4sf ysin, ycos; 
+  sincos_ps(x, &ysin, &ycos); 
+  return ysin;
+}
+
+v4sf cos_ps(v4sf x) {
+  v4sf ysin, ycos; 
+  sincos_ps(x, &ysin, &ycos); 
+  return ycos;
+}
+
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/pommier/sse_mathfun.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/pommier/sse_mathfun.h
@@ -1,0 +1,766 @@
+
+#ifndef POMMIER_SSE_MATHFUN_H
+#define POMMIER_SSE_MATHFUN_H
+
+/* SIMD (SSE1+MMX or SSE2) implementation of sin, cos, exp and log
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library
+
+   The default is to use the SSE1 version. If you define USE_SSE2 the
+   the SSE2 intrinsics will be used in place of the MMX intrinsics. Do
+   not expect any significant performance improvement with SSE2.
+*/
+
+/* Copyright (C) 2007  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+
+#include <xmmintrin.h>
+
+/* yes I know, the top of this file is quite ugly */
+
+#ifdef _MSC_VER /* visual c++ */
+# define ALIGN16_BEG __declspec(align(16))
+# define ALIGN16_END 
+#else /* gcc or icc */
+# define ALIGN16_BEG
+# define ALIGN16_END __attribute__((aligned(16)))
+#endif
+
+/* __m128 is ugly to write */
+typedef __m128 v4sf;  // vector of 4 float (sse1)
+
+#ifdef USE_SSE2
+# include <emmintrin.h>
+typedef __m128i v4si; // vector of 4 int (sse2)
+#else
+typedef __m64 v2si;   // vector of 2 int (mmx)
+#endif
+
+/* declare some SSE constants -- why can't I figure a better way to do that? */
+#define _PS_CONST(Name, Val)                                            \
+  static const ALIGN16_BEG float _ps_##Name[4] ALIGN16_END = { Val, Val, Val, Val }
+#define _PI32_CONST(Name, Val)                                            \
+  static const ALIGN16_BEG int _pi32_##Name[4] ALIGN16_END = { Val, Val, Val, Val }
+#define _PS_CONST_TYPE(Name, Type, Val)                                 \
+  static const ALIGN16_BEG Type _ps_##Name[4] ALIGN16_END = { Val, Val, Val, Val }
+
+_PS_CONST(1  , 1.0f);
+_PS_CONST(0p5, 0.5f);
+/* the smallest non denormalized float number */
+_PS_CONST_TYPE(min_norm_pos, int, 0x00800000);
+_PS_CONST_TYPE(mant_mask, int, 0x7f800000);
+_PS_CONST_TYPE(inv_mant_mask, int, ~0x7f800000);
+
+_PS_CONST_TYPE(sign_mask, int, (int)0x80000000);
+_PS_CONST_TYPE(inv_sign_mask, int, ~0x80000000);
+
+_PI32_CONST(1, 1);
+_PI32_CONST(inv1, ~1);
+_PI32_CONST(2, 2);
+_PI32_CONST(4, 4);
+_PI32_CONST(0x7f, 0x7f);
+
+_PS_CONST(cephes_SQRTHF, 0.707106781186547524);
+_PS_CONST(cephes_log_p0, 7.0376836292E-2);
+_PS_CONST(cephes_log_p1, - 1.1514610310E-1);
+_PS_CONST(cephes_log_p2, 1.1676998740E-1);
+_PS_CONST(cephes_log_p3, - 1.2420140846E-1);
+_PS_CONST(cephes_log_p4, + 1.4249322787E-1);
+_PS_CONST(cephes_log_p5, - 1.6668057665E-1);
+_PS_CONST(cephes_log_p6, + 2.0000714765E-1);
+_PS_CONST(cephes_log_p7, - 2.4999993993E-1);
+_PS_CONST(cephes_log_p8, + 3.3333331174E-1);
+_PS_CONST(cephes_log_q1, -2.12194440e-4);
+_PS_CONST(cephes_log_q2, 0.693359375);
+
+#if defined (__MINGW32__)
+
+/* the ugly part below: many versions of gcc used to be completely buggy with respect to some intrinsics
+   The movehl_ps is fixed in mingw 3.4.5, but I found out that all the _mm_cmp* intrinsics were completely
+   broken on my mingw gcc 3.4.5 ...
+
+   Note that the bug on _mm_cmp* does occur only at -O0 optimization level
+*/
+
+inline __m128 my_movehl_ps(__m128 a, const __m128 b) {
+	asm (
+			"movhlps %2,%0\n\t"
+			: "=x" (a)
+			: "0" (a), "x"(b)
+	    );
+	return a;                                 }
+#warning "redefined _mm_movehl_ps (see gcc bug 21179)"
+#define _mm_movehl_ps my_movehl_ps
+
+inline __m128 my_cmplt_ps(__m128 a, const __m128 b) {
+	asm (
+			"cmpltps %2,%0\n\t"
+			: "=x" (a)
+			: "0" (a), "x"(b)
+	    );
+	return a;               
+                  }
+inline __m128 my_cmpgt_ps(__m128 a, const __m128 b) {
+	asm (
+			"cmpnleps %2,%0\n\t"
+			: "=x" (a)
+			: "0" (a), "x"(b)
+	    );
+	return a;               
+}
+inline __m128 my_cmpeq_ps(__m128 a, const __m128 b) {
+	asm (
+			"cmpeqps %2,%0\n\t"
+			: "=x" (a)
+			: "0" (a), "x"(b)
+	    );
+	return a;               
+}
+#warning "redefined _mm_cmpxx_ps functions..."
+#define _mm_cmplt_ps my_cmplt_ps
+#define _mm_cmpgt_ps my_cmpgt_ps
+#define _mm_cmpeq_ps my_cmpeq_ps
+#endif
+
+#ifndef USE_SSE2
+typedef union xmm_mm_union {
+  __m128 xmm;
+  __m64 mm[2];
+} xmm_mm_union;
+
+#define COPY_XMM_TO_MM(xmm_, mm0_, mm1_) {          \
+    xmm_mm_union u; u.xmm = xmm_;                   \
+    mm0_ = u.mm[0];                                 \
+    mm1_ = u.mm[1];                                 \
+}
+
+#define COPY_MM_TO_XMM(mm0_, mm1_, xmm_) {                         \
+    xmm_mm_union u; u.mm[0]=mm0_; u.mm[1]=mm1_; xmm_ = u.xmm;      \
+  }
+
+#endif // USE_SSE2
+
+/* natural logarithm computed for 4 simultaneous float 
+   return NaN for x <= 0
+*/
+v4sf log_ps(v4sf x) {
+#ifdef USE_SSE2
+  v4si emm0;
+#else
+  v2si mm0, mm1;
+#endif
+  v4sf one = *(v4sf*)_ps_1;
+
+  v4sf invalid_mask = _mm_cmple_ps(x, _mm_setzero_ps());
+
+  x = _mm_max_ps(x, *(v4sf*)_ps_min_norm_pos);  /* cut off denormalized stuff */
+
+#ifndef USE_SSE2
+  /* part 1: x = frexpf(x, &e); */
+  COPY_XMM_TO_MM(x, mm0, mm1);
+  mm0 = _mm_srli_pi32(mm0, 23);
+  mm1 = _mm_srli_pi32(mm1, 23);
+#else
+  emm0 = _mm_srli_epi32(_mm_castps_si128(x), 23);
+#endif
+  /* keep only the fractional part */
+  x = _mm_and_ps(x, *(v4sf*)_ps_inv_mant_mask);
+  x = _mm_or_ps(x, *(v4sf*)_ps_0p5);
+
+#ifndef USE_SSE2
+  /* now e=mm0:mm1 contain the really base-2 exponent */
+  mm0 = _mm_sub_pi32(mm0, *(v2si*)_pi32_0x7f);
+  mm1 = _mm_sub_pi32(mm1, *(v2si*)_pi32_0x7f);
+  v4sf e = _mm_cvtpi32x2_ps(mm0, mm1);
+  _mm_empty(); /* bye bye mmx */
+#else
+  emm0 = _mm_sub_epi32(emm0, *(v4si*)_pi32_0x7f);
+  v4sf e = _mm_cvtepi32_ps(emm0);
+#endif
+
+  e = _mm_add_ps(e, one);
+
+  /* part2: 
+     if( x < SQRTHF ) {
+       e -= 1;
+       x = x + x - 1.0;
+     } else { x = x - 1.0; }
+  */
+  v4sf mask = _mm_cmplt_ps(x, *(v4sf*)_ps_cephes_SQRTHF);
+  v4sf tmp = _mm_and_ps(x, mask);
+  x = _mm_sub_ps(x, one);
+  e = _mm_sub_ps(e, _mm_and_ps(one, mask));
+  x = _mm_add_ps(x, tmp);
+
+
+  v4sf z = _mm_mul_ps(x,x);
+
+  v4sf y = *(v4sf*)_ps_cephes_log_p0;
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p1);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p2);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p3);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p4);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p5);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p6);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p7);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p8);
+  y = _mm_mul_ps(y, x);
+
+  y = _mm_mul_ps(y, z);
+  
+
+  tmp = _mm_mul_ps(e, *(v4sf*)_ps_cephes_log_q1);
+  y = _mm_add_ps(y, tmp);
+
+
+  tmp = _mm_mul_ps(z, *(v4sf*)_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+
+  tmp = _mm_mul_ps(e, *(v4sf*)_ps_cephes_log_q2);
+  x = _mm_add_ps(x, y);
+  x = _mm_add_ps(x, tmp);
+  x = _mm_or_ps(x, invalid_mask); // negative arg will be NAN
+  return x;
+}
+
+_PS_CONST(exp_hi,	88.3762626647949f);
+_PS_CONST(exp_lo,	-88.3762626647949f);
+
+_PS_CONST(cephes_LOG2EF, 1.44269504088896341);
+_PS_CONST(cephes_exp_C1, 0.693359375);
+_PS_CONST(cephes_exp_C2, -2.12194440e-4);
+
+_PS_CONST(cephes_exp_p0, 1.9875691500E-4);
+_PS_CONST(cephes_exp_p1, 1.3981999507E-3);
+_PS_CONST(cephes_exp_p2, 8.3334519073E-3);
+_PS_CONST(cephes_exp_p3, 4.1665795894E-2);
+_PS_CONST(cephes_exp_p4, 1.6666665459E-1);
+_PS_CONST(cephes_exp_p5, 5.0000001201E-1);
+
+v4sf exp_ps(v4sf x) {
+  v4sf tmp = _mm_setzero_ps(), fx;
+#ifdef USE_SSE2
+  v4si emm0;
+#else
+  v2si mm0, mm1;
+#endif
+  v4sf one = *(v4sf*)_ps_1;
+
+  x = _mm_min_ps(x, *(v4sf*)_ps_exp_hi);
+  x = _mm_max_ps(x, *(v4sf*)_ps_exp_lo);
+
+  /* express exp(x) as exp(g + n*log(2)) */
+  fx = _mm_mul_ps(x, *(v4sf*)_ps_cephes_LOG2EF);
+  fx = _mm_add_ps(fx, *(v4sf*)_ps_0p5);
+
+  /* how to perform a floorf with SSE: just below */
+#ifndef USE_SSE2
+  /* step 1 : cast to int */
+  tmp = _mm_movehl_ps(tmp, fx);
+  mm0 = _mm_cvttps_pi32(fx);
+  mm1 = _mm_cvttps_pi32(tmp);
+  /* step 2 : cast back to float */
+  tmp = _mm_cvtpi32x2_ps(mm0, mm1);
+#else
+  emm0 = _mm_cvttps_epi32(fx);
+  tmp  = _mm_cvtepi32_ps(emm0);
+#endif
+  /* if greater, substract 1 */
+  v4sf mask = _mm_cmpgt_ps(tmp, fx);    
+  mask = _mm_and_ps(mask, one);
+  fx = _mm_sub_ps(tmp, mask);
+
+  tmp = _mm_mul_ps(fx, *(v4sf*)_ps_cephes_exp_C1);
+  v4sf z = _mm_mul_ps(fx, *(v4sf*)_ps_cephes_exp_C2);
+  x = _mm_sub_ps(x, tmp);
+  x = _mm_sub_ps(x, z);
+
+  z = _mm_mul_ps(x,x);
+  
+  v4sf y = *(v4sf*)_ps_cephes_exp_p0;
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p1);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p2);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p3);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p4);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p5);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, x);
+  y = _mm_add_ps(y, one);
+
+  /* build 2^n */
+#ifndef USE_SSE2
+  z = _mm_movehl_ps(z, fx);
+  mm0 = _mm_cvttps_pi32(fx);
+  mm1 = _mm_cvttps_pi32(z);
+  mm0 = _mm_add_pi32(mm0, *(v2si*)_pi32_0x7f);
+  mm1 = _mm_add_pi32(mm1, *(v2si*)_pi32_0x7f);
+  mm0 = _mm_slli_pi32(mm0, 23); 
+  mm1 = _mm_slli_pi32(mm1, 23);
+  
+  v4sf pow2n; 
+  COPY_MM_TO_XMM(mm0, mm1, pow2n);
+  _mm_empty();
+#else
+  emm0 = _mm_cvttps_epi32(fx);
+  emm0 = _mm_add_epi32(emm0, *(v4si*)_pi32_0x7f);
+  emm0 = _mm_slli_epi32(emm0, 23);
+  v4sf pow2n = _mm_castsi128_ps(emm0);
+#endif
+  y = _mm_mul_ps(y, pow2n);
+  return y;
+}
+
+_PS_CONST(minus_cephes_DP1, -0.78515625);
+_PS_CONST(minus_cephes_DP2, -2.4187564849853515625e-4);
+_PS_CONST(minus_cephes_DP3, -3.77489497744594108e-8);
+_PS_CONST(sincof_p0, -1.9515295891E-4);
+_PS_CONST(sincof_p1,  8.3321608736E-3);
+_PS_CONST(sincof_p2, -1.6666654611E-1);
+_PS_CONST(coscof_p0,  2.443315711809948E-005);
+_PS_CONST(coscof_p1, -1.388731625493765E-003);
+_PS_CONST(coscof_p2,  4.166664568298827E-002);
+_PS_CONST(cephes_FOPI, 1.27323954473516); // 4 / M_PI
+
+
+/* evaluation of 4 sines at onces, using only SSE1+MMX intrinsics so
+   it runs also on old athlons XPs and the pentium III of your grand
+   mother.
+
+   The code is the exact rewriting of the cephes sinf function.
+   Precision is excellent as long as x < 8192 (I did not bother to
+   take into account the special handling they have for greater values
+   -- it does not return garbage for arguments over 8192, though, but
+   the extra precision is missing).
+
+   Note that it is such that sinf((float)M_PI) = 8.74e-8, which is the
+   surprising but correct result.
+
+   Performance is also surprisingly good, 1.33 times faster than the
+   macos vsinf SSE2 function, and 1.5 times faster than the
+   __vrs4_sinf of amd's ACML (which is only available in 64 bits). Not
+   too bad for an SSE1 function (with no special tuning) !
+   However the latter libraries probably have a much better handling of NaN,
+   Inf, denormalized and other special arguments..
+
+   On my core 1 duo, the execution of this function takes approximately 95 cycles.
+
+   From what I have observed on the experiments with Intel AMath lib, switching to an
+   SSE2 version would improve the perf by only 10%.
+
+   Since it is based on SSE intrinsics, it has to be compiled at -O2 to
+   deliver full speed.
+*/
+v4sf sin_ps(v4sf x) { // any x
+  v4sf xmm1, xmm2 = _mm_setzero_ps(), xmm3, sign_bit, y;
+
+#ifdef USE_SSE2
+  v4si emm0, emm2;
+#else
+  v2si mm0, mm1, mm2, mm3;
+#endif
+  sign_bit = x;
+  /* take the absolute value */
+  x = _mm_and_ps(x, *(v4sf*)_ps_inv_sign_mask);
+  /* extract the sign bit (upper one) */
+  sign_bit = _mm_and_ps(sign_bit, *(v4sf*)_ps_sign_mask);
+  
+  /* scale by 4/Pi */
+  y = _mm_mul_ps(x, *(v4sf*)_ps_cephes_FOPI);
+
+  //printf("plop:"); print4(y); 
+#ifdef USE_SSE2
+  /* store the integer part of y in mm0 */
+  emm2 = _mm_cvttps_epi32(y);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _mm_add_epi32(emm2, *(v4si*)_pi32_1);
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_inv1);
+  y = _mm_cvtepi32_ps(emm2);
+  /* get the swap sign flag */
+  emm0 = _mm_and_si128(emm2, *(v4si*)_pi32_4);
+  emm0 = _mm_slli_epi32(emm0, 29);
+  /* get the polynom selection mask 
+     there is one polynom for 0 <= x <= Pi/4
+     and another one for Pi/4<x<=Pi/2
+
+     Both branches will be computed.
+  */
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_2);
+  emm2 = _mm_cmpeq_epi32(emm2, _mm_setzero_si128());
+  
+  v4sf swap_sign_bit = _mm_castsi128_ps(emm0);
+  v4sf poly_mask = _mm_castsi128_ps(emm2);
+  sign_bit = _mm_xor_ps(sign_bit, swap_sign_bit);
+#else
+  /* store the integer part of y in mm0:mm1 */
+  xmm2 = _mm_movehl_ps(xmm2, y);
+  mm2 = _mm_cvttps_pi32(y);
+  mm3 = _mm_cvttps_pi32(xmm2);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  mm2 = _mm_add_pi32(mm2, *(v2si*)_pi32_1);
+  mm3 = _mm_add_pi32(mm3, *(v2si*)_pi32_1);
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_inv1);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_inv1);
+  y = _mm_cvtpi32x2_ps(mm2, mm3);
+  /* get the swap sign flag */
+  mm0 = _mm_and_si64(mm2, *(v2si*)_pi32_4);
+  mm1 = _mm_and_si64(mm3, *(v2si*)_pi32_4);
+  mm0 = _mm_slli_pi32(mm0, 29);
+  mm1 = _mm_slli_pi32(mm1, 29);
+  /* get the polynom selection mask */
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_2);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_2);
+  mm2 = _mm_cmpeq_pi32(mm2, _mm_setzero_si64());
+  mm3 = _mm_cmpeq_pi32(mm3, _mm_setzero_si64());
+  v4sf swap_sign_bit, poly_mask;
+  COPY_MM_TO_XMM(mm0, mm1, swap_sign_bit);
+  COPY_MM_TO_XMM(mm2, mm3, poly_mask);
+  sign_bit = _mm_xor_ps(sign_bit, swap_sign_bit);
+  _mm_empty(); /* good-bye mmx */
+#endif
+  
+  /* The magic pass: "Extended precision modular arithmetic" 
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = *(v4sf*)_ps_minus_cephes_DP1;
+  xmm2 = *(v4sf*)_ps_minus_cephes_DP2;
+  xmm3 = *(v4sf*)_ps_minus_cephes_DP3;
+  xmm1 = _mm_mul_ps(y, xmm1);
+  xmm2 = _mm_mul_ps(y, xmm2);
+  xmm3 = _mm_mul_ps(y, xmm3);
+  x = _mm_add_ps(x, xmm1);
+  x = _mm_add_ps(x, xmm2);
+  x = _mm_add_ps(x, xmm3);
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  y = *(v4sf*)_ps_coscof_p0;
+  v4sf z = _mm_mul_ps(x,x);
+
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p1);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p2);
+  y = _mm_mul_ps(y, z);
+  y = _mm_mul_ps(y, z);
+  v4sf tmp = _mm_mul_ps(z, *(v4sf*)_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+  y = _mm_add_ps(y, *(v4sf*)_ps_1);
+  
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+
+  v4sf y2 = *(v4sf*)_ps_sincof_p0;
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p1);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p2);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_mul_ps(y2, x);
+  y2 = _mm_add_ps(y2, x);
+
+  /* select the correct result from the two polynoms */  
+  xmm3 = poly_mask;
+  y2 = _mm_and_ps(xmm3, y2); //, xmm3);
+  y = _mm_andnot_ps(xmm3, y);
+  y = _mm_add_ps(y,y2);
+  /* update the sign */
+  y = _mm_xor_ps(y, sign_bit);
+
+  return y;
+}
+
+/* almost the same as sin_ps */
+v4sf cos_ps(v4sf x) { // any x
+  v4sf xmm1, xmm2 = _mm_setzero_ps(), xmm3, y;
+#ifdef USE_SSE2
+  v4si emm0, emm2;
+#else
+  v2si mm0, mm1, mm2, mm3;
+#endif
+  /* take the absolute value */
+  x = _mm_and_ps(x, *(v4sf*)_ps_inv_sign_mask);
+  
+  /* scale by 4/Pi */
+  y = _mm_mul_ps(x, *(v4sf*)_ps_cephes_FOPI);
+  
+#ifdef USE_SSE2
+  /* store the integer part of y in mm0 */
+  emm2 = _mm_cvttps_epi32(y);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _mm_add_epi32(emm2, *(v4si*)_pi32_1);
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_inv1);
+  y = _mm_cvtepi32_ps(emm2);
+
+  emm2 = _mm_sub_epi32(emm2, *(v4si*)_pi32_2);
+  
+  /* get the swap sign flag */
+  emm0 = _mm_andnot_si128(emm2, *(v4si*)_pi32_4);
+  emm0 = _mm_slli_epi32(emm0, 29);
+  /* get the polynom selection mask */
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_2);
+  emm2 = _mm_cmpeq_epi32(emm2, _mm_setzero_si128());
+  
+  v4sf sign_bit = _mm_castsi128_ps(emm0);
+  v4sf poly_mask = _mm_castsi128_ps(emm2);
+#else
+  /* store the integer part of y in mm0:mm1 */
+  xmm2 = _mm_movehl_ps(xmm2, y);
+  mm2 = _mm_cvttps_pi32(y);
+  mm3 = _mm_cvttps_pi32(xmm2);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  mm2 = _mm_add_pi32(mm2, *(v2si*)_pi32_1);
+  mm3 = _mm_add_pi32(mm3, *(v2si*)_pi32_1);
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_inv1);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_inv1);
+
+  y = _mm_cvtpi32x2_ps(mm2, mm3);
+
+
+  mm2 = _mm_sub_pi32(mm2, *(v2si*)_pi32_2);
+  mm3 = _mm_sub_pi32(mm3, *(v2si*)_pi32_2);
+
+  /* get the swap sign flag in mm0:mm1 and the 
+     polynom selection mask in mm2:mm3 */
+
+  mm0 = _mm_andnot_si64(mm2, *(v2si*)_pi32_4);
+  mm1 = _mm_andnot_si64(mm3, *(v2si*)_pi32_4);
+  mm0 = _mm_slli_pi32(mm0, 29);
+  mm1 = _mm_slli_pi32(mm1, 29);
+
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_2);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_2);
+
+  mm2 = _mm_cmpeq_pi32(mm2, _mm_setzero_si64());
+  mm3 = _mm_cmpeq_pi32(mm3, _mm_setzero_si64());
+
+  v4sf sign_bit, poly_mask;
+  COPY_MM_TO_XMM(mm0, mm1, sign_bit);
+  COPY_MM_TO_XMM(mm2, mm3, poly_mask);
+  _mm_empty(); /* good-bye mmx */
+#endif
+  /* The magic pass: "Extended precision modular arithmetic" 
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = *(v4sf*)_ps_minus_cephes_DP1;
+  xmm2 = *(v4sf*)_ps_minus_cephes_DP2;
+  xmm3 = *(v4sf*)_ps_minus_cephes_DP3;
+  xmm1 = _mm_mul_ps(y, xmm1);
+  xmm2 = _mm_mul_ps(y, xmm2);
+  xmm3 = _mm_mul_ps(y, xmm3);
+  x = _mm_add_ps(x, xmm1);
+  x = _mm_add_ps(x, xmm2);
+  x = _mm_add_ps(x, xmm3);
+  
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  y = *(v4sf*)_ps_coscof_p0;
+  v4sf z = _mm_mul_ps(x,x);
+
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p1);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p2);
+  y = _mm_mul_ps(y, z);
+  y = _mm_mul_ps(y, z);
+  v4sf tmp = _mm_mul_ps(z, *(v4sf*)_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+  y = _mm_add_ps(y, *(v4sf*)_ps_1);
+  
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+
+  v4sf y2 = *(v4sf*)_ps_sincof_p0;
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p1);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p2);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_mul_ps(y2, x);
+  y2 = _mm_add_ps(y2, x);
+
+  /* select the correct result from the two polynoms */  
+  xmm3 = poly_mask;
+  y2 = _mm_and_ps(xmm3, y2); //, xmm3);
+  y = _mm_andnot_ps(xmm3, y);
+  y = _mm_add_ps(y,y2);
+  /* update the sign */
+  y = _mm_xor_ps(y, sign_bit);
+
+  return y;
+}
+
+/* since sin_ps and cos_ps are almost identical, sincos_ps could replace both of them..
+   it is almost as fast, and gives you a free cosine with your sine */
+void sincos_ps(v4sf x, v4sf *s, v4sf *c) {
+  v4sf xmm1, xmm2, xmm3 = _mm_setzero_ps(), sign_bit_sin, y;
+#ifdef USE_SSE2
+  v4si emm0, emm2, emm4;
+#else
+  v2si mm0, mm1, mm2, mm3, mm4, mm5;
+#endif
+  sign_bit_sin = x;
+  /* take the absolute value */
+  x = _mm_and_ps(x, *(v4sf*)_ps_inv_sign_mask);
+  /* extract the sign bit (upper one) */
+  sign_bit_sin = _mm_and_ps(sign_bit_sin, *(v4sf*)_ps_sign_mask);
+  
+  /* scale by 4/Pi */
+  y = _mm_mul_ps(x, *(v4sf*)_ps_cephes_FOPI);
+    
+#ifdef USE_SSE2
+  /* store the integer part of y in emm2 */
+  emm2 = _mm_cvttps_epi32(y);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _mm_add_epi32(emm2, *(v4si*)_pi32_1);
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_inv1);
+  y = _mm_cvtepi32_ps(emm2);
+
+  emm4 = emm2;
+
+  /* get the swap sign flag for the sine */
+  emm0 = _mm_and_si128(emm2, *(v4si*)_pi32_4);
+  emm0 = _mm_slli_epi32(emm0, 29);
+  v4sf swap_sign_bit_sin = _mm_castsi128_ps(emm0);
+
+  /* get the polynom selection mask for the sine*/
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_2);
+  emm2 = _mm_cmpeq_epi32(emm2, _mm_setzero_si128());
+  v4sf poly_mask = _mm_castsi128_ps(emm2);
+#else
+  /* store the integer part of y in mm2:mm3 */
+  xmm3 = _mm_movehl_ps(xmm3, y);
+  mm2 = _mm_cvttps_pi32(y);
+  mm3 = _mm_cvttps_pi32(xmm3);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  mm2 = _mm_add_pi32(mm2, *(v2si*)_pi32_1);
+  mm3 = _mm_add_pi32(mm3, *(v2si*)_pi32_1);
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_inv1);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_inv1);
+
+  y = _mm_cvtpi32x2_ps(mm2, mm3);
+
+  mm4 = mm2;
+  mm5 = mm3;
+
+  /* get the swap sign flag for the sine */
+  mm0 = _mm_and_si64(mm2, *(v2si*)_pi32_4);
+  mm1 = _mm_and_si64(mm3, *(v2si*)_pi32_4);
+  mm0 = _mm_slli_pi32(mm0, 29);
+  mm1 = _mm_slli_pi32(mm1, 29);
+  v4sf swap_sign_bit_sin;
+  COPY_MM_TO_XMM(mm0, mm1, swap_sign_bit_sin);
+
+  /* get the polynom selection mask for the sine */
+
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_2);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_2);
+  mm2 = _mm_cmpeq_pi32(mm2, _mm_setzero_si64());
+  mm3 = _mm_cmpeq_pi32(mm3, _mm_setzero_si64());
+  v4sf poly_mask;
+  COPY_MM_TO_XMM(mm2, mm3, poly_mask);
+#endif
+
+  /* The magic pass: "Extended precision modular arithmetic" 
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = *(v4sf*)_ps_minus_cephes_DP1;
+  xmm2 = *(v4sf*)_ps_minus_cephes_DP2;
+  xmm3 = *(v4sf*)_ps_minus_cephes_DP3;
+  xmm1 = _mm_mul_ps(y, xmm1);
+  xmm2 = _mm_mul_ps(y, xmm2);
+  xmm3 = _mm_mul_ps(y, xmm3);
+  x = _mm_add_ps(x, xmm1);
+  x = _mm_add_ps(x, xmm2);
+  x = _mm_add_ps(x, xmm3);
+
+#ifdef USE_SSE2
+  emm4 = _mm_sub_epi32(emm4, *(v4si*)_pi32_2);
+  emm4 = _mm_andnot_si128(emm4, *(v4si*)_pi32_4);
+  emm4 = _mm_slli_epi32(emm4, 29);
+  v4sf sign_bit_cos = _mm_castsi128_ps(emm4);
+#else
+  /* get the sign flag for the cosine */
+  mm4 = _mm_sub_pi32(mm4, *(v2si*)_pi32_2);
+  mm5 = _mm_sub_pi32(mm5, *(v2si*)_pi32_2);
+  mm4 = _mm_andnot_si64(mm4, *(v2si*)_pi32_4);
+  mm5 = _mm_andnot_si64(mm5, *(v2si*)_pi32_4);
+  mm4 = _mm_slli_pi32(mm4, 29);
+  mm5 = _mm_slli_pi32(mm5, 29);
+  v4sf sign_bit_cos;
+  COPY_MM_TO_XMM(mm4, mm5, sign_bit_cos);
+  _mm_empty(); /* good-bye mmx */
+#endif
+
+  sign_bit_sin = _mm_xor_ps(sign_bit_sin, swap_sign_bit_sin);
+
+  
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  v4sf z = _mm_mul_ps(x,x);
+  y = *(v4sf*)_ps_coscof_p0;
+
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p1);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p2);
+  y = _mm_mul_ps(y, z);
+  y = _mm_mul_ps(y, z);
+  v4sf tmp = _mm_mul_ps(z, *(v4sf*)_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+  y = _mm_add_ps(y, *(v4sf*)_ps_1);
+  
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+
+  v4sf y2 = *(v4sf*)_ps_sincof_p0;
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p1);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p2);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_mul_ps(y2, x);
+  y2 = _mm_add_ps(y2, x);
+
+  /* select the correct result from the two polynoms */  
+  xmm3 = poly_mask;
+  v4sf ysin2 = _mm_and_ps(xmm3, y2);
+  v4sf ysin1 = _mm_andnot_ps(xmm3, y);
+  y2 = _mm_sub_ps(y2,ysin2);
+  y = _mm_sub_ps(y, ysin1);
+
+  xmm1 = _mm_add_ps(ysin1,ysin2);
+  xmm2 = _mm_add_ps(y,y2);
+ 
+  /* update the sign */
+  *s = _mm_xor_ps(xmm1, sign_bit_sin);
+  *c = _mm_xor_ps(xmm2, sign_bit_cos);
+}
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/speex/COPYING
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/speex/COPYING
@@ -1,0 +1,35 @@
+Copyright 2002-2007 	Xiph.org Foundation
+Copyright 2002-2007 	Jean-Marc Valin
+Copyright 2005-2007	Analog Devices Inc.
+Copyright 2005-2007	Commonwealth Scientific and Industrial Research 
+                        Organisation (CSIRO)
+Copyright 1993, 2002, 2006 David Rowe
+Copyright 2003 		EpicGames
+Copyright 1992-1994	Jutta Degener, Carsten Bormann
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/speex/resample.c
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/speex/resample.c
@@ -1,0 +1,1265 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*- vi:set ts=8 sts=4 sw=4: */
+
+/* Copyright (C) 2007 Jean-Marc Valin
+
+   File: resample.c
+   Arbitrary resampling code
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+   The design goals of this code are:
+      - Very fast algorithm
+      - SIMD-friendly algorithm
+      - Low memory requirement
+      - Good *perceptual* quality (and not best SNR)
+
+   Warning: This resampler is relatively new. Although I think I got rid of
+   all the major bugs and I don't expect the API to change anymore, there
+   may be something I've missed. So use with caution.
+
+   This algorithm is based on this original resampling algorithm:
+   Smith, Julius O. Digital Audio Resampling Home Page
+   Center for Computer Research in Music and Acoustics (CCRMA),
+   Stanford University, 2007.
+   Web published at http://www-ccrma.stanford.edu/~jos/resample/.
+
+   There is one main difference, though. This resampler uses cubic
+   interpolation instead of linear interpolation in the above paper. This
+   makes the table much smaller and makes it possible to compute that table
+   on a per-stream basis. In turn, being able to tweak the table for each
+   stream makes it possible to both reduce complexity on simple ratios
+   (e.g. 2/3), and get rid of the rounding operations in the inner loop.
+   The latter both reduces CPU time and makes the algorithm more SIMD-friendly.
+*/
+
+/*
+   NOTE: This code has been cut down and reformatted by Chris Cannam
+   for personal reading preference, and for use in the Rubber Band
+   time stretching and pitch shifting library.  If you have problems
+   with this code, cast suspicion on the butchering it has undergone;
+   it's probably my fault.  If you want a properly functioning
+   version, please go for the original Speex code first.  I haven't
+   made any substantial changes to this code, I've just made it less
+   generally useful.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <string.h>
+
+#ifdef HAVE_IPP
+#include <ipps.h>
+#endif
+
+// Simple allocators with a fixed minimum, to avoid reallocation if
+// the size changes but remains smaller than that.  The system alloc
+// functions no doubt do exactly the same thing for some value
+// probably not too distant from ours, but we want the certainty.
+
+#define ALLOC_MINIMUM 4096
+
+static void *speex_alloc (int count, int size)
+{
+#ifdef HAVE_IPP
+    void *rv;
+#endif
+    if (count * size < ALLOC_MINIMUM) {
+        count = ALLOC_MINIMUM / size;
+    }
+
+#ifdef HAVE_IPP
+    if (size == sizeof(float) && size == 4) { // or sizeof(int32) or whatever, doesn't matter
+        rv = ippsMalloc_32f(count);
+    } else if (size == sizeof(double) && size == 8) {
+        rv = ippsMalloc_64f(count);
+    } else {
+        rv = ippsMalloc_8u(count * size);
+    }
+    memset(rv, 0, count * size);
+    return rv;
+#else
+    return calloc(count, size);
+#endif
+}
+
+static void speex_free (void *ptr) 
+{
+//	fprintf(stderr,"speex_free(%p)\n", ptr);
+#ifdef HAVE_IPP
+  	ippsFree(ptr);
+#else
+    free(ptr);
+#endif
+}
+
+static void *speex_realloc (void *ptr, int oldcount, int newcount, int size)
+{
+#ifdef HAVE_IPP
+	void *newptr;
+#endif
+
+//	fprintf(stderr,"speex_realloc(%p,%d,%d,%d)\n", ptr, oldcount, newcount, size);
+
+    if (newcount * size < ALLOC_MINIMUM) {
+//		fprintf(stderr,"returning %p\n",ptr);
+        return ptr;
+    }
+//    fprintf(stderr, "NOTE: speex_realloc: actual reallocation happening (newcount = %d, size = %d)\n", newcount, size);
+
+#ifdef HAVE_IPP
+    newptr = speex_alloc(newcount, size);
+    if (ptr && oldcount > 0) {
+        int copy = newcount;
+        if (oldcount < copy) copy = oldcount;
+        memcpy(newptr, ptr, copy * size);
+    }
+    speex_free(ptr);
+//	fprintf(stderr,"returning %p\n", ptr);
+    return newptr;
+#else
+    return realloc(ptr, newcount * size);
+#endif
+}
+
+#include "speex_resampler.h"
+
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159263
+#endif
+
+#define FILTER_SIZE 64
+#define OVERSAMPLE 8
+
+#define IMAX(a,b) ((a) > (b) ? (a) : (b))
+#define IMIN(a,b) ((a) < (b) ? (a) : (b))
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+
+typedef int (*resampler_basic_func)(SpeexResamplerState *, spx_uint32_t , const float *, spx_uint32_t *, float *, spx_uint32_t *);
+
+struct SpeexResamplerState_ {
+    spx_uint32_t in_rate;
+    spx_uint32_t out_rate;
+    spx_uint32_t num_rate;
+    spx_uint32_t den_rate;
+
+    int    quality;
+    spx_uint32_t nb_channels;
+    spx_uint32_t filt_len;
+    spx_uint32_t mem_alloc_size;
+    int          int_advance;
+    int          frac_advance;
+    float  cutoff;
+    spx_uint32_t oversample;
+    int          initialised;
+    int          started;
+
+    /* These are per-channel */
+    spx_int32_t  *last_sample;
+    spx_uint32_t *samp_frac_num;
+    spx_uint32_t *magic_samples;
+
+    float *mem;
+    float *sinc_table;
+    spx_uint32_t sinc_table_length;
+    spx_uint32_t sinc_table_alloc;
+    resampler_basic_func resampler_ptr;
+
+    int    in_stride;
+    int    out_stride;
+} ;
+
+static double kaiser12_table[68] = {
+    0.99859849, 1.00000000, 0.99859849, 0.99440475, 0.98745105, 0.97779076,
+    0.96549770, 0.95066529, 0.93340547, 0.91384741, 0.89213598, 0.86843014,
+    0.84290116, 0.81573067, 0.78710866, 0.75723148, 0.72629970, 0.69451601,
+    0.66208321, 0.62920216, 0.59606986, 0.56287762, 0.52980938, 0.49704014,
+    0.46473455, 0.43304576, 0.40211431, 0.37206735, 0.34301800, 0.31506490,
+    0.28829195, 0.26276832, 0.23854851, 0.21567274, 0.19416736, 0.17404546,
+    0.15530766, 0.13794294, 0.12192957, 0.10723616, 0.09382272, 0.08164178,
+    0.07063950, 0.06075685, 0.05193064, 0.04409466, 0.03718069, 0.03111947,
+    0.02584161, 0.02127838, 0.01736250, 0.01402878, 0.01121463, 0.00886058,
+    0.00691064, 0.00531256, 0.00401805, 0.00298291, 0.00216702, 0.00153438,
+    0.00105297, 0.00069463, 0.00043489, 0.00025272, 0.00013031, 0.0000527734,
+    0.00001000, 0.00000000
+};
+
+static double kaiser10_table[36] = {
+    0.99537781, 1.00000000, 0.99537781, 0.98162644, 0.95908712, 0.92831446,
+    0.89005583, 0.84522401, 0.79486424, 0.74011713, 0.68217934, 0.62226347,
+    0.56155915, 0.50119680, 0.44221549, 0.38553619, 0.33194107, 0.28205962,
+    0.23636152, 0.19515633, 0.15859932, 0.12670280, 0.09935205, 0.07632451,
+    0.05731132, 0.04193980, 0.02979584, 0.02044510, 0.01345224, 0.00839739,
+    0.00488951, 0.00257636, 0.00115101, 0.00035515, 0.00000000, 0.00000000
+};
+
+static double kaiser8_table[36] = {
+    0.99635258, 1.00000000, 0.99635258, 0.98548012, 0.96759014, 0.94302200,
+    0.91223751, 0.87580811, 0.83439927, 0.78875245, 0.73966538, 0.68797126,
+    0.63451750, 0.58014482, 0.52566725, 0.47185369, 0.41941150, 0.36897272,
+    0.32108304, 0.27619388, 0.23465776, 0.19672670, 0.16255380, 0.13219758,
+    0.10562887, 0.08273982, 0.06335451, 0.04724088, 0.03412321, 0.02369490,
+    0.01563093, 0.00959968, 0.00527363, 0.00233883, 0.00050000, 0.00000000
+};
+
+static double kaiser6_table[36] = {
+    0.99733006, 1.00000000, 0.99733006, 0.98935595, 0.97618418, 0.95799003,
+    0.93501423, 0.90755855, 0.87598009, 0.84068475, 0.80211977, 0.76076565,
+    0.71712752, 0.67172623, 0.62508937, 0.57774224, 0.53019925, 0.48295561,
+    0.43647969, 0.39120616, 0.34752997, 0.30580127, 0.26632152, 0.22934058,
+    0.19505503, 0.16360756, 0.13508755, 0.10953262, 0.08693120, 0.06722600,
+    0.05031820, 0.03607231, 0.02432151, 0.01487334, 0.00752000, 0.00000000
+};
+
+struct FuncDef {
+    double *table;
+    int oversample;
+};
+
+static struct FuncDef _KAISER12 = {kaiser12_table, 64};
+#define KAISER12 (&_KAISER12)
+static struct FuncDef _KAISER10 = {kaiser10_table, 32};
+#define KAISER10 (&_KAISER10)
+static struct FuncDef _KAISER8 = {kaiser8_table, 32};
+#define KAISER8 (&_KAISER8)
+static struct FuncDef _KAISER6 = {kaiser6_table, 32};
+#define KAISER6 (&_KAISER6)
+
+struct QualityMapping {
+    int base_length;
+    int oversample;
+    float downsample_bandwidth;
+    float upsample_bandwidth;
+
+    struct FuncDef *window_func;
+};
+
+
+/* This table maps conversion quality to internal parameters. There are two
+   reasons that explain why the up-sampling bandwidth is larger than the
+   down-sampling bandwidth:
+   1) When up-sampling, we can assume that the spectrum is already attenuated
+      close to the Nyquist rate (from an A/D or a previous resampling filter)
+   2) Any aliasing that occurs very close to the Nyquist rate will be masked
+      by the sinusoids/noise just below the Nyquist rate (guaranteed only for
+      up-sampling).
+*/
+
+static const struct QualityMapping quality_map[11] = {
+   {  8,  4, 0.830f, 0.860f, KAISER6 }, /* Q0 */
+   { 16,  4, 0.850f, 0.880f, KAISER6 }, /* Q1 */
+   { 32,  4, 0.882f, 0.910f, KAISER6 }, /* Q2 */  /* 82.3% cutoff ( ~60 dB stop) 6  */
+   { 48,  8, 0.895f, 0.917f, KAISER8 }, /* Q3 */  /* 84.9% cutoff ( ~80 dB stop) 8  */
+   { 64,  8, 0.921f, 0.940f, KAISER8 }, /* Q4 */  /* 88.7% cutoff ( ~80 dB stop) 8  */
+   { 80, 16, 0.922f, 0.940f, KAISER10}, /* Q5 */  /* 89.1% cutoff (~100 dB stop) 10 */
+   { 96, 16, 0.940f, 0.945f, KAISER10}, /* Q6 */  /* 91.5% cutoff (~100 dB stop) 10 */
+   {128, 16, 0.950f, 0.950f, KAISER10}, /* Q7 */  /* 93.1% cutoff (~100 dB stop) 10 */
+   {160, 16, 0.960f, 0.960f, KAISER10}, /* Q8 */  /* 94.5% cutoff (~100 dB stop) 10 */
+   {192, 32, 0.968f, 0.968f, KAISER12}, /* Q9 */  /* 95.5% cutoff (~100 dB stop) 10 */
+   {256, 32, 0.975f, 0.975f, KAISER12}, /* Q10 */ /* 96.6% cutoff (~100 dB stop) 10 */
+};
+/*8,24,40,56,80,104,128,160,200,256,320*/
+
+static double compute_func(float x, struct FuncDef *func)
+{
+    float y, frac;
+    double interp[4];
+    int ind;
+
+    y = x * func->oversample;
+    ind = (int)floor(y);
+    frac = (y - ind);
+
+    /* CSE with handle the repeated powers */
+    interp[3] =  -0.1666666667 * frac + 0.1666666667 * (frac * frac * frac);
+    interp[2] = frac + 0.5 * (frac * frac) - 0.5 * (frac * frac * frac);
+    interp[0] = -0.3333333333 * frac + 0.5 * (frac * frac) - 0.1666666667 * (frac * frac * frac);
+
+    /* Just to make sure we don't have rounding problems */
+    interp[1] = 1.f - interp[3] - interp[2] - interp[0];
+
+    /*sum = frac*accum[1] + (1-frac)*accum[2];*/
+    return 
+	interp[0]*func->table[ind] + interp[1]*func->table[ind+1] +
+	interp[2]*func->table[ind+2] + interp[3]*func->table[ind+3];
+}
+
+/* The slow way of computing a sinc for the table. Should improve that some day */
+static float sinc(float cutoff, float x, int N, struct FuncDef *window_func)
+{
+    float xx = x * cutoff;
+
+    if (fabsf(x) < 1e-6)
+        return cutoff;
+    else if (fabsf(x) > .5*N)
+        return 0;
+
+    /*FIXME: Can it really be any slower than this? */
+    return cutoff*sin(M_PI*xx) / (M_PI*xx)
+	* compute_func(fabs(2.*x / N), window_func);
+}
+
+static void cubic_coef(float frac, float interp[4])
+{
+    /* Compute interpolation coefficients. I'm not sure whether this
+    corresponds to cubic interpolation but I know it's MMSE-optimal on
+    a sinc */
+
+    interp[0] =  -0.16667f * frac + 0.16667f * frac * frac * frac;
+    interp[1] = frac + 0.5f * frac * frac - 0.5f * frac * frac * frac;
+    interp[3] = -0.33333f * frac + 0.5f * frac * frac - 0.16667f * frac * frac * frac;
+
+    /* Just to make sure we don't have rounding problems */
+    interp[2] = 1. - interp[0] - interp[1] - interp[3];
+}
+
+static int resampler_basic_direct_single(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    int last_sample = st->last_sample[channel_index];
+    unsigned int samp_frac_num = st->samp_frac_num[channel_index];
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+
+    while (!(last_sample >= (int)*in_len || out_sample >= (int)*out_len)) {
+
+        int j;
+        float sum = 0;
+
+        /* We already have all the filter coefficients pre-computed in the table */
+        const float *ptr;
+
+        for (j = 0; last_sample - N + 1 + j < 0; j++) {
+            sum += ((float)(mem[last_sample+j]) *
+		    (float)(st->sinc_table[samp_frac_num*st->filt_len+j]));
+        }
+
+        /* Do the new part */
+        if (in != NULL) {
+
+            ptr = in + st->in_stride * (last_sample - N + 1 + j);
+
+            for (; j < N; j++) {
+                sum += ((float)(*ptr) *
+			(float)(st->sinc_table[samp_frac_num*st->filt_len+j]));
+                ptr += st->in_stride;
+            }
+        }
+
+        *out = (sum);
+
+        out += st->out_stride;
+        out_sample++;
+        last_sample += st->int_advance;
+        samp_frac_num += st->frac_advance;
+
+        if (samp_frac_num >= st->den_rate) {
+            samp_frac_num -= st->den_rate;
+            last_sample++;
+        }
+    }
+
+    st->last_sample[channel_index] = last_sample;
+
+    st->samp_frac_num[channel_index] = samp_frac_num;
+    return out_sample;
+}
+
+/* This is the same as the previous function, except with a double-precision accumulator */
+static int resampler_basic_direct_double(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    int last_sample = st->last_sample[channel_index];
+    unsigned int samp_frac_num = st->samp_frac_num[channel_index];
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+
+    while (!(last_sample >= (int)*in_len || out_sample >= (int)*out_len)) {
+
+        int j;
+        double sum = 0;
+
+        /* We already have all the filter coefficients pre-computed in
+         * the table */
+        const float *ptr;
+
+        for (j = 0; last_sample - N + 1 + j < 0; j++) {
+            sum += ((float)(mem[last_sample+j]) *
+		    (float)((double)st->sinc_table[samp_frac_num*st->filt_len+j]));
+        }
+
+        /* Do the new part */
+        if (in != NULL) {
+            ptr = in + st->in_stride * (last_sample - N + 1 + j);
+
+            for (; j < N; j++) {
+                sum += ((float)(*ptr) *
+			(float)((double)st->sinc_table[samp_frac_num*st->filt_len+j]));
+                ptr += st->in_stride;
+            }
+        }
+
+        *out = sum;
+
+        out += st->out_stride;
+        out_sample++;
+        last_sample += st->int_advance;
+        samp_frac_num += st->frac_advance;
+
+        if (samp_frac_num >= st->den_rate) {
+            samp_frac_num -= st->den_rate;
+            last_sample++;
+        }
+    }
+
+    st->last_sample[channel_index] = last_sample;
+
+    st->samp_frac_num[channel_index] = samp_frac_num;
+    return out_sample;
+}
+
+static int resampler_basic_interpolate_single(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    int last_sample = st->last_sample[channel_index];
+    unsigned int samp_frac_num = st->samp_frac_num[channel_index];
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+
+    while (!(last_sample >= (int)*in_len || out_sample >= (int)*out_len)) {
+
+        int j;
+        float sum = 0;
+
+        /* We need to interpolate the sinc filter */
+        float accum[4] = {0.f, 0.f, 0.f, 0.f};
+        float interp[4];
+        const float *ptr;
+        int offset;
+        float frac;
+
+        offset = samp_frac_num * st->oversample / st->den_rate;
+
+        frac = ((float)((samp_frac_num * st->oversample) % st->den_rate))
+	    / st->den_rate;
+
+        /* This code is written like this to make it easy to optimise
+	 * with SIMD.  For most DSPs, it would be best to split the
+	 * loops in two because most DSPs have only two
+	 * accumulators */
+
+        for (j = 0; last_sample - N + 1 + j < 0; j++) {
+
+            float curr_mem = mem[last_sample+j];
+
+            accum[0] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset - 2]));
+            accum[1] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset - 1]));
+            accum[2] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset]));
+            accum[3] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset + 1]));
+        }
+
+        if (in != NULL) {
+
+            ptr = in + st->in_stride * (last_sample - N + 1 + j);
+
+            /* Do the new part */
+            for (; j < N; j++) {
+
+                float curr_in = *ptr;
+                ptr += st->in_stride;
+
+                accum[0] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset - 2]));
+                accum[1] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset - 1]));
+                accum[2] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset]));
+                accum[3] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset + 1]));
+            }
+        }
+
+        cubic_coef(frac, interp);
+
+        sum =
+	    ((interp[0]) * (accum[0])) +
+	    ((interp[1]) * (accum[1])) +
+	    ((interp[2]) * (accum[2])) +
+	    ((interp[3]) * (accum[3]));
+
+        *out = (sum);
+        out += st->out_stride;
+        out_sample++;
+        last_sample += st->int_advance;
+        samp_frac_num += st->frac_advance;
+
+        if (samp_frac_num >= st->den_rate) {
+            samp_frac_num -= st->den_rate;
+            last_sample++;
+        }
+    }
+
+    st->last_sample[channel_index] = last_sample;
+    st->samp_frac_num[channel_index] = samp_frac_num;
+    return out_sample;
+}
+
+/* This is the same as the previous function, except with a
+ * double-precision accumulator */
+static int resampler_basic_interpolate_double(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len) 
+{
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    int last_sample = st->last_sample[channel_index];
+    unsigned int samp_frac_num = st->samp_frac_num[channel_index];
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+
+    while (!(last_sample >= (int)*in_len || out_sample >= (int)*out_len)) {
+
+        int j;
+        float sum = 0;
+
+        /* We need to interpolate the sinc filter */
+        double accum[4] = {0.f, 0.f, 0.f, 0.f};
+        float interp[4];
+        const float *ptr;
+        float alpha = ((float)samp_frac_num) / st->den_rate;
+        int offset = samp_frac_num * st->oversample / st->den_rate;
+        float frac = alpha * st->oversample - offset;
+
+        /* This code is written like this to make it easy to optimise
+	 * with SIMD.  For most DSPs, it would be best to split the
+	 * loops in two because most DSPs have only two
+	 * accumulators */
+
+        for (j = 0; last_sample - N + 1 + j < 0; j++) {
+
+            double curr_mem = mem[last_sample + j];
+
+            accum[0] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset - 2]));
+            accum[1] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset - 1]));
+            accum[2] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset]));
+            accum[3] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset + 1]));
+        }
+
+        if (in != NULL) {
+
+            ptr = in + st->in_stride * (last_sample - N + 1 + j);
+
+            /* Do the new part */
+            for (; j < N; j++) {
+
+                double curr_in = *ptr;
+                ptr += st->in_stride;
+
+                accum[0] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset - 2]));
+                accum[1] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset - 1]));
+                accum[2] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset]));
+                accum[3] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset + 1]));
+            }
+        }
+
+        cubic_coef(frac, interp);
+
+        sum =
+	    interp[0] * accum[0] +
+	    interp[1] * accum[1] +
+	    interp[2] * accum[2] +
+	    interp[3] * accum[3];
+
+        *out = (sum);
+        out += st->out_stride;
+        out_sample++;
+        last_sample += st->int_advance;
+        samp_frac_num += st->frac_advance;
+
+        if (samp_frac_num >= st->den_rate) {
+            samp_frac_num -= st->den_rate;
+            last_sample++;
+        }
+    }
+
+    st->last_sample[channel_index] = last_sample;
+    st->samp_frac_num[channel_index] = samp_frac_num;
+
+    return out_sample;
+}
+
+static void update_filter(SpeexResamplerState *st)
+{
+    unsigned int old_length;
+
+    /*   fprintf(stderr, "update_filter\n"); */
+
+    old_length = st->filt_len;
+    st->oversample = quality_map[st->quality].oversample;
+    st->filt_len = quality_map[st->quality].base_length;
+
+    if (st->num_rate > st->den_rate) {
+
+        /* down-sampling */
+        st->cutoff = quality_map[st->quality].downsample_bandwidth
+            * st->den_rate / st->num_rate;
+
+        st->filt_len = (unsigned int)
+            ceil(st->filt_len * ((double)st->num_rate / (double)st->den_rate));
+
+        /* Round down to make sure we have a multiple of 4 */
+        st->filt_len &= (~0x3);
+
+        if (2*st->den_rate < st->num_rate)
+            st->oversample >>= 1;
+
+        if (4*st->den_rate < st->num_rate)
+            st->oversample >>= 1;
+
+        if (8*st->den_rate < st->num_rate)
+            st->oversample >>= 1;
+
+        if (16*st->den_rate < st->num_rate)
+            st->oversample >>= 1;
+
+        if (st->oversample < 1)
+            st->oversample = 1;
+
+    } else {
+
+        /* up-sampling */
+        st->cutoff = quality_map[st->quality].upsample_bandwidth;
+    }
+
+    /* Choose the resampling type that requires the least amount of memory */
+
+    if (st->den_rate <= st->oversample) {
+
+        unsigned int i;
+
+        if (!st->sinc_table) {
+
+            st->sinc_table = (float *)speex_alloc
+                (st->filt_len * st->den_rate, sizeof(float));
+
+	} else if (st->sinc_table_alloc < st->filt_len*st->den_rate) {
+
+//		fprintf(stderr,"sinc_table=%p\n",st->sinc_table);
+            st->sinc_table = (float *)speex_realloc
+                (st->sinc_table, st->sinc_table_alloc,
+                 st->filt_len * st->den_rate, sizeof(float));
+            st->sinc_table_alloc = st->filt_len * st->den_rate;
+        }
+
+        for (i = 0; i < st->den_rate; i++) {
+
+            int j;
+
+            for (j = 0; j < st->filt_len; j++) {
+                st->sinc_table[i*st->filt_len+j] = sinc
+                    (st->cutoff,
+                     ((j - (int)st->filt_len / 2 + 1) - ((float)i) / st->den_rate), 
+                     st->filt_len,
+                     quality_map[st->quality].window_func);
+            }
+        }
+
+        if (st->quality > 8) {
+            st->resampler_ptr = resampler_basic_direct_double;
+        } else {
+            st->resampler_ptr = resampler_basic_direct_single;
+        }
+
+        /*      fprintf (stderr, "resampler uses direct sinc table and normalised cutoff %f\n", st->cutoff); */
+
+    } else {
+
+        int i;
+
+        if (!st->sinc_table) {
+
+            st->sinc_table = (float *)speex_alloc
+                ((st->filt_len * st->oversample + 8),  sizeof(float));
+
+	} else if (st->sinc_table_alloc < st->filt_len*st->oversample + 8) {
+
+		//fprintf(stderr,"sinc_table=%p\n",st->sinc_table);
+            st->sinc_table = (float *)speex_realloc
+                (st->sinc_table, st->sinc_table_alloc,
+                 (st->filt_len * st->oversample + 8), sizeof(float));
+            st->sinc_table_alloc = st->filt_len * st->oversample + 8;
+        }
+
+        for (i = -4; i < (int)(st->oversample * st->filt_len + 4); i++) {
+            st->sinc_table[i+4] = sinc
+                (st->cutoff,
+                 (i / (float)st->oversample - st->filt_len / 2),
+                 st->filt_len,
+                 quality_map[st->quality].window_func);
+	}
+
+        if (st->quality > 8)
+            st->resampler_ptr = resampler_basic_interpolate_double;
+        else
+            st->resampler_ptr = resampler_basic_interpolate_single;
+
+        /* fprintf (stderr, "resampler uses interpolated sinc table and normalised cutoff %f\n", st->cutoff); */
+
+        /* fprintf (stderr, "table length %d, filt len %d\n", st->sinc_table_length, st->filt_len); */
+    }
+
+    st->int_advance = st->num_rate / st->den_rate;
+    st->frac_advance = st->num_rate % st->den_rate;
+
+    /* Here's the place where we update the filter memory to take into
+       account the change in filter length. It's probably the messiest
+       part of the code due to handling of lots of corner cases. */
+
+    if (!st->mem) {
+
+        unsigned int i;
+        st->mem = (float*)speex_alloc
+            (st->nb_channels * (st->filt_len - 1), sizeof(float));
+
+        for (i = 0; i < st->nb_channels * (st->filt_len - 1); i++)
+            st->mem[i] = 0;
+
+        st->mem_alloc_size = st->filt_len - 1;
+
+    } else if (!st->started) {
+
+        unsigned int i;
+
+		//fprintf(stderr,"mem=%p\n",st->mem);
+		st->mem = (float*)speex_realloc
+            (st->mem, 0, st->nb_channels * (st->filt_len - 1), sizeof(float));
+
+        for (i = 0; i < st->nb_channels * (st->filt_len - 1); i++)
+            st->mem[i] = 0;
+
+        st->mem_alloc_size = st->filt_len - 1;
+
+    } else if (st->filt_len > old_length) {
+
+        int i;
+
+        /* Increase the filter length */
+
+        int old_alloc_size = st->mem_alloc_size;
+
+        if (st->filt_len - 1 > st->mem_alloc_size) {
+			
+		//fprintf(stderr,"mem=%p\n",st->mem);
+
+            st->mem = (float*)speex_realloc
+                (st->mem, st->nb_channels * (old_length - 1),
+                 st->nb_channels * (st->filt_len - 1), sizeof(float));
+            st->mem_alloc_size = st->filt_len - 1;
+        }
+
+        for (i = st->nb_channels - 1; i >= 0; i--) {
+
+            int j;
+            unsigned int olen = old_length;
+
+	    /*if (st->magic_samples[i])*/
+            {
+
+                /* Try and remove the magic samples as if nothing had happened */
+
+                /* FIXME: This is wrong but for now we need it to
+                 * avoid going over the array bounds */
+
+                olen = old_length + 2 * st->magic_samples[i];
+
+                for (j = old_length - 2 + st->magic_samples[i]; j >= 0; j--) {
+                    st->mem[i*st->mem_alloc_size+j+st->magic_samples[i]] =
+                        st->mem[i*old_alloc_size+j];
+                }
+
+                for (j = 0; j < st->magic_samples[i]; j++) {
+                    st->mem[i*st->mem_alloc_size+j] = 0;
+                }
+
+                st->magic_samples[i] = 0;
+            }
+
+            if (st->filt_len > olen) {
+
+                /* If the new filter length is still bigger than the
+                 * "augmented" length */
+
+                /* Copy data going backward */
+
+                for (j = 0; j < olen - 1; j++) {
+                    st->mem[i*st->mem_alloc_size+(st->filt_len-2-j)] =
+                        st->mem[i*st->mem_alloc_size+(olen-2-j)];
+                }
+
+                /* Then put zeros for lack of anything better */
+                for (; j < st->filt_len - 1; j++) {
+                    st->mem[i*st->mem_alloc_size+(st->filt_len-2-j)] = 0;
+                }
+
+                /* Adjust last_sample */
+                st->last_sample[i] += (st->filt_len - olen) / 2;
+
+            } else {
+
+                /* Put back some of the magic! */
+                st->magic_samples[i] = (olen - st->filt_len) / 2;
+
+                for (j = 0; j < st->filt_len - 1 + st->magic_samples[i]; j++) {
+                    st->mem[i*st->mem_alloc_size+j] =
+                        st->mem[i*st->mem_alloc_size+j+st->magic_samples[i]];
+                }
+            }
+        }
+    } else if (st->filt_len < old_length) {
+
+        unsigned int i;
+
+        /* Reduce filter length, this a bit tricky. We need to store
+           some of the memory as "magic" samples so they can be used
+           directly as input the next time(s) */
+
+        for (i = 0; i < st->nb_channels; i++) {
+
+            unsigned int j;
+            unsigned int old_magic = st->magic_samples[i];
+            st->magic_samples[i] = (old_length - st->filt_len) / 2;
+
+            /* We must copy some of the memory that's no longer used */
+            /* Copy data going backward */
+
+            for (j = 0; j < st->filt_len - 1 + st->magic_samples[i] + old_magic; j++) {
+                st->mem[i*st->mem_alloc_size+j] =
+                    st->mem[i*st->mem_alloc_size+j+st->magic_samples[i]];
+	    }
+
+            st->magic_samples[i] += old_magic;
+        }
+    }
+}
+
+SpeexResamplerState *speex_resampler_init(unsigned int nb_channels, unsigned int in_rate, unsigned int out_rate, int quality, int *err)
+{
+    return speex_resampler_init_frac(nb_channels, in_rate, out_rate,
+				     in_rate, out_rate, quality, err);
+}
+
+SpeexResamplerState *speex_resampler_init_frac(unsigned int nb_channels, unsigned int ratio_num, unsigned int ratio_den, unsigned int in_rate, unsigned int out_rate, int quality, int *err)
+{
+    unsigned int i;
+    SpeexResamplerState *st;
+
+    if (quality > 10 || quality < 0) {
+        if (err) *err = RESAMPLER_ERR_INVALID_ARG;
+        return NULL;
+    }
+
+    st = (SpeexResamplerState *)speex_alloc(1, sizeof(SpeexResamplerState));
+
+    st->initialised = 0;
+    st->started = 0;
+    st->in_rate = 0;
+    st->out_rate = 0;
+    st->num_rate = 0;
+    st->den_rate = 0;
+    st->quality = -1;
+	st->sinc_table = 0;
+    st->sinc_table_length = 0;
+    st->sinc_table_alloc = 0;
+    st->mem_alloc_size = 0;
+    st->filt_len = 0;
+    st->mem = 0;
+    st->resampler_ptr = 0;
+
+    st->cutoff = 1.f;
+    st->nb_channels = nb_channels;
+    st->in_stride = 1;
+    st->out_stride = 1;
+
+    /* Per channel data */
+    st->last_sample = (int*)speex_alloc(nb_channels, sizeof(int));
+    st->magic_samples = (unsigned int*)speex_alloc(nb_channels, sizeof(int));
+    st->samp_frac_num = (unsigned int*)speex_alloc(nb_channels, sizeof(int));
+
+    for (i = 0; i < nb_channels; i++) {
+        st->last_sample[i] = 0;
+        st->magic_samples[i] = 0;
+        st->samp_frac_num[i] = 0;
+    }
+
+    speex_resampler_set_quality(st, quality);
+    speex_resampler_set_rate_frac(st, ratio_num, ratio_den, in_rate, out_rate);
+
+    update_filter(st);
+
+    st->initialised = 1;
+
+    if (err) *err = RESAMPLER_ERR_SUCCESS;
+
+    return st;
+}
+
+void speex_resampler_destroy(SpeexResamplerState *st)
+{
+    speex_free(st->mem);
+    speex_free(st->sinc_table);
+    speex_free(st->last_sample);
+    speex_free(st->magic_samples);
+    speex_free(st->samp_frac_num);
+    speex_free(st);
+}
+
+static int speex_resampler_process_native(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    int j = 0;
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    unsigned int tmp_out_len = 0;
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+    st->started = 1;
+
+    /* Handle the case where we have samples left from a reduction in
+     * filter length */
+
+    if (st->magic_samples[channel_index]) {
+
+        int istride_save;
+        unsigned int tmp_in_len;
+        unsigned int tmp_magic;
+
+        istride_save = st->in_stride;
+        tmp_in_len = st->magic_samples[channel_index];
+        tmp_out_len = *out_len;
+
+        /* magic_samples needs to be set to zero to avoid infinite recursion */
+        tmp_magic = st->magic_samples[channel_index];
+        st->magic_samples[channel_index] = 0;
+        st->in_stride = 1;
+        speex_resampler_process_native(st, channel_index, mem + N-1,
+                                       &tmp_in_len, out, &tmp_out_len);
+        st->in_stride = istride_save;
+
+        /* If we couldn't process all "magic" input samples, save the
+         * rest for next time */
+
+        if (tmp_in_len < tmp_magic) {
+
+            unsigned int i;
+
+            st->magic_samples[channel_index] = tmp_magic - tmp_in_len;
+
+            for (i = 0; i < st->magic_samples[channel_index]; i++) {
+                mem[N-1+i] = mem[N-1+i+tmp_in_len];
+            }
+        }
+
+        out += tmp_out_len * st->out_stride;
+        *out_len -= tmp_out_len;
+    }
+
+    /* Call the right resampler through the function ptr */
+    out_sample = st->resampler_ptr(st, channel_index,
+                                   in, in_len, out, out_len);
+
+    if (st->last_sample[channel_index] < (int)*in_len) {
+        *in_len = st->last_sample[channel_index];
+    }
+
+    *out_len = out_sample + tmp_out_len;
+
+    st->last_sample[channel_index] -= *in_len;
+
+    for (j = 0; j < N-1 - (int)*in_len; j++) {
+        mem[j] = mem[j+*in_len];
+    }
+
+    if (in != NULL) {
+        for ( ; j < N-1; j++) mem[j] = in[st->in_stride*(j+*in_len-N+1)];
+    } else {
+        for ( ; j < N-1; j++) mem[j] = 0;
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+int speex_resampler_process_float(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    return speex_resampler_process_native(st, channel_index, in, in_len, out, out_len);
+}
+
+int speex_resampler_process_interleaved_float(SpeexResamplerState *st, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    unsigned int i;
+    int istride_save, ostride_save;
+    unsigned int bak_len = *out_len;
+
+    istride_save = st->in_stride;
+    ostride_save = st->out_stride;
+    st->in_stride = st->out_stride = st->nb_channels;
+
+    for (i = 0; i < st->nb_channels; i++) {
+
+        *out_len = bak_len;
+
+        if (in != NULL) {
+            speex_resampler_process_float(st, i, in + i, in_len, out + i, out_len);
+        } else {
+            speex_resampler_process_float(st, i, NULL, in_len, out + i, out_len);
+        }
+    }
+
+    st->in_stride = istride_save;
+    st->out_stride = ostride_save;
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+int speex_resampler_set_rate(SpeexResamplerState *st, unsigned int in_rate, unsigned int out_rate)
+{
+    return speex_resampler_set_rate_frac(st, in_rate, out_rate, in_rate, out_rate);
+}
+
+void speex_resampler_get_rate(SpeexResamplerState *st, unsigned int *in_rate, unsigned int *out_rate)
+{
+    *in_rate = st->in_rate;
+    *out_rate = st->out_rate;
+}
+
+static unsigned int gcd(unsigned int a, unsigned int b)
+{
+    /* Euclid */
+
+    while (b) {
+        unsigned int tmp = b;
+        b = a % b;
+        a = tmp;
+    }
+
+    return a;
+}
+
+int speex_resampler_set_rate_frac(SpeexResamplerState *st, unsigned int ratio_num, unsigned int ratio_den, unsigned int in_rate, unsigned int out_rate)
+{
+    unsigned int old_den;
+    unsigned int i;
+	unsigned int g;
+
+    if (st->in_rate == in_rate && st->out_rate == out_rate &&
+	st->num_rate == ratio_num && st->den_rate == ratio_den) {
+        return RESAMPLER_ERR_SUCCESS;
+    }
+
+    old_den = st->den_rate;
+
+    st->in_rate = in_rate;
+    st->out_rate = out_rate;
+
+    st->num_rate = ratio_num;
+    st->den_rate = ratio_den;
+
+    g = gcd(st->num_rate, st->den_rate);
+
+    st->num_rate /= g;
+    st->den_rate /= g;
+
+    if (old_den > 0) {
+
+        for (i = 0; i < st->nb_channels; i++) {
+
+            st->samp_frac_num[i] = st->samp_frac_num[i] * st->den_rate / old_den;
+
+            if (st->samp_frac_num[i] >= st->den_rate) {
+                st->samp_frac_num[i] = st->den_rate - 1;
+	    }
+        }
+    }
+
+    if (st->initialised) {
+        update_filter(st);
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+void speex_resampler_get_ratio(SpeexResamplerState *st, unsigned int *ratio_num, unsigned int *ratio_den)
+{
+    *ratio_num = st->num_rate;
+    *ratio_den = st->den_rate;
+}
+
+int speex_resampler_set_quality(SpeexResamplerState *st, int quality)
+{
+    if (quality > 10 || quality < 0) {
+        return RESAMPLER_ERR_INVALID_ARG;
+    }
+
+    if (st->quality == quality) {
+        return RESAMPLER_ERR_SUCCESS;
+    }
+
+    st->quality = quality;
+
+    if (st->initialised) {
+        update_filter(st); 
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+void speex_resampler_get_quality(SpeexResamplerState *st, int *quality)
+{
+    *quality = st->quality;
+}
+
+void speex_resampler_set_input_stride(SpeexResamplerState *st, unsigned int stride)
+{
+    st->in_stride = stride;
+}
+
+void speex_resampler_get_input_stride(SpeexResamplerState *st, unsigned int *stride)
+{
+    *stride = st->in_stride;
+}
+
+void speex_resampler_set_output_stride(SpeexResamplerState *st, unsigned int stride)
+{
+    st->out_stride = stride;
+}
+
+void speex_resampler_get_output_stride(SpeexResamplerState *st, unsigned int *stride)
+{
+    *stride = st->out_stride;
+}
+
+int speex_resampler_get_input_latency(SpeexResamplerState *st)
+{
+    return st->filt_len / 2;
+}
+
+int speex_resampler_get_output_latency(SpeexResamplerState *st) 
+{
+    return ((st->filt_len / 2) * st->den_rate + (st->num_rate >> 1)) / st->num_rate;
+}
+
+int speex_resampler_skip_zeros(SpeexResamplerState *st)
+{
+    unsigned int i;
+
+    for (i = 0; i < st->nb_channels; i++) {
+        st->last_sample[i] = st->filt_len / 2;
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+int speex_resampler_reset_mem(SpeexResamplerState *st)
+{
+    unsigned int i;
+
+    for (i = 0; i < st->nb_channels*(st->filt_len - 1); i++) {
+        st->mem[i] = 0;
+    }
+
+    for (i = 0; i < st->nb_channels; i++) {
+        st->last_sample[i] = 0;
+        st->magic_samples[i] = 0;
+        st->samp_frac_num[i] = 0;
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+const char *speex_resampler_strerror(int err)
+{
+    switch (err) {
+
+    case RESAMPLER_ERR_SUCCESS:
+        return "Success.";
+
+    case RESAMPLER_ERR_ALLOC_FAILED:
+        return "Memory allocation failed.";
+
+    case RESAMPLER_ERR_BAD_STATE:
+        return "Bad resampler state.";
+
+    case RESAMPLER_ERR_INVALID_ARG:
+        return "Invalid argument.";
+
+    case RESAMPLER_ERR_PTR_OVERLAP:
+        return "Input and output buffers overlap.";
+
+    default:
+        return "Unknown error. Bad error code or strange version mismatch.";
+    }
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/speex/speex_resampler.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/ext/speex/speex_resampler.h
@@ -1,0 +1,301 @@
+/* Copyright (C) 2007 Jean-Marc Valin
+      
+   File: speex_resampler.h
+   Resampling code
+      
+   The design goals of this code are:
+      - Very fast algorithm
+      - Low memory requirement
+      - Good *perceptual* quality (and not best SNR)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef SPEEX_RESAMPLER_H
+#define SPEEX_RESAMPLER_H
+
+/********* WARNING: MENTAL SANITY ENDS HERE *************/
+
+/* If the resampler is defined outside of Speex, we change the symbol
+   names so that there won't be any clash if linking with Speex later
+   on. */
+
+#define RANDOM_PREFIX rubberband
+
+#ifndef RANDOM_PREFIX
+#error "Please define RANDOM_PREFIX (above) to something specific to your project to prevent symbol name clashes"
+#endif
+
+#define CAT_PREFIX2(a,b) a ## b
+#define CAT_PREFIX(a,b) CAT_PREFIX2(a, b)
+      
+#define speex_resampler_init CAT_PREFIX(RANDOM_PREFIX,_resampler_init)
+#define speex_resampler_init_frac CAT_PREFIX(RANDOM_PREFIX,_resampler_init_frac)
+#define speex_resampler_destroy CAT_PREFIX(RANDOM_PREFIX,_resampler_destroy)
+#define speex_resampler_process_float CAT_PREFIX(RANDOM_PREFIX,_resampler_process_float)
+#define speex_resampler_process_int CAT_PREFIX(RANDOM_PREFIX,_resampler_process_int)
+#define speex_resampler_process_interleaved_float CAT_PREFIX(RANDOM_PREFIX,_resampler_process_interleaved_float)
+#define speex_resampler_process_interleaved_int CAT_PREFIX(RANDOM_PREFIX,_resampler_process_interleaved_int)
+#define speex_resampler_set_rate CAT_PREFIX(RANDOM_PREFIX,_resampler_set_rate)
+#define speex_resampler_get_rate CAT_PREFIX(RANDOM_PREFIX,_resampler_get_rate)
+#define speex_resampler_set_rate_frac CAT_PREFIX(RANDOM_PREFIX,_resampler_set_rate_frac)
+#define speex_resampler_get_ratio CAT_PREFIX(RANDOM_PREFIX,_resampler_get_ratio)
+#define speex_resampler_set_quality CAT_PREFIX(RANDOM_PREFIX,_resampler_set_quality)
+#define speex_resampler_get_quality CAT_PREFIX(RANDOM_PREFIX,_resampler_get_quality)
+#define speex_resampler_set_input_stride CAT_PREFIX(RANDOM_PREFIX,_resampler_set_input_stride)
+#define speex_resampler_get_input_stride CAT_PREFIX(RANDOM_PREFIX,_resampler_get_input_stride)
+#define speex_resampler_set_output_stride CAT_PREFIX(RANDOM_PREFIX,_resampler_set_output_stride)
+#define speex_resampler_get_output_stride CAT_PREFIX(RANDOM_PREFIX,_resampler_get_output_stride)
+#define speex_resampler_get_input_latency CAT_PREFIX(RANDOM_PREFIX,_resampler_get_input_latency)
+#define speex_resampler_get_output_latency CAT_PREFIX(RANDOM_PREFIX,_resampler_get_output_latency)
+#define speex_resampler_skip_zeros CAT_PREFIX(RANDOM_PREFIX,_resampler_skip_zeros)
+#define speex_resampler_reset_mem CAT_PREFIX(RANDOM_PREFIX,_resampler_reset_mem)
+#define speex_resampler_strerror CAT_PREFIX(RANDOM_PREFIX,_resampler_strerror)
+
+#define spx_int16_t short
+#define spx_int32_t int
+#define spx_uint16_t unsigned short
+#define spx_uint32_t unsigned int
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SPEEX_RESAMPLER_QUALITY_MAX 10
+#define SPEEX_RESAMPLER_QUALITY_MIN 0
+#define SPEEX_RESAMPLER_QUALITY_DEFAULT 4
+#define SPEEX_RESAMPLER_QUALITY_VOIP 3
+#define SPEEX_RESAMPLER_QUALITY_DESKTOP 5
+
+enum {
+   RESAMPLER_ERR_SUCCESS         = 0,
+   RESAMPLER_ERR_ALLOC_FAILED    = 1,
+   RESAMPLER_ERR_BAD_STATE       = 2,
+   RESAMPLER_ERR_INVALID_ARG     = 3,
+   RESAMPLER_ERR_PTR_OVERLAP     = 4,
+   
+   RESAMPLER_ERR_MAX_ERROR
+};
+
+struct SpeexResamplerState_;
+typedef struct SpeexResamplerState_ SpeexResamplerState;
+
+/** Create a new resampler with integer input and output rates.
+ * @param nb_channels Number of channels to be processed
+ * @param in_rate Input sampling rate (integer number of Hz).
+ * @param out_rate Output sampling rate (integer number of Hz).
+ * @param quality Resampling quality between 0 and 10, where 0 has poor quality
+ * and 10 has very high quality.
+ * @return Newly created resampler state
+ * @retval NULL Error: not enough memory
+ */
+SpeexResamplerState *speex_resampler_init(spx_uint32_t nb_channels, 
+                                          spx_uint32_t in_rate, 
+                                          spx_uint32_t out_rate, 
+                                          int quality,
+                                          int *err);
+
+/** Create a new resampler with fractional input/output rates. The sampling 
+ * rate ratio is an arbitrary rational number with both the numerator and 
+ * denominator being 32-bit integers.
+ * @param nb_channels Number of channels to be processed
+ * @param ratio_num Numerator of the sampling rate ratio
+ * @param ratio_den Denominator of the sampling rate ratio
+ * @param in_rate Input sampling rate rounded to the nearest integer (in Hz).
+ * @param out_rate Output sampling rate rounded to the nearest integer (in Hz).
+ * @param quality Resampling quality between 0 and 10, where 0 has poor quality
+ * and 10 has very high quality.
+ * @return Newly created resampler state
+ * @retval NULL Error: not enough memory
+ */
+SpeexResamplerState *speex_resampler_init_frac(spx_uint32_t nb_channels, 
+                                               spx_uint32_t ratio_num, 
+                                               spx_uint32_t ratio_den, 
+                                               spx_uint32_t in_rate, 
+                                               spx_uint32_t out_rate, 
+                                               int quality,
+                                               int *err);
+
+/** Destroy a resampler state.
+ * @param st Resampler state
+ */
+void speex_resampler_destroy(SpeexResamplerState *st);
+
+/** Resample a float array. The input and output buffers must *not* overlap.
+ * @param st Resampler state
+ * @param channel_index Index of the channel to process for the multi-channel 
+ * base (0 otherwise)
+ * @param in Input buffer
+ * @param in_len Number of input samples in the input buffer. Returns the 
+ * number of samples processed
+ * @param out Output buffer
+ * @param out_len Size of the output buffer. Returns the number of samples written
+ */
+int speex_resampler_process_float(SpeexResamplerState *st, 
+                                   spx_uint32_t channel_index, 
+                                   const float *in, 
+                                   spx_uint32_t *in_len, 
+                                   float *out, 
+                                   spx_uint32_t *out_len);
+
+/** Resample an interleaved float array. The input and output buffers must *not* overlap.
+ * @param st Resampler state
+ * @param in Input buffer
+ * @param in_len Number of input samples in the input buffer. Returns the number
+ * of samples processed. This is all per-channel.
+ * @param out Output buffer
+ * @param out_len Size of the output buffer. Returns the number of samples written.
+ * This is all per-channel.
+ */
+int speex_resampler_process_interleaved_float(SpeexResamplerState *st, 
+                                               const float *in, 
+                                               spx_uint32_t *in_len, 
+                                               float *out, 
+                                               spx_uint32_t *out_len);
+
+/** Set (change) the input/output sampling rates (integer value).
+ * @param st Resampler state
+ * @param in_rate Input sampling rate (integer number of Hz).
+ * @param out_rate Output sampling rate (integer number of Hz).
+ */
+int speex_resampler_set_rate(SpeexResamplerState *st, 
+                              spx_uint32_t in_rate, 
+                              spx_uint32_t out_rate);
+
+/** Get the current input/output sampling rates (integer value).
+ * @param st Resampler state
+ * @param in_rate Input sampling rate (integer number of Hz) copied.
+ * @param out_rate Output sampling rate (integer number of Hz) copied.
+ */
+void speex_resampler_get_rate(SpeexResamplerState *st, 
+                              spx_uint32_t *in_rate, 
+                              spx_uint32_t *out_rate);
+
+/** Set (change) the input/output sampling rates and resampling ratio 
+ * (fractional values in Hz supported).
+ * @param st Resampler state
+ * @param ratio_num Numerator of the sampling rate ratio
+ * @param ratio_den Denominator of the sampling rate ratio
+ * @param in_rate Input sampling rate rounded to the nearest integer (in Hz).
+ * @param out_rate Output sampling rate rounded to the nearest integer (in Hz).
+ */
+int speex_resampler_set_rate_frac(SpeexResamplerState *st, 
+                                   spx_uint32_t ratio_num, 
+                                   spx_uint32_t ratio_den, 
+                                   spx_uint32_t in_rate, 
+                                   spx_uint32_t out_rate);
+
+/** Get the current resampling ratio. This will be reduced to the least
+ * common denominator.
+ * @param st Resampler state
+ * @param ratio_num Numerator of the sampling rate ratio copied
+ * @param ratio_den Denominator of the sampling rate ratio copied
+ */
+void speex_resampler_get_ratio(SpeexResamplerState *st, 
+                               spx_uint32_t *ratio_num, 
+                               spx_uint32_t *ratio_den);
+
+/** Set (change) the conversion quality.
+ * @param st Resampler state
+ * @param quality Resampling quality between 0 and 10, where 0 has poor 
+ * quality and 10 has very high quality.
+ */
+int speex_resampler_set_quality(SpeexResamplerState *st, 
+                                 int quality);
+
+/** Get the conversion quality.
+ * @param st Resampler state
+ * @param quality Resampling quality between 0 and 10, where 0 has poor 
+ * quality and 10 has very high quality.
+ */
+void speex_resampler_get_quality(SpeexResamplerState *st, 
+                                 int *quality);
+
+/** Set (change) the input stride.
+ * @param st Resampler state
+ * @param stride Input stride
+ */
+void speex_resampler_set_input_stride(SpeexResamplerState *st, 
+                                      spx_uint32_t stride);
+
+/** Get the input stride.
+ * @param st Resampler state
+ * @param stride Input stride copied
+ */
+void speex_resampler_get_input_stride(SpeexResamplerState *st, 
+                                      spx_uint32_t *stride);
+
+/** Set (change) the output stride.
+ * @param st Resampler state
+ * @param stride Output stride
+ */
+void speex_resampler_set_output_stride(SpeexResamplerState *st, 
+                                      spx_uint32_t stride);
+
+/** Get the output stride.
+ * @param st Resampler state copied
+ * @param stride Output stride
+ */
+void speex_resampler_get_output_stride(SpeexResamplerState *st, 
+                                      spx_uint32_t *stride);
+
+/** Get the latency in input samples introduced by the resampler.
+ * @param st Resampler state
+ */
+int speex_resampler_get_input_latency(SpeexResamplerState *st);
+
+/** Get the latency in output samples introduced by the resampler.
+ * @param st Resampler state
+ */
+int speex_resampler_get_output_latency(SpeexResamplerState *st);
+
+/** Make sure that the first samples to go out of the resamplers don't have 
+ * leading zeros. This is only useful before starting to use a newly created 
+ * resampler. It is recommended to use that when resampling an audio file, as
+ * it will generate a file with the same length. For real-time processing,
+ * it is probably easier not to use this call (so that the output duration
+ * is the same for the first frame).
+ * @param st Resampler state
+ */
+int speex_resampler_skip_zeros(SpeexResamplerState *st);
+
+/** Reset a resampler so a new (unrelated) stream can be processed.
+ * @param st Resampler state
+ */
+int speex_resampler_reset_mem(SpeexResamplerState *st);
+
+/** Returns the English meaning for an error code
+ * @param err Error code
+ * @return English string
+ */
+const char *speex_resampler_strerror(int err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/AudioCurveCalculator.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/AudioCurveCalculator.cpp
@@ -1,0 +1,72 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "AudioCurveCalculator.h"
+
+#include <iostream>
+
+namespace RubberBand
+{
+
+static const int MaxPerceivedFreq = 16000;
+
+AudioCurveCalculator::AudioCurveCalculator(Parameters parameters) :
+    m_sampleRate(parameters.sampleRate),
+    m_fftSize(parameters.fftSize)
+{
+    recalculateLastPerceivedBin();
+}
+
+AudioCurveCalculator::~AudioCurveCalculator()
+{
+}
+
+void
+AudioCurveCalculator::setSampleRate(int newRate)
+{
+    m_sampleRate = newRate;
+    recalculateLastPerceivedBin();
+}
+
+void
+AudioCurveCalculator::setFftSize(int newSize)
+{
+    m_fftSize = newSize;
+    recalculateLastPerceivedBin();
+}
+
+void
+AudioCurveCalculator::recalculateLastPerceivedBin()
+{
+    if (m_sampleRate == 0) {
+        m_lastPerceivedBin = 0;
+        return;
+    }
+    m_lastPerceivedBin = ((MaxPerceivedFreq * m_fftSize) / m_sampleRate);
+    if (m_lastPerceivedBin > m_fftSize/2) {
+        m_lastPerceivedBin = m_fftSize/2;
+    }
+}
+
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/AudioCurveCalculator.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/AudioCurveCalculator.h
@@ -1,0 +1,134 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_AUDIO_CURVE_CALCULATOR_H
+#define RUBBERBAND_AUDIO_CURVE_CALCULATOR_H
+
+#include <sys/types.h>
+
+#include "../common/sysutils.h"
+
+namespace RubberBand 
+{
+
+/**
+ * AudioCurveCalculator turns a sequence of audio "columns" --
+ * short-time spectrum magnitude blocks -- into a sequence of numbers
+ * representing some quality of the input such as power or likelihood
+ * of an onset occurring.
+ *
+ * These are typically low-level building-blocks: AudioCurveCalculator
+ * is a simple causal interface in which each input column corresponds
+ * to exactly one output value which is returned immediately.  They
+ * have far less power (because of the causal interface and
+ * magnitude-only input) and flexibility (because of the limited
+ * return types) than for example the Vamp plugin interface.
+ *
+ * AudioCurveCalculator implementations typically remember the history
+ * of their processing data, and the caller must call reset() before
+ * resynchronising to an unrelated piece of input audio.
+ */
+class AudioCurveCalculator
+{
+public:
+    struct Parameters {
+        Parameters(int _sampleRate, int _fftSize) :
+            sampleRate(_sampleRate),
+            fftSize(_fftSize)
+        { }
+        int sampleRate;
+        int fftSize;
+    };
+
+    AudioCurveCalculator(Parameters parameters);
+    virtual ~AudioCurveCalculator();
+
+    int getSampleRate() const { return m_sampleRate; }
+    int getFftSize() const { return m_fftSize; }
+
+    virtual void setSampleRate(int newRate);
+    virtual void setFftSize(int newSize);
+
+    Parameters getParameters() const {
+        return Parameters(m_sampleRate, m_fftSize);
+    }
+    void setParameters(Parameters p) {
+        setSampleRate(p.sampleRate);
+        setFftSize(p.fftSize);
+    }
+
+    // You may not mix calls to the various process functions on a
+    // given instance
+
+
+    /**
+     * Process the given magnitude spectrum block and return the curve
+     * value for it.  The mag input contains (fftSize/2 + 1) values
+     * corresponding to the magnitudes of the complex FFT output bins
+     * for a windowed input of size fftSize.  The hop (expressed in
+     * time-domain audio samples) from the previous to the current
+     * input block is given by increment.
+     */
+    virtual float processFloat(const float *R__ mag, int increment) = 0;
+
+    /**
+     * Process the given magnitude spectrum block and return the curve
+     * value for it.  The mag input contains (fftSize/2 + 1) values
+     * corresponding to the magnitudes of the complex FFT output bins
+     * for a windowed input of size fftSize.  The hop (expressed in
+     * time-domain audio samples) from the previous to the current
+     * input block is given by increment.
+     */
+    virtual double processDouble(const double *R__ mag, int increment) = 0;
+
+    /**
+     * Obtain a confidence for the curve value (if applicable). A
+     * value of 1.0 indicates perfect confidence in the curve
+     * calculation, 0.0 indicates none.
+     */
+    virtual double getConfidence() const { return 1.0; }
+
+    /**
+     * Reset the calculator, forgetting the history of the audio input
+     * so far.
+     */
+    virtual void reset() = 0;
+
+    /**
+     * If the output of this calculator has a known unit, return it as
+     * text.  For example, "Hz" or "V".
+     */
+    virtual const char *getUnit() const { return ""; }
+
+protected:
+    int m_sampleRate;
+    int m_fftSize;
+    int m_lastPerceivedBin;
+    void recalculateLastPerceivedBin();
+};
+
+
+}
+
+#endif
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/CompoundAudioCurve.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/CompoundAudioCurve.cpp
@@ -1,0 +1,167 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "CompoundAudioCurve.h"
+
+#include "../common/MovingMedian.h"
+
+#include <iostream>
+
+namespace RubberBand
+{
+
+
+CompoundAudioCurve::CompoundAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters),
+    m_percussive(parameters),
+    m_hf(parameters),
+    m_hfFilter(new MovingMedian<double>(19, 85)),
+    m_hfDerivFilter(new MovingMedian<double>(19, 90)),
+    m_type(CompoundDetector),
+    m_lastHf(0.0),
+    m_lastResult(0.0),
+    m_risingCount(0)
+{
+}
+
+CompoundAudioCurve::~CompoundAudioCurve()
+{
+    delete m_hfFilter;
+    delete m_hfDerivFilter;
+}
+
+void
+CompoundAudioCurve::setType(Type type)
+{
+    m_type = type;
+}
+
+void
+CompoundAudioCurve::reset()
+{
+    m_percussive.reset();
+    m_hf.reset();
+    m_hfFilter->reset();
+    m_hfDerivFilter->reset();
+    m_lastHf = 0.0;
+    m_lastResult = 0.0;
+}
+
+void
+CompoundAudioCurve::setFftSize(int newSize)
+{
+    m_percussive.setFftSize(newSize);
+    m_hf.setFftSize(newSize);
+    m_fftSize = newSize;
+    m_lastHf = 0.0;
+    m_lastResult = 0.0;
+}
+
+float
+CompoundAudioCurve::processFloat(const float *R__ mag, int increment)
+{
+    float percussive = 0.f;
+    float hf = 0.f;
+    switch (m_type) {
+    case PercussiveDetector:
+        percussive = m_percussive.processFloat(mag, increment);
+        break;
+    case CompoundDetector:
+        percussive = m_percussive.processFloat(mag, increment);
+        hf = m_hf.processFloat(mag, increment);
+        break;
+    case SoftDetector:
+        hf = m_hf.processFloat(mag, increment);
+        break;
+    }
+    return processFiltering(percussive, hf);
+}
+
+double
+CompoundAudioCurve::processDouble(const double *R__ mag, int increment)
+{
+    double percussive = 0.0;
+    double hf = 0.0;
+    switch (m_type) {
+    case PercussiveDetector:
+        percussive = m_percussive.processDouble(mag, increment);
+        break;
+    case CompoundDetector:
+        percussive = m_percussive.processDouble(mag, increment);
+        hf = m_hf.processDouble(mag, increment);
+        break;
+    case SoftDetector:
+        hf = m_hf.processDouble(mag, increment);
+        break;
+    }
+    return processFiltering(percussive, hf);
+}
+
+double
+CompoundAudioCurve::processFiltering(double percussive, double hf)
+{
+    if (m_type == PercussiveDetector) {
+        return percussive;
+    }
+
+    double rv = 0.f;
+    
+    double hfDeriv = hf - m_lastHf;
+
+    m_hfFilter->push(hf);
+    m_hfDerivFilter->push(hfDeriv);
+
+    double hfFiltered = m_hfFilter->get();
+    double hfDerivFiltered = m_hfDerivFilter->get();
+
+    m_lastHf = hf;
+
+    double result = 0.f;
+    
+    double hfExcess = hf - hfFiltered;
+
+    if (hfExcess > 0.0) {
+        result = hfDeriv - hfDerivFiltered;
+    }
+
+    if (result < m_lastResult) {
+        if (m_risingCount > 3 && m_lastResult > 0) rv = 0.5;
+        m_risingCount = 0;
+    } else {
+        m_risingCount ++;
+    }
+
+    if (m_type == CompoundDetector) {
+        if (percussive > 0.35 && percussive > rv) {
+            rv = percussive;
+        }
+    }
+
+    m_lastResult = result;
+
+    return rv;
+}
+
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/CompoundAudioCurve.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/CompoundAudioCurve.h
@@ -1,0 +1,73 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_COMPOUND_AUDIO_CURVE_H
+#define RUBBERBAND_COMPOUND_AUDIO_CURVE_H
+
+#include "PercussiveAudioCurve.h"
+#include "HighFrequencyAudioCurve.h"
+#include "../common/SampleFilter.h"
+
+namespace RubberBand
+{
+
+class CompoundAudioCurve : public AudioCurveCalculator
+{
+public:
+    CompoundAudioCurve(Parameters parameters);
+
+    virtual ~CompoundAudioCurve();
+
+    enum Type {
+        PercussiveDetector,
+        CompoundDetector,
+        SoftDetector
+    };
+    virtual void setType(Type); // default is CompoundDetector
+    
+    virtual void setFftSize(int newSize);
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+
+    virtual void reset();
+
+protected:
+    PercussiveAudioCurve m_percussive;
+    HighFrequencyAudioCurve m_hf;
+
+    SampleFilter<double> *m_hfFilter;
+    SampleFilter<double> *m_hfDerivFilter;
+
+    Type m_type;
+
+    double m_lastHf;
+    double m_lastResult;
+    int m_risingCount;
+
+    double processFiltering(double percussive, double hf);
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/HighFrequencyAudioCurve.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/HighFrequencyAudioCurve.cpp
@@ -1,0 +1,73 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "HighFrequencyAudioCurve.h"
+
+namespace RubberBand
+{
+
+
+HighFrequencyAudioCurve::HighFrequencyAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters)
+{
+}
+
+HighFrequencyAudioCurve::~HighFrequencyAudioCurve()
+{
+}
+
+void
+HighFrequencyAudioCurve::reset()
+{
+}
+
+float
+HighFrequencyAudioCurve::processFloat(const float *R__ mag, int)
+{
+    float result = 0.0;
+
+    const int sz = m_lastPerceivedBin;
+
+    for (int n = 0; n <= sz; ++n) {
+        result = result + mag[n] * n;
+    }
+
+    return result;
+}
+
+double
+HighFrequencyAudioCurve::processDouble(const double *R__ mag, int)
+{
+    double result = 0.0;
+
+    const int sz = m_lastPerceivedBin;
+
+    for (int n = 0; n <= sz; ++n) {
+        result = result + mag[n] * n;
+    }
+    
+    return result;
+}
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/HighFrequencyAudioCurve.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/HighFrequencyAudioCurve.h
@@ -1,0 +1,47 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_HIGHFREQUENCY_AUDIO_CURVE_H
+#define RUBBERBAND_HIGHFREQUENCY_AUDIO_CURVE_H
+
+#include "AudioCurveCalculator.h"
+
+namespace RubberBand
+{
+
+class HighFrequencyAudioCurve : public AudioCurveCalculator
+{
+public:
+    HighFrequencyAudioCurve(Parameters parameters);
+
+    virtual ~HighFrequencyAudioCurve();
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+    virtual void reset();
+    virtual const char *getUnit() const { return "Vbin"; }
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/PercussiveAudioCurve.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/PercussiveAudioCurve.cpp
@@ -1,0 +1,114 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "PercussiveAudioCurve.h"
+
+#include "../common/Allocators.h"
+#include "../common/VectorOps.h"
+
+#include <cmath>
+#include <iostream>
+namespace RubberBand
+{
+
+
+PercussiveAudioCurve::PercussiveAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters)
+{
+    m_prevMag = allocate_and_zero<double>(m_fftSize/2 + 1);
+}
+
+PercussiveAudioCurve::~PercussiveAudioCurve()
+{
+    deallocate(m_prevMag);
+}
+
+void
+PercussiveAudioCurve::reset()
+{
+    v_zero(m_prevMag, m_fftSize/2 + 1);
+}
+
+void
+PercussiveAudioCurve::setFftSize(int newSize)
+{
+    m_prevMag = reallocate(m_prevMag, m_fftSize/2 + 1, newSize/2 + 1);
+    AudioCurveCalculator::setFftSize(newSize);
+    reset();
+}
+
+float
+PercussiveAudioCurve::processFloat(const float *R__ mag, int)
+{
+    static float threshold = powf(10.f, 0.15f); // 3dB rise in square of magnitude
+    static float zeroThresh = powf(10.f, -8);
+
+    int count = 0;
+    int nonZeroCount = 0;
+
+    const int sz = m_lastPerceivedBin;
+
+    for (int n = 1; n <= sz; ++n) {
+        float v = 0.f;
+        if (m_prevMag[n] > zeroThresh) v = mag[n] / m_prevMag[n];
+        else if (mag[n] > zeroThresh) v = threshold;
+        bool above = (v >= threshold);
+        if (above) ++count;
+        if (mag[n] > zeroThresh) ++nonZeroCount;
+    }
+
+    v_convert(m_prevMag, mag, sz + 1);
+
+    if (nonZeroCount == 0) return 0;
+    else return float(count) / float(nonZeroCount);
+}
+
+double
+PercussiveAudioCurve::processDouble(const double *R__ mag, int)
+{
+    static double threshold = pow(10., 0.15); // 3dB rise in square of magnitude
+    static double zeroThresh = pow(10., -8);
+
+    int count = 0;
+    int nonZeroCount = 0;
+
+    const int sz = m_lastPerceivedBin;
+
+    for (int n = 1; n <= sz; ++n) {
+        double v = 0.0;
+        if (m_prevMag[n] > zeroThresh) v = mag[n] / m_prevMag[n];
+        else if (mag[n] > zeroThresh) v = threshold;
+        bool above = (v >= threshold);
+        if (above) ++count;
+        if (mag[n] > zeroThresh) ++nonZeroCount;
+    }
+
+    v_copy(m_prevMag, mag, sz + 1);
+
+    if (nonZeroCount == 0) return 0;
+    else return double(count) / double(nonZeroCount);
+}
+
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/PercussiveAudioCurve.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/PercussiveAudioCurve.h
@@ -1,0 +1,54 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_PERCUSSIVE_AUDIO_CURVE_H
+#define RUBBERBAND_PERCUSSIVE_AUDIO_CURVE_H
+
+#include "AudioCurveCalculator.h"
+
+namespace RubberBand
+{
+
+class PercussiveAudioCurve : public AudioCurveCalculator
+{
+public:
+    PercussiveAudioCurve(Parameters parameters);
+
+    virtual ~PercussiveAudioCurve();
+
+    virtual void setFftSize(int newSize);
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+
+
+    virtual void reset();
+    virtual const char *getUnit() const { return "bin/total"; }
+
+protected:
+    double *R__ m_prevMag;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/R2Stretcher.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/R2Stretcher.cpp
@@ -1,0 +1,1363 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "R2Stretcher.h"
+
+#include "PercussiveAudioCurve.h"
+#include "HighFrequencyAudioCurve.h"
+#include "SilentAudioCurve.h"
+#include "CompoundAudioCurve.h"
+#include "StretcherChannelData.h"
+
+#include "../common/StretchCalculator.h"
+#include "../common/Resampler.h"
+#include "../common/Profiler.h"
+#include "../common/sysutils.h"
+#include "../common/mathmisc.h"
+
+#include <cassert>
+#include <cmath>
+#include <set>
+#include <map>
+#include <algorithm>
+
+using std::vector;
+using std::map;
+using std::set;
+using std::max;
+using std::min;
+
+namespace RubberBand {
+
+const size_t
+R2Stretcher::m_defaultIncrement = 256;
+
+const size_t
+R2Stretcher::m_defaultFftSize = 2048;
+
+R2Stretcher::R2Stretcher(size_t sampleRate,
+                         size_t channels,
+                         RubberBandStretcher::Options options,
+                         double initialTimeRatio,
+                         double initialPitchScale,
+                         Log log) :
+    m_sampleRate(sampleRate),
+    m_channels(channels),
+    m_timeRatio(initialTimeRatio),
+    m_pitchScale(initialPitchScale),
+    m_fftSize(m_defaultFftSize),
+    m_aWindowSize(m_defaultFftSize),
+    m_sWindowSize(m_defaultFftSize),
+    m_increment(m_defaultIncrement),
+    m_outbufSize(m_defaultFftSize * 2),
+    m_maxProcessSize(m_defaultFftSize),
+    m_expectedInputDuration(0),
+#ifndef NO_THREADING
+    m_threaded(false),
+#endif
+    m_realtime(false),
+    m_options(options),
+    m_log(log),
+    m_mode(JustCreated),
+    m_awindow(0),
+    m_afilter(0),
+    m_swindow(0),
+    m_studyFFT(0),
+#ifndef NO_THREADING
+    m_spaceAvailable("space"),
+#endif
+    m_inputDuration(0),
+    m_detectorType(CompoundAudioCurve::CompoundDetector),
+    m_silentHistory(0),
+    m_lastProcessOutputIncrements(16),
+    m_lastProcessPhaseResetDf(16),
+    m_emergencyScavenger(10, 4),
+    m_phaseResetAudioCurve(0),
+    m_silentAudioCurve(0),
+    m_stretchCalculator(0),
+    m_freq0(600),
+    m_freq1(1200),
+    m_freq2(12000),
+    m_baseFftSize(m_defaultFftSize)
+{
+    Profiler profiler("R2Stretcher::R2Stretcher");
+
+    m_log.log(1, "R2Stretcher::R2Stretcher: rate, options",
+              m_sampleRate, options);
+    m_log.log(1, "R2Stretcher::R2Stretcher: initial time ratio and pitch scale",
+              m_timeRatio, m_pitchScale);
+
+    // Window size will vary according to the audio sample rate, but
+    // we don't let it drop below the 48k default
+    m_rateMultiple = float(m_sampleRate) / 48000.f;
+//    if (m_rateMultiple < 1.f) m_rateMultiple = 1.f;
+    m_baseFftSize = roundUp(int(m_defaultFftSize * m_rateMultiple));
+
+    if ((options & RubberBandStretcher::OptionWindowShort) ||
+        (options & RubberBandStretcher::OptionWindowLong)) {
+        if ((options & RubberBandStretcher::OptionWindowShort) &&
+            (options & RubberBandStretcher::OptionWindowLong)) {
+            m_log.log(0, "R2Stretcher::R2Stretcher: Cannot specify OptionWindowLong and OptionWindowShort together; falling back to OptionWindowStandard");
+        } else if (options & RubberBandStretcher::OptionWindowShort) {
+            m_baseFftSize = m_baseFftSize / 2;
+            m_log.log(1, "setting baseFftSize", m_baseFftSize);
+        } else if (options & RubberBandStretcher::OptionWindowLong) {
+            m_baseFftSize = m_baseFftSize * 2;
+            m_log.log(1, "setting baseFftSize", m_baseFftSize);
+        }
+        m_fftSize = m_baseFftSize;
+        m_aWindowSize = m_baseFftSize;
+        m_sWindowSize = m_baseFftSize;
+        m_outbufSize = m_sWindowSize * 2;
+        m_maxProcessSize = m_aWindowSize;
+    }
+
+    if (m_options & RubberBandStretcher::OptionProcessRealTime) {
+        m_realtime = true;
+    }
+
+#ifndef NO_THREADING
+    if (m_channels > 1) {
+
+        m_threaded = true;
+
+        if (m_realtime) {
+            m_threaded = false;
+        } else if (m_options & RubberBandStretcher::OptionThreadingNever) {
+            m_threaded = false;
+        } else if (!(m_options & RubberBandStretcher::OptionThreadingAlways) &&
+                   !system_is_multiprocessor()) {
+            m_threaded = false;
+        }
+
+        if (m_threaded) {
+            m_log.log(1, "Going multithreaded...");
+        }
+    }
+#endif
+
+    configure();
+}
+
+R2Stretcher::~R2Stretcher()
+{
+#ifndef NO_THREADING
+    if (m_threaded) {
+        MutexLocker locker(&m_threadSetMutex);
+        for (set<ProcessThread *>::iterator i = m_threadSet.begin();
+             i != m_threadSet.end(); ++i) {
+            m_log.log(1, "RubberBandStretcher::~RubberBandStretcher: joining for channel", (*i)->channel());
+            (*i)->abandon();
+            (*i)->wait();
+            delete *i;
+        }
+    }
+#endif
+
+    for (size_t c = 0; c < m_channels; ++c) {
+        delete m_channelData[c];
+    }
+
+    delete m_phaseResetAudioCurve;
+    delete m_silentAudioCurve;
+    delete m_stretchCalculator;
+    delete m_studyFFT;
+
+    for (map<size_t, Window<float> *>::iterator i = m_windows.begin();
+         i != m_windows.end(); ++i) {
+        delete i->second;
+    }
+    for (map<size_t, SincWindow<float> *>::iterator i = m_sincs.begin();
+         i != m_sincs.end(); ++i) {
+        delete i->second;
+    }
+}
+
+void
+R2Stretcher::reset()
+{
+#ifndef NO_THREADING
+    if (m_threaded) {
+        m_threadSetMutex.lock();
+        for (set<ProcessThread *>::iterator i = m_threadSet.begin();
+             i != m_threadSet.end(); ++i) {
+            m_log.log(1, "RubberBandStretcher::~RubberBandStretcher: joining for channel", (*i)->channel());
+            (*i)->abandon();
+            (*i)->wait();
+            delete *i;
+        }
+        m_threadSet.clear();
+    }
+#endif
+
+    m_emergencyScavenger.scavenge();
+
+    if (m_stretchCalculator) {
+        m_stretchCalculator->reset();
+    }
+
+    for (size_t c = 0; c < m_channels; ++c) {
+        m_channelData[c]->reset();
+    }
+
+    m_mode = JustCreated;
+    if (m_phaseResetAudioCurve) m_phaseResetAudioCurve->reset();
+    if (m_silentAudioCurve) m_silentAudioCurve->reset();
+    m_expectedInputDuration = 0;
+    m_maxProcessSize = 0;
+    m_inputDuration = 0;
+    m_silentHistory = 0;
+
+#ifndef NO_THREADING
+    if (m_threaded) m_threadSetMutex.unlock();
+#endif
+
+    reconfigure();
+}
+
+void
+R2Stretcher::setTimeRatio(double ratio)
+{
+    if (!m_realtime) {
+        if (m_mode == Studying || m_mode == Processing) {
+            m_log.log(0, "R2Stretcher::setTimeRatio: Cannot set ratio while studying or processing in non-RT mode");
+            return;
+        }
+    }
+
+    if (ratio == m_timeRatio) return;
+    m_timeRatio = ratio;
+
+    reconfigure();
+}
+
+void
+R2Stretcher::setPitchScale(double fs)
+{
+    if (!m_realtime) {
+        if (m_mode == Studying || m_mode == Processing) {
+            m_log.log(0, "R2Stretcher::setPitchScale: Cannot set ratio while studying or processing in non-RT mode");
+            return;
+        }
+    }
+
+    if (fs == m_pitchScale) return;
+    
+    bool was1 = (m_pitchScale == 1.f);
+    bool rbs = resampleBeforeStretching();
+
+    m_pitchScale = fs;
+
+    reconfigure();
+
+    if (!(m_options & RubberBandStretcher::OptionPitchHighConsistency) &&
+        (was1 || resampleBeforeStretching() != rbs) &&
+        m_pitchScale != 1.f) {
+        
+        // resampling mode has changed
+        for (int c = 0; c < int(m_channels); ++c) {
+            if (m_channelData[c]->resampler) {
+                m_channelData[c]->resampler->reset();
+            }
+        }
+    }
+}
+
+double
+R2Stretcher::getTimeRatio() const
+{
+    return m_timeRatio;
+}
+
+double
+R2Stretcher::getPitchScale() const
+{
+    return m_pitchScale;
+}
+
+void
+R2Stretcher::setExpectedInputDuration(size_t samples)
+{
+    if (samples == m_expectedInputDuration) return;
+    m_expectedInputDuration = samples;
+
+    reconfigure();
+}
+
+void
+R2Stretcher::setMaxProcessSize(size_t samples)
+{
+    m_log.log(2, "R2Stretcher::setMaxProcessSize", samples);
+    if (samples <= m_maxProcessSize) return;
+
+    m_log.log(2, "R2Stretcher::setMaxProcessSize: increasing from, to", m_maxProcessSize, samples);
+    m_maxProcessSize = samples;
+
+    reconfigure();
+}
+
+size_t
+R2Stretcher::getProcessSizeLimit() const
+{
+    return 524288;
+}
+
+void
+R2Stretcher::setKeyFrameMap(const std::map<size_t, size_t> &mapping)
+{
+    if (m_realtime) {
+        m_log.log(0, "R2Stretcher::setKeyFrameMap: Cannot specify key frame map in RT mode");
+        return;
+    }
+    if (m_mode == Processing) {
+        m_log.log(0, "R2Stretcher::setKeyFrameMap: Cannot specify key frame map after process() has begun");
+        return;
+    }
+
+    if (m_stretchCalculator) {
+        m_stretchCalculator->setKeyFrameMap(mapping);
+    }
+}
+
+float
+R2Stretcher::getFrequencyCutoff(int n) const
+{
+    switch (n) {
+    case 0: return m_freq0;
+    case 1: return m_freq1;
+    case 2: return m_freq2;
+    }
+    return 0.f;
+}
+
+void
+R2Stretcher::setFrequencyCutoff(int n, float f)
+{
+    switch (n) {
+    case 0: m_freq0 = f; break;
+    case 1: m_freq1 = f; break;
+    case 2: m_freq2 = f; break;
+    }
+}
+
+double
+R2Stretcher::getEffectiveRatio() const
+{
+    // Returns the ratio that the internal time stretcher needs to
+    // achieve, not the resulting duration ratio of the output (which
+    // is simply m_timeRatio).
+
+    // A frequency shift is achieved using an additional time shift,
+    // followed by resampling back to the original time shift to
+    // change the pitch.  Note that the resulting frequency change is
+    // fixed, as it is effected by the resampler -- in contrast to
+    // time shifting, which is variable aiming to place the majority
+    // of the stretch or squash in low-interest regions of audio.
+
+    return m_timeRatio * m_pitchScale;
+}
+
+void
+R2Stretcher::calculateSizes()
+{
+    size_t inputIncrement = m_defaultIncrement;
+    size_t windowSize = m_baseFftSize;
+    size_t outputIncrement;
+
+    if (m_pitchScale <= 0.0) {
+        // This special case is likelier than one might hope, because
+        // of naive initialisations in programs that set it from a
+        // variable
+        m_log.log(0, "WARNING: Pitch scale must be greater than zero! Resetting it to default, no pitch shift will happen", m_pitchScale);
+        m_pitchScale = 1.0;
+    }
+    if (m_timeRatio <= 0.0) {
+        // Likewise
+        m_log.log(0, "WARNING: Time ratio must be greater than zero! Resetting it to default, no time stretch will happen", m_timeRatio);
+        m_timeRatio = 1.0;
+    }
+    if (m_pitchScale != m_pitchScale || m_timeRatio != m_timeRatio ||
+        m_pitchScale == m_pitchScale/2.0 || m_timeRatio == m_timeRatio/2.0) {
+        m_log.log(0, "WARNING: NaN or Inf presented for time ratio or pitch scale! Resetting it to default, no time stretch will happen", m_timeRatio, m_pitchScale);
+        m_timeRatio = 1.0;
+        m_pitchScale = 1.0;
+    }
+    
+    double r = getEffectiveRatio();
+
+    if (m_realtime) {
+
+        if (r < 1) {
+            
+            bool rsb = (m_pitchScale < 1.0 && !resampleBeforeStretching());
+            float windowIncrRatio = 4.5;
+            if (r == 1.0) windowIncrRatio = 4;
+            else if (rsb) windowIncrRatio = 4.5;
+            else windowIncrRatio = 6;
+
+            inputIncrement = int(windowSize / windowIncrRatio);
+            outputIncrement = int(floor(inputIncrement * r));
+
+            // Very long stretch or very low pitch shift
+            if (outputIncrement < m_defaultIncrement / 4) {
+                if (outputIncrement < 1) outputIncrement = 1;
+                while (outputIncrement < m_defaultIncrement / 4 &&
+                       windowSize < m_baseFftSize * 4) {
+                    outputIncrement *= 2;
+                    inputIncrement = lrint(ceil(outputIncrement / r));
+                    windowSize = roundUp(lrint(ceil(inputIncrement * windowIncrRatio)));
+                }
+            }
+
+        } else {
+
+            bool rsb = (m_pitchScale > 1.0 && resampleBeforeStretching());
+            float windowIncrRatio = 4.5;
+            if (r == 1.0) windowIncrRatio = 4;
+            else if (rsb) windowIncrRatio = 4.5;
+            else windowIncrRatio = 8;
+
+            outputIncrement = int(windowSize / windowIncrRatio);
+            inputIncrement = int(outputIncrement / r);
+            while (outputIncrement > 1024 * m_rateMultiple &&
+                   inputIncrement > 1) {
+                outputIncrement /= 2;
+                inputIncrement = int(outputIncrement / r);
+            }
+            while (inputIncrement < 1) {
+                outputIncrement *= 2;
+                inputIncrement = int(outputIncrement / r);
+            }
+            size_t minwin = roundUp(lrint(outputIncrement * windowIncrRatio));
+            if (windowSize < minwin) windowSize = minwin;
+
+            if (rsb) {
+                size_t oldWindowSize = windowSize;
+                size_t newWindowSize = roundUp(lrint(windowSize / m_pitchScale));
+                if (newWindowSize < 512) newWindowSize = 512;
+                size_t div = windowSize / newWindowSize;
+                if (inputIncrement > div && outputIncrement > div) {
+                    inputIncrement /= div;
+                    outputIncrement /= div;
+                    windowSize /= div;
+                }
+                m_log.log(2, "adjusting window size from/to", oldWindowSize, windowSize);
+                m_log.log(2, "input and output increments", inputIncrement, outputIncrement);
+            }
+        }
+
+    } else {
+
+        if (r < 1) {
+            inputIncrement = windowSize / 4;
+            while (inputIncrement >= 512) inputIncrement /= 2;
+            outputIncrement = int(floor(inputIncrement * r));
+            if (outputIncrement < 1) {
+                outputIncrement = 1;
+                inputIncrement = roundUp(lrint(ceil(outputIncrement / r)));
+                windowSize = inputIncrement * 4;
+            }
+        } else {
+            outputIncrement = windowSize / 6;
+            inputIncrement = int(outputIncrement / r);
+            while (outputIncrement > 1024 && inputIncrement > 1) {
+                outputIncrement /= 2;
+                inputIncrement = int(outputIncrement / r);
+            }
+            while (inputIncrement < 1) {
+                outputIncrement *= 2;
+                inputIncrement = int(outputIncrement / r);
+            }
+            windowSize = std::max(windowSize, roundUp(outputIncrement * 6));
+            if (r > 5) while (windowSize < 8192) windowSize *= 2;
+        }
+    }
+
+    if (m_expectedInputDuration > 0) {
+        while (inputIncrement * 4 > m_expectedInputDuration &&
+               inputIncrement > 1) {
+            inputIncrement /= 2;
+        }
+    }
+
+    // m_fftSize can be almost anything, but it can't be greater than
+    // 4 * m_baseFftSize unless ratio is less than 1/1024.
+
+    m_fftSize = windowSize;
+    
+    if (m_options & RubberBandStretcher::OptionSmoothingOn) {
+        m_aWindowSize = windowSize * 2;
+        m_sWindowSize = windowSize * 2;
+    } else {
+        m_aWindowSize = windowSize;
+        m_sWindowSize = windowSize;
+    }
+
+    m_increment = inputIncrement;
+
+    // When squashing, the greatest theoretically possible output
+    // increment is the input increment.  When stretching adaptively
+    // the sky's the limit in principle, but we expect
+    // StretchCalculator to restrict itself to using no more than
+    // twice the basic output increment (i.e. input increment times
+    // ratio) for any chunk.
+
+    m_log.log(1, "calculateSizes: time ratio and pitch scale", m_timeRatio, m_pitchScale);
+    m_log.log(1, "effective ratio", getEffectiveRatio());
+    m_log.log(1, "analysis and synthesis window sizes", m_aWindowSize, m_sWindowSize);
+    m_log.log(1, "fft size", m_fftSize);
+    m_log.log(1, "input increment and mean output increment", m_increment, m_increment * getEffectiveRatio());
+
+    if (std::max(m_aWindowSize, m_sWindowSize) > m_maxProcessSize) {
+        m_maxProcessSize = std::max(m_aWindowSize, m_sWindowSize);
+    }
+
+    m_outbufSize =
+        size_t
+        (ceil(max
+              (m_maxProcessSize / m_pitchScale,
+               m_maxProcessSize * 2 * (m_timeRatio > 1.f ? m_timeRatio : 1.f))));
+
+    if (m_realtime) {
+        // This headroom is so as to try to avoid reallocation when
+        // the pitch scale changes
+        m_outbufSize = m_outbufSize * 16;
+    } else {
+#ifndef NO_THREADING
+        if (m_threaded) {
+            // This headroom is to permit the processing threads to
+            // run ahead of the buffer output drainage; the exact
+            // amount of headroom is a question of tuning rather than
+            // results
+            m_outbufSize = m_outbufSize * 16;
+        }
+#endif
+    }
+
+    m_log.log(1, "calculateSizes: outbuf size", m_outbufSize);
+}
+
+void
+R2Stretcher::configure()
+{
+    if (m_realtime) {
+        m_log.log(1, "configure, realtime: pitch scale and channels",
+                  m_pitchScale, m_channels);
+    } else {
+        m_log.log(1, "configure, offline: pitch scale and channels",
+                  m_pitchScale, m_channels);
+    }              
+
+    size_t prevFftSize = m_fftSize;
+    size_t prevAWindowSize = m_aWindowSize;
+    size_t prevSWindowSize = m_sWindowSize;
+    size_t prevOutbufSize = m_outbufSize;
+    if (m_windows.empty()) {
+        prevFftSize = 0;
+        prevAWindowSize = 0;
+        prevSWindowSize = 0;
+        prevOutbufSize = 0;
+    }
+
+    calculateSizes();
+
+    bool fftSizeChanged = (prevFftSize != m_fftSize);
+    bool windowSizeChanged = ((prevAWindowSize != m_aWindowSize) ||
+                              (prevSWindowSize != m_sWindowSize));
+    bool outbufSizeChanged = (prevOutbufSize != m_outbufSize);
+
+    // This function may be called at any time in non-RT mode, after a
+    // parameter has changed.  It shouldn't be legal to call it after
+    // processing has already begun.
+
+    // This function is only called once (on construction) in RT
+    // mode.  After that reconfigure() does the work in a hopefully
+    // RT-safe way.
+
+    set<size_t> windowSizes;
+    if (m_realtime) {
+        windowSizes.insert(m_baseFftSize);
+        windowSizes.insert(m_baseFftSize / 2);
+        windowSizes.insert(m_baseFftSize * 2);
+//        windowSizes.insert(m_baseFftSize * 4);
+    }
+    windowSizes.insert(m_fftSize);
+    windowSizes.insert(m_aWindowSize);
+    windowSizes.insert(m_sWindowSize);
+
+    if (windowSizeChanged) {
+
+        for (set<size_t>::const_iterator i = windowSizes.begin();
+             i != windowSizes.end(); ++i) {
+            if (m_windows.find(*i) == m_windows.end()) {
+                m_windows[*i] = new Window<float>(HannWindow, *i);
+            }
+            if (m_sincs.find(*i) == m_sincs.end()) {
+                m_sincs[*i] = new SincWindow<float>(*i, *i);
+            }
+        }
+        m_awindow = m_windows[m_aWindowSize];
+        m_afilter = m_sincs[m_aWindowSize];
+        m_swindow = m_windows[m_sWindowSize];
+
+        m_log.log(1, "analysis and synthesis window areas",
+                  m_awindow->getArea(), m_swindow->getArea());
+    }
+
+    if (windowSizeChanged || outbufSizeChanged) {
+        
+        for (size_t c = 0; c < m_channelData.size(); ++c) {
+            delete m_channelData[c];
+        }
+        m_channelData.clear();
+
+        for (size_t c = 0; c < m_channels; ++c) {
+            m_channelData.push_back
+                (new ChannelData(windowSizes,
+                                 std::max(m_aWindowSize, m_sWindowSize),
+                                 m_fftSize,
+                                 m_outbufSize));
+        }
+    }
+
+    if (!m_realtime && fftSizeChanged) {
+        delete m_studyFFT;
+        m_studyFFT = new FFT(m_fftSize);
+        m_studyFFT->initFloat();
+    }
+
+    if (m_pitchScale != 1.0 ||
+        (m_options & RubberBandStretcher::OptionPitchHighConsistency) ||
+        m_realtime) {
+
+        for (size_t c = 0; c < m_channels; ++c) {
+
+            if (m_channelData[c]->resampler) continue;
+
+            Resampler::Parameters params;
+            params.quality = Resampler::FastestTolerable;
+
+            if (m_realtime) {
+                params.dynamism = Resampler::RatioOftenChanging;
+                params.ratioChange = Resampler::SmoothRatioChange;
+            } else {
+                // ratio can't be changed in offline mode
+                params.dynamism = Resampler::RatioMostlyFixed;
+                params.ratioChange = Resampler::SuddenRatioChange;
+            }
+            
+            params.maxBufferSize = 4096 * 16;
+            int myLevel = m_log.getDebugLevel();
+            params.debugLevel = (myLevel > 0 ? myLevel-1 : 0);
+            
+            m_channelData[c]->resampler = new Resampler(params, 1);
+
+            // rbs is the amount of buffer space we think we'll need
+            // for resampling; but allocate a sensible amount in case
+            // the pitch scale changes during use
+            size_t rbs = 
+                lrintf(ceil((m_increment * m_timeRatio * 2) / m_pitchScale));
+            if (rbs < m_increment * 16) rbs = m_increment * 16;
+            if (rbs < m_aWindowSize * 2) rbs = m_aWindowSize * 2;
+            m_channelData[c]->setResampleBufSize(rbs);
+        }
+    }
+    
+    delete m_phaseResetAudioCurve;
+    m_phaseResetAudioCurve = new CompoundAudioCurve
+        (CompoundAudioCurve::Parameters(m_sampleRate, m_fftSize));
+    m_phaseResetAudioCurve->setType(m_detectorType);
+
+    delete m_silentAudioCurve;
+    m_silentAudioCurve = new SilentAudioCurve
+        (SilentAudioCurve::Parameters(m_sampleRate, m_fftSize));
+
+    delete m_stretchCalculator;
+    m_stretchCalculator = new StretchCalculator
+        (m_sampleRate, m_increment,
+         !(m_options & RubberBandStretcher::OptionTransientsSmooth),
+         m_log);
+
+    m_stretchCalculator->setDebugLevel(m_log.getDebugLevel());
+    m_inputDuration = 0;
+
+    // Prepare the inbufs with half a chunk of emptiness.  The centre
+    // point of the first processing chunk for the onset detector
+    // should be the first sample of the audio, and we continue until
+    // we can no longer centre a chunk within the input audio.  The
+    // number of onset detector chunks will be the number of audio
+    // samples input, divided by the input increment, plus one.
+
+    // In real-time mode, we don't do this prefill -- it's better to
+    // start with a swoosh than introduce more latency, and we don't
+    // want gaps when the ratio changes.
+
+    if (!m_realtime) {
+        m_log.log(1, "offline mode: prefilling with", m_aWindowSize/2);
+        for (size_t c = 0; c < m_channels; ++c) {
+            m_channelData[c]->reset();
+            m_channelData[c]->inbuf->zero(m_aWindowSize/2);
+        }
+    } else {
+        m_log.log(1, "realtime mode: no prefill");
+    }
+}
+
+void
+R2Stretcher::reconfigure()
+{
+    if (!m_realtime) {
+        if (m_mode == Studying) {
+            // stop and calculate the stretch curve so far, then reset
+            // the df vectors
+            calculateStretch();
+            m_phaseResetDf.clear();
+            m_silence.clear();
+            m_inputDuration = 0;
+        }
+        configure();
+    }
+
+    size_t prevFftSize = m_fftSize;
+    size_t prevAWindowSize = m_aWindowSize;
+    size_t prevSWindowSize = m_sWindowSize;
+    size_t prevOutbufSize = m_outbufSize;
+
+    calculateSizes();
+
+    bool somethingChanged = false;
+    
+    // There are various allocations in this function, but they should
+    // never happen in normal use -- they just recover from the case
+    // where not all of the things we need were correctly created when
+    // we first configured (for whatever reason).  This is intended to
+    // be "effectively" realtime safe.  The same goes for
+    // ChannelData::setOutbufSize and setSizes.
+
+    if (m_aWindowSize != prevAWindowSize ||
+        m_sWindowSize != prevSWindowSize) {
+
+        if (m_windows.find(m_aWindowSize) == m_windows.end()) {
+            m_log.log(0, "WARNING: reconfigure(): window allocation required in realtime mode, size", m_aWindowSize);
+            m_windows[m_aWindowSize] = new Window<float>
+                (HannWindow, m_aWindowSize);
+            m_sincs[m_aWindowSize] = new SincWindow<float>
+                (m_aWindowSize, m_aWindowSize);
+        }
+
+        if (m_windows.find(m_sWindowSize) == m_windows.end()) {
+            m_log.log(0, "WARNING: reconfigure(): window allocation required in realtime mode, size", m_sWindowSize);
+            m_windows[m_sWindowSize] = new Window<float>
+                (HannWindow, m_sWindowSize);
+            m_sincs[m_sWindowSize] = new SincWindow<float>
+                (m_sWindowSize, m_sWindowSize);
+        }
+
+        m_awindow = m_windows[m_aWindowSize];
+        m_afilter = m_sincs[m_aWindowSize];
+        m_swindow = m_windows[m_sWindowSize];
+
+        for (size_t c = 0; c < m_channels; ++c) {
+            m_channelData[c]->setSizes(std::max(m_aWindowSize, m_sWindowSize),
+                                       m_fftSize);
+        }
+
+        somethingChanged = true;
+    }
+
+    if (m_outbufSize != prevOutbufSize) {
+        for (size_t c = 0; c < m_channels; ++c) {
+            m_channelData[c]->setOutbufSize(m_outbufSize);
+        }
+        somethingChanged = true;
+    }
+
+    if (m_pitchScale != 1.0) {
+        for (size_t c = 0; c < m_channels; ++c) {
+
+            if (m_channelData[c]->resampler) continue;
+
+            m_log.log(0, "WARNING: reconfigure(): resampler construction required in RT mode");
+
+            Resampler::Parameters params;
+            params.quality = Resampler::FastestTolerable;
+            params.dynamism = Resampler::RatioOftenChanging;
+            params.ratioChange = Resampler::SmoothRatioChange;
+            params.maxBufferSize = m_sWindowSize;
+            int myLevel = m_log.getDebugLevel();
+            params.debugLevel = (myLevel > 0 ? myLevel-1 : 0);
+            
+            m_channelData[c]->resampler = new Resampler(params, 1);
+
+            size_t rbs = 
+                lrintf(ceil((m_increment * m_timeRatio * 2) / m_pitchScale));
+            if (rbs < m_increment * 16) rbs = m_increment * 16;
+            m_channelData[c]->setResampleBufSize(rbs);
+
+            somethingChanged = true;
+        }
+    }
+
+    if (m_fftSize != prevFftSize) {
+        m_phaseResetAudioCurve->setFftSize(m_fftSize);
+        m_silentAudioCurve->setFftSize(m_fftSize);
+        somethingChanged = true;
+    }
+
+    if (somethingChanged) {
+        m_log.log(1, "reconfigure: at least one parameter changed");
+    } else {
+        m_log.log(1, "reconfigure: nothing changed");
+    }
+}
+
+size_t
+R2Stretcher::getPreferredStartPad() const
+{
+    if (!m_realtime) return 0;
+
+    size_t pad = m_aWindowSize / 2;
+    
+    if (resampleBeforeStretching()) {
+        return size_t(ceil(pad * m_pitchScale));
+    } else {
+        return pad;
+    }
+}
+
+size_t
+R2Stretcher::getStartDelay() const
+{
+    if (!m_realtime) return 0;
+
+    size_t pad = m_aWindowSize / 2;
+
+    if (resampleBeforeStretching()) {
+        return pad;
+    } else {
+        return size_t(ceil(pad / m_pitchScale));
+    }
+}
+
+void
+R2Stretcher::setTransientsOption(RubberBandStretcher::Options options)
+{
+    if (!m_realtime) {
+        m_log.log(0, "R2Stretcher::setTransientsOption: Not permissible in non-realtime mode");
+        return;
+    }
+    int mask = (RubberBandStretcher::OptionTransientsMixed |
+                RubberBandStretcher::OptionTransientsSmooth |
+                RubberBandStretcher::OptionTransientsCrisp);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+
+    m_stretchCalculator->setUseHardPeaks
+        (!(m_options & RubberBandStretcher::OptionTransientsSmooth));
+}
+
+void
+R2Stretcher::setDetectorOption(RubberBandStretcher::Options options)
+{
+    if (!m_realtime) {
+        m_log.log(0, "R2Stretcher::setDetectorOption: Not permissible in non-realtime mode");
+        return;
+    }
+    int mask = (RubberBandStretcher::OptionDetectorPercussive |
+                RubberBandStretcher::OptionDetectorCompound |
+                RubberBandStretcher::OptionDetectorSoft);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+
+    CompoundAudioCurve::Type dt = CompoundAudioCurve::CompoundDetector;
+    if (m_options & RubberBandStretcher::OptionDetectorPercussive) {
+        dt = CompoundAudioCurve::PercussiveDetector;
+    } else if (m_options & RubberBandStretcher::OptionDetectorSoft) {
+        dt = CompoundAudioCurve::SoftDetector;
+    }
+    
+    if (dt == m_detectorType) return;
+    m_detectorType = dt;
+
+    if (m_phaseResetAudioCurve) {
+        m_phaseResetAudioCurve->setType(m_detectorType);
+    }
+}
+
+void
+R2Stretcher::setPhaseOption(RubberBandStretcher::Options options)
+{
+    int mask = (RubberBandStretcher::OptionPhaseLaminar |
+                RubberBandStretcher::OptionPhaseIndependent);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+}
+
+void
+R2Stretcher::setFormantOption(RubberBandStretcher::Options options)
+{
+    int mask = (RubberBandStretcher::OptionFormantShifted |
+                RubberBandStretcher::OptionFormantPreserved);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+}
+
+void
+R2Stretcher::setPitchOption(RubberBandStretcher::Options options)
+{
+    if (!m_realtime) {
+        m_log.log(0, "R2Stretcher::setPitchOption: Pitch option is not used in non-RT mode");
+        return;
+    }
+
+    RubberBandStretcher::Options prior = m_options;
+
+    int mask = (RubberBandStretcher::OptionPitchHighQuality |
+                RubberBandStretcher::OptionPitchHighSpeed |
+                RubberBandStretcher::OptionPitchHighConsistency);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+
+    if (prior != m_options) reconfigure();
+}
+
+void
+R2Stretcher::study(const float *const *input, size_t samples, bool final)
+{
+    Profiler profiler("R2Stretcher::study");
+
+    if (m_realtime) {
+        m_log.log(0, "R2Stretcher::study: Not meaningful in realtime mode");
+        return;
+    }
+
+    if (m_mode == Processing || m_mode == Finished) {
+        m_log.log(0, "R2Stretcher::study: Cannot study after processing");
+        return;
+    }
+    m_mode = Studying;
+    
+    size_t consumed = 0;
+
+    ChannelData &cd = *m_channelData[0];
+    RingBuffer<float> &inbuf = *cd.inbuf;
+
+    const float *mixdown;
+    float *mdalloc = 0;
+
+    if (m_channels > 1 || final) {
+        // mix down into a single channel for analysis
+        mdalloc = new float[samples];
+        for (size_t i = 0; i < samples; ++i) {
+            if (i < samples) {
+                mdalloc[i] = input[0][i];
+            } else {
+                mdalloc[i] = 0.f;
+            }
+        }
+        for (size_t c = 1; c < m_channels; ++c) {
+            for (size_t i = 0; i < samples; ++i) {
+                mdalloc[i] += input[c][i];
+            }
+        }
+        for (size_t i = 0; i < samples; ++i) {
+            mdalloc[i] /= m_channels;
+        }
+        mixdown = mdalloc;
+    } else {
+        mixdown = input[0];
+    }
+
+    std::vector<float> optionalFoldBuffer;
+    
+    while (consumed < samples) {
+
+	size_t writable = inbuf.getWriteSpace();
+	writable = min(writable, samples - consumed);
+
+	if (writable == 0) {
+            // warn
+            m_log.log(0, "WARNING: writable == 0: consumed, samples",
+                      consumed, samples);
+	} else {
+            inbuf.write(mixdown + consumed, writable);
+            consumed += writable;
+        }
+
+	while ((inbuf.getReadSpace() >= int(m_aWindowSize)) ||
+               (final && (inbuf.getReadSpace() >= int(m_aWindowSize/2)))) {
+
+	    // We know we have at least m_aWindowSize samples
+	    // available in m_inbuf.  We need to peek m_aWindowSize of
+	    // them for processing, and then skip m_increment to
+	    // advance the read pointer.
+
+            // cd.accumulator is not otherwise used during studying,
+            // so we can use it as a temporary buffer here
+
+            size_t ready = inbuf.getReadSpace();
+            assert(final || ready >= m_aWindowSize);
+            inbuf.peek(cd.accumulator, std::min(ready, m_aWindowSize));
+
+            if (m_aWindowSize == m_fftSize) {
+
+                // We don't need the fftshift for studying, as we're
+                // only interested in magnitude.
+
+                m_awindow->cut(cd.accumulator);
+
+            } else {
+
+                // If we need to fold (i.e. if the window size is
+                // greater than the fft size so we are doing a
+                // time-aliased presum fft) or zero-pad, then we might
+                // as well use our standard function for it.  This
+                // means we retain the m_afilter cut if folding as well,
+                // which is good for consistency with real-time mode.
+                // We get fftshift as well, which we don't want, but
+                // the penalty is nominal.
+
+                // Note that we can't do this in-place.  Pity
+
+                // This doesn't have to be allocation-free, as we're
+                // in offline-mode study
+
+                optionalFoldBuffer.resize(std::max(m_fftSize, m_aWindowSize));
+
+                if (m_aWindowSize > m_fftSize) {
+                    m_afilter->cut(cd.accumulator);
+                }
+
+                cutShiftAndFold(optionalFoldBuffer.data(), m_fftSize,
+                                cd.accumulator, m_awindow);
+                v_copy(cd.accumulator, optionalFoldBuffer.data(), m_fftSize);
+            }
+
+            m_studyFFT->forwardMagnitude(cd.accumulator, cd.fltbuf);
+
+            float df = m_phaseResetAudioCurve->processFloat(cd.fltbuf, m_increment);
+            m_phaseResetDf.push_back(df);
+
+            df = m_silentAudioCurve->processFloat(cd.fltbuf, m_increment);
+            bool silent = (df > 0.f);
+            if (silent) {
+                m_log.log(2, "silence at", m_inputDuration);
+            }
+            m_silence.push_back(silent);
+
+            // We have augmented the input by m_aWindowSize/2 so that
+            // the first chunk is centred on the first audio sample.
+            // We want to ensure that m_inputDuration contains the
+            // exact input duration without including this extra bit.
+            // We just add up all the increments here, and deduct the
+            // extra afterwards.
+
+            m_inputDuration += m_increment;
+            inbuf.skip(m_increment);
+	}
+    }
+    
+    if (final) {
+        int rs = inbuf.getReadSpace();
+        m_inputDuration += rs;
+        if (m_inputDuration > m_aWindowSize/2) { // deducting the extra
+            m_inputDuration -= m_aWindowSize/2;
+        }
+    }
+
+    if (m_channels > 1 || final) delete[] mdalloc;
+}
+
+vector<int>
+R2Stretcher::getOutputIncrements() const
+{
+    if (!m_realtime) {
+        return m_outputIncrements;
+    } else {
+        vector<int> increments;
+        while (m_lastProcessOutputIncrements.getReadSpace() > 0) {
+            increments.push_back(m_lastProcessOutputIncrements.readOne());
+        }
+        return increments;
+    }
+}
+
+vector<float>
+R2Stretcher::getPhaseResetCurve() const
+{
+    if (!m_realtime) {
+        return m_phaseResetDf;
+    } else {
+        vector<float> df;
+        while (m_lastProcessPhaseResetDf.getReadSpace() > 0) {
+            df.push_back(m_lastProcessPhaseResetDf.readOne());
+        }
+        return df;
+    }
+}
+
+vector<int>
+R2Stretcher::getExactTimePoints() const
+{
+    std::vector<int> points;
+    if (!m_realtime) {
+        std::vector<StretchCalculator::Peak> peaks =
+            m_stretchCalculator->getLastCalculatedPeaks();
+        for (size_t i = 0; i < peaks.size(); ++i) {
+            points.push_back(peaks[i].chunk);
+        }
+    }
+    return points;
+}
+
+void
+R2Stretcher::calculateStretch()
+{
+    Profiler profiler("R2Stretcher::calculateStretch");
+
+    size_t inputDuration = m_inputDuration;
+
+    if (!m_realtime && m_expectedInputDuration > 0) {
+        if (m_expectedInputDuration != inputDuration) {
+            m_log.log(0, "WARNING: Actual study() duration differs from duration set by setExpectedInputDuration - using the latter for calculation", m_inputDuration, m_expectedInputDuration);
+            inputDuration = m_expectedInputDuration;
+        }
+    }
+
+    std::vector<int> increments = m_stretchCalculator->calculate
+        (getEffectiveRatio(),
+         inputDuration,
+         m_phaseResetDf);
+
+    int history = 0;
+    for (size_t i = 0; i < increments.size(); ++i) {
+        if (i >= m_silence.size()) break;
+        if (m_silence[i]) ++history;
+        else history = 0;
+        if (history >= int(m_aWindowSize / m_increment) && increments[i] >= 0) {
+            increments[i] = -increments[i];
+            m_log.log(2, "phase reset on silence: silent history", history);
+        }
+    }
+
+    if (m_outputIncrements.empty()) m_outputIncrements = increments;
+    else {
+        for (size_t i = 0; i < increments.size(); ++i) {
+            m_outputIncrements.push_back(increments[i]);
+        }
+    }
+    
+    return;
+}
+
+void
+R2Stretcher::setDebugLevel(int level)
+{
+    m_log.setDebugLevel(level);
+    if (m_stretchCalculator) {
+        m_stretchCalculator->setDebugLevel(level);
+    }
+}	
+
+size_t
+R2Stretcher::getSamplesRequired() const
+{
+    Profiler profiler("R2Stretcher::getSamplesRequired");
+
+    size_t reqd = 0;
+
+    for (size_t c = 0; c < m_channels; ++c) {
+
+        size_t reqdHere = 0;
+
+        ChannelData &cd = *m_channelData[c];
+        RingBuffer<float> &inbuf = *cd.inbuf;
+        RingBuffer<float> &outbuf = *cd.outbuf;
+
+        size_t rs = inbuf.getReadSpace();
+        size_t ws = outbuf.getReadSpace();
+
+        m_log.log(3, "getSamplesRequired: ws and rs ", ws, rs);
+
+        // We should never return zero in non-threaded modes if
+        // available() would also return zero, i.e. if ws == 0.  If we
+        // do that, nothing will ever happen again!  We need to demand
+        // at least one increment (i.e. a nominal amount) to feed the
+        // engine.
+
+        if (ws == 0 && reqd == 0) reqd = m_increment;
+
+        // See notes in testInbufReadSpace 
+
+        if (rs < m_aWindowSize && !cd.draining) {
+            
+            if (cd.inputSize == -1) {
+                reqdHere = m_aWindowSize - rs;
+                if (reqdHere > reqd) reqd = reqdHere;
+                continue;
+            }
+        
+            if (rs == 0) {
+                reqdHere = m_aWindowSize;
+                if (reqdHere > reqd) reqd = reqdHere;
+                continue;
+            }
+        }
+    }
+
+    if (resampleBeforeStretching() && m_pitchScale > 1.0) {
+        reqd = size_t(ceil(double(reqd) * m_pitchScale));
+    }
+    
+    return reqd;
+}    
+
+void
+R2Stretcher::process(const float *const *input, size_t samples, bool final)
+{
+    Profiler profiler("R2Stretcher::process");
+
+    m_log.log(3, "process entering, samples and final", samples, final);
+
+    if (m_mode == Finished) {
+        m_log.log(0, "R2Stretcher::process: Cannot process again after final chunk");
+        return;
+    }
+
+    if (m_mode == JustCreated || m_mode == Studying) {
+
+        if (m_mode == Studying) {
+
+            calculateStretch();
+
+            if (!m_realtime) {
+                // See note in configure() above. Of course, we should
+                // never enter Studying unless we are non-RT anyway
+                m_log.log(1, "offline mode: prefilling with", m_aWindowSize/2);
+                for (size_t c = 0; c < m_channels; ++c) {
+                    m_channelData[c]->reset();
+                    m_channelData[c]->inbuf->zero(m_aWindowSize/2);
+                }
+            }
+        }
+
+#ifndef NO_THREADING
+        if (m_threaded) {
+            MutexLocker locker(&m_threadSetMutex);
+
+            for (size_t c = 0; c < m_channels; ++c) {
+                ProcessThread *thread = new ProcessThread(this, c);
+                m_threadSet.insert(thread);
+                thread->start();
+            }
+
+            m_log.log(1, "created threads", m_channels);
+        }
+#endif
+        
+        m_mode = Processing;
+    }
+
+    bool allConsumed = false;
+
+    size_t *consumed = (size_t *)alloca(m_channels * sizeof(size_t));
+    for (size_t c = 0; c < m_channels; ++c) {
+        consumed[c] = 0;
+    }
+
+    while (!allConsumed) {
+
+        // In a threaded mode, our "consumed" counters only indicate
+        // the number of samples that have been taken into the input
+        // ring buffers waiting to be processed by the process thread.
+        // In non-threaded mode, "consumed" counts the number that
+        // have actually been processed.
+
+        allConsumed = true;
+
+        for (size_t c = 0; c < m_channels; ++c) {
+            consumed[c] += consumeChannel(c,
+                                          input,
+                                          consumed[c],
+                                          samples - consumed[c],
+                                          final);
+            if (c == 0) {
+                m_log.log(3, "consumed channel 0, consumed and samples now", consumed[c], samples);
+            }
+            if (consumed[c] < samples) {
+                allConsumed = false;
+            } else {
+                if (final) {
+                    if (c == 0) {
+                        m_log.log(2, "final is true, setting input size", m_channelData[c]->inCount);
+                    }
+                    m_channelData[c]->inputSize = m_channelData[c]->inCount;
+                }
+            }
+            if (
+#ifndef NO_THREADING
+                !m_threaded &&
+#endif
+                !m_realtime) {
+                bool any = false, last = false;
+                processChunks(c, any, last);
+            }
+        }
+
+        if (m_realtime) {
+            // When running in real time, we need to process both
+            // channels in step because we will need to use the sum of
+            // their frequency domain representations as the input to
+            // the realtime onset detector
+            processOneChunk();
+        }
+#ifndef NO_THREADING
+        if (m_threaded) {
+            for (ThreadSet::iterator i = m_threadSet.begin();
+                 i != m_threadSet.end(); ++i) {
+                (*i)->signalDataAvailable();
+            }
+            m_spaceAvailable.lock();
+            if (!allConsumed) {
+                m_spaceAvailable.wait(500);
+            }
+            m_spaceAvailable.unlock();
+        }
+#endif
+
+        m_log.log(3, "process looping");
+    }
+
+    m_log.log(3, "process returning");
+
+    if (final) m_mode = Finished;
+}
+
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/R2Stretcher.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/R2Stretcher.h
@@ -1,0 +1,262 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_STRETCHERIMPL_H
+#define RUBBERBAND_STRETCHERIMPL_H
+
+#include "../common/Window.h"
+#include "../common/FFT.h"
+#include "../common/RingBuffer.h"
+#include "../common/Scavenger.h"
+#include "../common/Thread.h"
+#include "../common/Log.h"
+#include "../common/sysutils.h"
+
+#include "SincWindow.h"
+#include "CompoundAudioCurve.h"
+
+#include "../../rubberband/RubberBandStretcher.h"
+
+#include <set>
+#include <algorithm>
+
+namespace RubberBand
+{
+
+class AudioCurveCalculator;
+class StretchCalculator;
+
+class R2Stretcher
+{
+public:
+    R2Stretcher(size_t sampleRate, size_t channels,
+                RubberBandStretcher::Options options,
+                double initialTimeRatio, double initialPitchScale,
+                Log log);
+    ~R2Stretcher();
+    
+    void reset();
+    void setTimeRatio(double ratio);
+    void setPitchScale(double scale);
+
+    double getTimeRatio() const;
+    double getPitchScale() const;
+
+    size_t getPreferredStartPad() const;
+    size_t getStartDelay() const;
+
+    void setTransientsOption(RubberBandStretcher::Options);
+    void setDetectorOption(RubberBandStretcher::Options);
+    void setPhaseOption(RubberBandStretcher::Options);
+    void setFormantOption(RubberBandStretcher::Options);
+    void setPitchOption(RubberBandStretcher::Options);
+
+    void setExpectedInputDuration(size_t samples);
+    void setMaxProcessSize(size_t samples);
+    size_t getProcessSizeLimit() const;
+    void setKeyFrameMap(const std::map<size_t, size_t> &);
+
+    size_t getSamplesRequired() const;
+
+    void study(const float *const *input, size_t samples, bool final);
+    void process(const float *const *input, size_t samples, bool final);
+
+    int available() const;
+    size_t retrieve(float *const *output, size_t samples) const;
+
+    float getFrequencyCutoff(int n) const;
+    void setFrequencyCutoff(int n, float f);
+
+    size_t getInputIncrement() const {
+        return m_increment;
+    }
+
+    std::vector<int> getOutputIncrements() const;
+    std::vector<float> getPhaseResetCurve() const;
+    std::vector<int> getExactTimePoints() const;
+
+    size_t getChannelCount() const {
+        return m_channels;
+    }
+    
+    void calculateStretch();
+
+    void setDebugLevel(int level);
+
+protected:
+    size_t m_sampleRate;
+    size_t m_channels;
+
+    void prepareChannelMS(size_t channel, const float *const *inputs,
+                          size_t offset, size_t samples, float *prepared);
+    size_t consumeChannel(size_t channel, const float *const *inputs,
+                          size_t offset, size_t samples, bool final);
+    void processChunks(size_t channel, bool &any, bool &last);
+    bool processOneChunk(); // across all channels, for real time use
+    bool processChunkForChannel(size_t channel, size_t phaseIncrement,
+                                size_t shiftIncrement, bool phaseReset);
+    bool testInbufReadSpace(size_t channel);
+    void calculateIncrements(size_t &phaseIncrement,
+                             size_t &shiftIncrement, bool &phaseReset);
+    bool getIncrements(size_t channel, size_t &phaseIncrement,
+                       size_t &shiftIncrement, bool &phaseReset);
+    void analyseChunk(size_t channel);
+    void modifyChunk(size_t channel, size_t outputIncrement, bool phaseReset);
+    void formantShiftChunk(size_t channel);
+    void synthesiseChunk(size_t channel, size_t shiftIncrement);
+    void writeChunk(size_t channel, size_t shiftIncrement, bool last);
+
+    void calculateSizes();
+    void configure();
+    void reconfigure();
+
+    double getEffectiveRatio() const;
+    
+    template <typename T, typename S>
+    void cutShiftAndFold(T *target, int targetSize,
+                         S *src, // destructive to src
+                         Window<float> *window) {
+        window->cut(src);
+        const int windowSize = window->getSize();
+        const int hs = targetSize / 2;
+        if (windowSize == targetSize) {
+            v_convert(target, src + hs, hs);
+            v_convert(target + hs, src, hs);
+        } else {
+            v_zero(target, targetSize);
+            int j = targetSize - windowSize/2;
+            while (j < 0) j += targetSize;
+            for (int i = 0; i < windowSize; ++i) {
+                target[j] += src[i];
+                if (++j == targetSize) j = 0;
+            }
+        }
+    }
+
+    bool resampleBeforeStretching() const;
+    
+    double m_timeRatio;
+    double m_pitchScale;
+
+    // n.b. either m_fftSize is an integer multiple of m_windowSize,
+    // or vice versa
+    size_t m_fftSize;
+    size_t m_aWindowSize; //!!! or use m_awindow->getSize() throughout?
+    size_t m_sWindowSize; //!!! or use m_swindow->getSize() throughout?
+    size_t m_increment;
+    size_t m_outbufSize;
+
+    size_t m_maxProcessSize;
+    size_t m_expectedInputDuration;
+
+#ifndef NO_THREADING    
+    bool m_threaded;
+#endif
+
+    bool m_realtime;
+    RubberBandStretcher::Options m_options;
+    Log m_log;
+
+    enum ProcessMode {
+        JustCreated,
+        Studying,
+        Processing,
+        Finished
+    };
+
+    ProcessMode m_mode;
+
+    std::map<size_t, Window<float> *> m_windows;
+    std::map<size_t, SincWindow<float> *> m_sincs;
+    Window<float> *m_awindow;
+    SincWindow<float> *m_afilter;
+    Window<float> *m_swindow;
+    FFT *m_studyFFT;
+
+#ifndef NO_THREADING
+    Condition m_spaceAvailable;
+    
+    class ProcessThread : public Thread
+    {
+    public:
+        ProcessThread(R2Stretcher *s, size_t c);
+        void run();
+        void signalDataAvailable();
+        void abandon();
+        size_t channel() { return m_channel; }
+    private:
+        R2Stretcher *m_s;
+        size_t m_channel;
+        Condition m_dataAvailable;
+        bool m_abandoning;
+    };
+
+    mutable Mutex m_threadSetMutex;
+    typedef std::set<ProcessThread *> ThreadSet;
+    ThreadSet m_threadSet;
+
+#if defined(HAVE_IPP) && !defined(NO_THREADING) && !defined(USE_BQRESAMPLER) && !defined(USE_SPEEX) && !defined(HAVE_LIBSAMPLERATE)
+    // Exasperatingly, the IPP polyphase resampler does not appear to
+    // be thread-safe as advertised -- a good reason to prefer any of
+    // the alternatives
+#define STRETCHER_IMPL_RESAMPLER_MUTEX_REQUIRED 1
+    Mutex m_resamplerMutex;
+#endif
+#endif // ! NO_THREADING
+    
+    size_t m_inputDuration;
+    CompoundAudioCurve::Type m_detectorType;
+    std::vector<float> m_phaseResetDf;
+    std::vector<bool> m_silence;
+    int m_silentHistory;
+
+    class ChannelData; 
+    std::vector<ChannelData *> m_channelData;
+
+    std::vector<int> m_outputIncrements;
+
+    mutable RingBuffer<int> m_lastProcessOutputIncrements;
+    mutable RingBuffer<float> m_lastProcessPhaseResetDf;
+    Scavenger<RingBuffer<float> > m_emergencyScavenger;
+
+    CompoundAudioCurve *m_phaseResetAudioCurve;
+    AudioCurveCalculator *m_silentAudioCurve;
+    StretchCalculator *m_stretchCalculator;
+
+    float m_freq0;
+    float m_freq1;
+    float m_freq2;
+
+    size_t m_baseFftSize;
+    float m_rateMultiple;
+
+    void writeOutput(RingBuffer<float> &to, float *from,
+                     size_t qty, size_t &outCount, size_t theoreticalOut);
+
+    static const size_t m_defaultIncrement;
+    static const size_t m_defaultFftSize;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/SilentAudioCurve.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/SilentAudioCurve.cpp
@@ -1,0 +1,73 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "SilentAudioCurve.h"
+
+#include <cmath>
+
+namespace RubberBand
+{
+
+
+SilentAudioCurve::SilentAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters)
+{
+}
+
+SilentAudioCurve::~SilentAudioCurve()
+{
+}
+
+void
+SilentAudioCurve::reset()
+{
+}
+
+float
+SilentAudioCurve::processFloat(const float *R__ mag, int)
+{
+    const int hs = m_lastPerceivedBin;
+    static float threshold = powf(10.f, -6);
+
+    for (int i = 0; i <= hs; ++i) {
+        if (mag[i] > threshold) return 0.f;
+    }
+        
+    return 1.f;
+}
+
+double
+SilentAudioCurve::processDouble(const double *R__ mag, int)
+{
+    const int hs = m_lastPerceivedBin;
+    static double threshold = pow(10.0, -6);
+
+    for (int i = 0; i <= hs; ++i) {
+        if (mag[i] > threshold) return 0.f;
+    }
+        
+    return 1.f;
+}
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/SilentAudioCurve.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/SilentAudioCurve.h
@@ -1,0 +1,46 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SILENT_AUDIO_CURVE_H
+#define RUBBERBAND_SILENT_AUDIO_CURVE_H
+
+#include "AudioCurveCalculator.h"
+
+namespace RubberBand
+{
+
+class SilentAudioCurve : public AudioCurveCalculator
+{
+public:
+    SilentAudioCurve(Parameters parameters);
+    virtual ~SilentAudioCurve();
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+    virtual void reset();
+    virtual const char *getUnit() const { return "bool"; }
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/SincWindow.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/SincWindow.h
@@ -1,0 +1,156 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SINC_WINDOW_H
+#define RUBBERBAND_SINC_WINDOW_H
+
+#include <cmath>
+#include <iostream>
+#include <cstdlib>
+#include <map>
+
+#include "../common/sysutils.h"
+#include "../common/mathmisc.h"
+#include "../common/VectorOps.h"
+#include "../common/Allocators.h"
+
+namespace RubberBand {
+
+template <typename T>
+class SincWindow
+{
+public:
+    /**
+     * Construct a sinc windower which produces a window of size n
+     * containing the values of sinc(x) with x=0 at index n/2, such
+     * that the distance from -pi to pi (the point at which the sinc
+     * function first crosses zero, for negative and positive
+     * arguments respectively) is p samples.
+     */
+    SincWindow(int n, int p) : m_size(n), m_p(p), m_cache(0) {
+        encache();
+    }
+    SincWindow(const SincWindow &w) : m_size(w.m_size), m_p(w.m_p), m_cache(0) {
+        encache();
+    }
+    SincWindow &operator=(const SincWindow &w) {
+	if (&w == this) return *this;
+	m_size = w.m_size;
+	m_p = w.m_p;
+        m_cache = 0;
+	encache();
+	return *this;
+    }
+    virtual ~SincWindow() {
+        deallocate(m_cache);
+    }
+
+    /**
+     * Regenerate the sinc window with the same size, but a new scale
+     * (the p value is interpreted as for the argument of the same
+     * name to the constructor).  If p is unchanged from the previous
+     * value, do nothing (quickly).
+     */
+    inline void rewrite(int p) {
+        if (m_p == p) return;
+        m_p = p;
+        encache();
+    }
+    
+    inline void cut(T *const R__ dst) const {
+        v_multiply(dst, m_cache, m_size);
+    }
+
+    inline void cut(const T *const R__ src, T *const R__ dst) const {
+        v_multiply(dst, src, m_cache, m_size);
+    }
+
+    inline void add(T *const R__ dst, T scale) const {
+        v_add_with_gain(dst, m_cache, scale, m_size);
+    }
+
+    inline T getArea() const { return m_area; }
+    inline T getValue(int i) const { return m_cache[i]; }
+
+    inline int getSize() const { return m_size; }
+    inline int getP() const { return m_p; }
+
+    /**
+     * Write a sinc window of size n with scale p (the p value is
+     * interpreted as for the argument of the same name to the
+     * constructor).
+     */
+    static
+    void write(T *const R__ dst, const int n, const int p) {
+        const int half = n/2;
+        writeHalf(dst, n, p);
+        int target = half - 1;
+        for (int i = half + 1; i < n; ++i) {
+            dst[target--] = dst[i];
+        }
+        const T twopi = T(2. * M_PI);
+        T arg = T(half) * twopi / p;
+        dst[0] = sin(arg) / arg;
+    }
+
+protected:
+    int m_size;
+    int m_p;
+    T *R__ m_cache;
+    T m_area;
+
+    /**
+     * Write the positive half (i.e. n/2 to n-1) of a sinc window of
+     * size n with scale p (the p value is interpreted as for the
+     * argument of the same name to the constructor). The negative
+     * half (indices 0 to n/2-1) of dst is left unchanged.
+     */
+    static
+    void writeHalf(T *const R__ dst, const int n, const int p) {
+        const int half = n/2;
+        const T twopi = T(2. * M_PI);
+        dst[half] = T(1.0);
+        for (int i = 1; i < half; ++i) {
+            T arg = T(i) * twopi / p;
+            dst[half+i] = sin(arg) / arg;
+        }
+    }
+    
+    void encache() {
+        if (!m_cache) {
+            m_cache = allocate<T>(m_size);
+        }
+
+        write(m_cache, m_size, m_p);
+	
+        m_area = 0;
+        for (int i = 0; i < m_size; ++i) {
+            m_area += m_cache[i];
+        }
+        m_area /= m_size;
+    }
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/StretcherChannelData.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/StretcherChannelData.cpp
@@ -1,0 +1,284 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "StretcherChannelData.h"
+
+#include "../common/Resampler.h"
+#include "../common/Allocators.h"
+
+#include <algorithm>
+
+namespace RubberBand 
+{
+      
+R2Stretcher::ChannelData::ChannelData(size_t windowSize,
+                                      size_t fftSize,
+                                      size_t outbufSize)
+{
+    std::set<size_t> s;
+    construct(s, windowSize, fftSize, outbufSize);
+}
+
+R2Stretcher::ChannelData::ChannelData(const std::set<size_t> &sizes,
+                                      size_t initialWindowSize,
+                                      size_t initialFftSize,
+                                      size_t outbufSize)
+{
+    construct(sizes, initialWindowSize, initialFftSize, outbufSize);
+}
+
+void
+R2Stretcher::ChannelData::construct(const std::set<size_t> &sizes,
+                                    size_t initialWindowSize,
+                                    size_t initialFftSize,
+                                    size_t outbufSize)
+{
+    size_t maxSize = initialWindowSize * 2;
+    if (initialFftSize > maxSize) maxSize = initialFftSize;
+
+    // std::set is ordered by value
+    std::set<size_t>::const_iterator i = sizes.end();
+    if (i != sizes.begin()) {
+        --i;
+        if (*i > maxSize) maxSize = *i;
+    }
+
+    // max possible size of the real "half" of freq data
+    size_t realSize = maxSize / 2 + 1;
+
+    if (outbufSize < maxSize) outbufSize = maxSize;
+
+    inbuf = new RingBuffer<float>(maxSize);
+    outbuf = new RingBuffer<float>(outbufSize);
+
+    mag = allocate_and_zero<process_t>(realSize);
+    phase = allocate_and_zero<process_t>(realSize);
+    prevPhase = allocate_and_zero<process_t>(realSize);
+    prevError = allocate_and_zero<process_t>(realSize);
+    unwrappedPhase = allocate_and_zero<process_t>(realSize);
+    envelope = allocate_and_zero<process_t>(realSize);
+
+    fltbuf = allocate_and_zero<float>(maxSize);
+    dblbuf = allocate_and_zero<process_t>(maxSize);
+
+    accumulator = allocate_and_zero<float>(maxSize);
+    windowAccumulator = allocate_and_zero<float>(maxSize);
+    ms = allocate_and_zero<float>(maxSize);
+    interpolator = allocate_and_zero<float>(maxSize);
+    interpolatorScale = 0;
+
+    unityResetLow = 16000.f;
+
+    for (i = sizes.begin(); i != sizes.end(); ++i) {
+        ffts[*i] = new FFT(*i);
+        if (sizeof(process_t) == sizeof(double)) {
+            ffts[*i]->initDouble();
+        } else {
+            ffts[*i]->initFloat();
+        }
+    }
+    fft = ffts[initialFftSize];
+
+    resampler = 0;
+    resamplebuf = 0;
+    resamplebufSize = 0;
+
+    reset();
+
+    // Avoid dividing opening sample (which will be discarded anyway) by zero
+    windowAccumulator[0] = 1.f;
+}
+
+
+void
+R2Stretcher::ChannelData::setSizes(size_t windowSize,
+                                   size_t fftSize)
+{
+    size_t maxSize = 2 * std::max(windowSize, fftSize);
+    size_t realSize = maxSize / 2 + 1;
+    size_t oldMax = inbuf->getSize();
+    size_t oldReal = oldMax / 2 + 1;
+
+    if (oldMax >= maxSize) {
+
+        // no need to reallocate buffers, just reselect fft
+
+        //!!! we can't actually do this without locking against the
+        //process thread, can we?  we need to zero the mag/phase
+        //buffers without interference
+
+        if (ffts.find(fftSize) == ffts.end()) {
+            //!!! this also requires a lock, but it shouldn't occur in
+            //RT mode with proper initialisation
+            ffts[fftSize] = new FFT(fftSize);
+            if (sizeof(process_t) == sizeof(double)) {
+                ffts[fftSize]->initDouble();
+            } else {
+                ffts[fftSize]->initFloat();
+            }
+        }
+        
+        fft = ffts[fftSize];
+
+        v_zero(fltbuf, maxSize);
+        v_zero(dblbuf, maxSize);
+
+        v_zero(mag, realSize);
+        v_zero(phase, realSize);
+        v_zero(prevPhase, realSize);
+        v_zero(prevError, realSize);
+        v_zero(unwrappedPhase, realSize);
+
+        return;
+    }
+
+    //!!! at this point we need a lock in case a different client
+    //thread is calling process() -- we need this lock even if we
+    //aren't running in threaded mode ourselves -- if we're in RT
+    //mode, then the process call should trylock and fail if the lock
+    //is unavailable (since this should never normally be the case in
+    //general use in RT mode)
+
+    RingBuffer<float> *newbuf = inbuf->resized(maxSize);
+    delete inbuf;
+    inbuf = newbuf;
+
+    // We don't want to preserve data in these arrays
+
+    mag = reallocate_and_zero(mag, oldReal, realSize);
+    phase = reallocate_and_zero(phase, oldReal, realSize);
+    prevPhase = reallocate_and_zero(prevPhase, oldReal, realSize);
+    prevError = reallocate_and_zero(prevError, oldReal, realSize);
+    unwrappedPhase = reallocate_and_zero(unwrappedPhase, oldReal, realSize);
+    envelope = reallocate_and_zero(envelope, oldReal, realSize);
+    fltbuf = reallocate_and_zero(fltbuf, oldMax, maxSize);
+    dblbuf = reallocate_and_zero(dblbuf, oldMax, maxSize);
+    ms = reallocate_and_zero(ms, oldMax, maxSize);
+    interpolator = reallocate_and_zero(interpolator, oldMax, maxSize);
+
+    // But we do want to preserve data in these
+
+    accumulator = reallocate_and_zero_extension
+        (accumulator, oldMax, maxSize);
+
+    windowAccumulator = reallocate_and_zero_extension
+        (windowAccumulator, oldMax, maxSize);
+
+    interpolatorScale = 0;
+    
+    //!!! and resampler?
+
+    if (ffts.find(fftSize) == ffts.end()) {
+        ffts[fftSize] = new FFT(fftSize);
+        if (sizeof(process_t) == sizeof(double)) {
+            ffts[fftSize]->initDouble();
+        } else {
+            ffts[fftSize]->initFloat();
+        }
+    }
+    
+    fft = ffts[fftSize];
+}
+
+void
+R2Stretcher::ChannelData::setOutbufSize(size_t outbufSize)
+{
+    size_t oldSize = outbuf->getSize();
+
+    if (oldSize < outbufSize) {
+
+        //!!! at this point we need a lock in case a different client
+        //thread is calling process()
+
+        RingBuffer<float> *newbuf = outbuf->resized(outbufSize);
+        delete outbuf;
+        outbuf = newbuf;
+    }
+}
+
+void
+R2Stretcher::ChannelData::setResampleBufSize(size_t sz)
+{
+    resamplebuf = reallocate_and_zero<float>(resamplebuf, resamplebufSize, sz);
+    resamplebufSize = sz;
+}
+
+R2Stretcher::ChannelData::~ChannelData()
+{
+    delete resampler;
+
+    deallocate(resamplebuf);
+
+    delete inbuf;
+    delete outbuf;
+
+    deallocate(mag);
+    deallocate(phase);
+    deallocate(prevPhase);
+    deallocate(prevError);
+    deallocate(unwrappedPhase);
+    deallocate(envelope);
+    deallocate(interpolator);
+    deallocate(ms);
+    deallocate(accumulator);
+    deallocate(windowAccumulator);
+    deallocate(fltbuf);
+    deallocate(dblbuf);
+
+    for (std::map<size_t, FFT *>::iterator i = ffts.begin();
+         i != ffts.end(); ++i) {
+        delete i->second;
+    }
+}
+
+void
+R2Stretcher::ChannelData::reset()
+{
+    inbuf->reset();
+    outbuf->reset();
+
+    if (resampler) resampler->reset();
+
+    size_t size = inbuf->getSize();
+
+    for (size_t i = 0; i < size; ++i) {
+        accumulator[i] = 0.f;
+        windowAccumulator[i] = 0.f;
+    }
+
+    // Avoid dividing opening sample (which will be discarded anyway) by zero
+    windowAccumulator[0] = 1.f;
+    
+    accumulatorFill = 0;
+    prevIncrement = 0;
+    chunkCount = 0;
+    inCount = 0;
+    inputSize = -1;
+    outCount = 0;
+    interpolatorScale = 0;
+    unchanged = true;
+    draining = false;
+    outputComplete = false;
+}
+
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/StretcherChannelData.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/StretcherChannelData.h
@@ -1,0 +1,148 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_STRETCHERCHANNELDATA_H
+#define RUBBERBAND_STRETCHERCHANNELDATA_H
+
+#include "R2Stretcher.h"
+
+#include <set>
+#include <atomic>
+
+namespace RubberBand
+{
+
+class Resampler;
+
+class R2Stretcher::ChannelData
+{
+public:        
+    /**
+     * Construct a ChannelData structure.
+     *
+     * The sizes passed in here are for the time-domain analysis
+     * window and FFT calculation, and most of the buffer sizes also
+     * depend on them.  In practice they are always powers of two, the
+     * window and FFT sizes are either equal or generally in a 2:1
+     * relationship either way, and except for very extreme stretches
+     * the FFT size is either 1024, 2048 or 4096.
+     *
+     * The outbuf size depends on other factors as well, including
+     * the pitch scale factor and any maximum processing block
+     * size specified by the user of the code.
+     */
+    ChannelData(size_t windowSize,
+                size_t fftSize,
+                size_t outbufSize);
+
+    /**
+     * Construct a ChannelData structure that can process at different
+     * FFT sizes without requiring reallocation when the size changes.
+     * The sizes can subsequently be changed with a call to setSizes.
+     * Reallocation will only be necessary if setSizes is called with
+     * values not equal to any of those passed in to the constructor.
+     *
+     * The outbufSize should be the maximum possible outbufSize to
+     * avoid reallocation, which will happen if setOutbufSize is
+     * called subsequently.
+     */
+    ChannelData(const std::set<size_t> &sizes,
+                size_t initialWindowSize,
+                size_t initialFftSize,
+                size_t outbufSize);
+    ~ChannelData();
+
+    /**
+     * Reset buffers
+     */
+    void reset();
+
+    /**
+     * Set the FFT, analysis window, and buffer sizes.  If this
+     * ChannelData was constructed with a set of sizes and the given
+     * window and FFT sizes here were among them, no reallocation will
+     * be required.
+     */
+    void setSizes(size_t windowSize, size_t fftSizes);
+
+    /**
+     * Set the outbufSize for the channel data.  Reallocation will
+     * occur.
+     */
+    void setOutbufSize(size_t outbufSize);
+
+    /**
+     * Set the resampler buffer size.  Default if not called is no
+     * buffer allocated at all.
+     */
+    void setResampleBufSize(size_t resamplebufSize);
+    
+    RingBuffer<float> *inbuf;
+    RingBuffer<float> *outbuf;
+
+    process_t *mag;
+    process_t *phase;
+
+    process_t *prevPhase;
+    process_t *prevError;
+    process_t *unwrappedPhase;
+
+    float *accumulator;
+    size_t accumulatorFill;
+    float *windowAccumulator;
+    float *ms; // only used when mid-side processing
+    float *interpolator; // only used when time-domain smoothing is on
+    int interpolatorScale;
+    float unityResetLow; // for gradual phase-reset on unity ratio
+
+    float *fltbuf;
+    process_t *dblbuf; // owned by FFT object, only used for time domain FFT i/o
+    process_t *envelope; // for cepstral formant shift
+    bool unchanged;
+
+    size_t prevIncrement; // only used in RT mode
+
+    size_t chunkCount;
+    size_t inCount;
+    std::atomic<int64_t> inputSize; // set only after known (when data ended); -1 previously
+    size_t outCount;
+
+    std::atomic<bool> draining;
+    std::atomic<bool> outputComplete;
+
+    FFT *fft;
+    std::map<size_t, FFT *> ffts;
+
+    Resampler *resampler;
+    float *resamplebuf;
+    size_t resamplebufSize;
+
+private:
+    void construct(const std::set<size_t> &sizes,
+                   size_t initialWindowSize, size_t initialFftSize,
+                   size_t outbufSize);
+};        
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/StretcherProcess.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/faster/StretcherProcess.cpp
@@ -1,0 +1,1304 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "R2Stretcher.h"
+#include "StretcherChannelData.h"
+
+#include "../common/StretchCalculator.h"
+#include "../common/Resampler.h"
+#include "../common/Profiler.h"
+#include "../common/VectorOps.h"
+#include "../common/sysutils.h"
+#include "../common/mathmisc.h"
+
+#include <cassert>
+#include <cmath>
+#include <set>
+#include <map>
+#include <deque>
+#include <algorithm>
+
+using namespace RubberBand;
+
+namespace RubberBand {
+
+#ifndef NO_THREADING
+
+R2Stretcher::ProcessThread::ProcessThread(R2Stretcher *s, size_t c) :
+    m_s(s),
+    m_channel(c),
+    m_dataAvailable(std::string("data ") + char('A' + c)),
+    m_abandoning(false)
+{ }
+
+void
+R2Stretcher::ProcessThread::run()
+{
+    m_s->m_log.log(2, "thread getting going for channel", m_channel);
+
+    ChannelData &cd = *m_s->m_channelData[m_channel];
+
+    while (cd.inputSize == -1 ||
+           cd.inbuf->getReadSpace() > 0) {
+
+        bool any = false, last = false;
+        m_s->processChunks(m_channel, any, last);
+
+        if (last) break;
+
+        if (any) {
+            m_s->m_spaceAvailable.lock();
+            m_s->m_spaceAvailable.signal();
+            m_s->m_spaceAvailable.unlock();
+        }
+
+        m_dataAvailable.lock();
+        if (!m_s->testInbufReadSpace(m_channel) && !m_abandoning) {
+            m_dataAvailable.wait(50000); // bounded in case of abandonment
+        }
+        m_dataAvailable.unlock();
+
+        if (m_abandoning) {
+            m_s->m_log.log(2, "thread abandoning for channel", m_channel);
+            return;
+        }
+    }
+
+    bool any = false, last = false;
+    m_s->processChunks(m_channel, any, last);
+    m_s->m_spaceAvailable.lock();
+    m_s->m_spaceAvailable.signal();
+    m_s->m_spaceAvailable.unlock();
+    
+    m_s->m_log.log(2, "thread done for channel", m_channel);
+}
+
+void
+R2Stretcher::ProcessThread::signalDataAvailable()
+{
+    m_dataAvailable.lock();
+    m_dataAvailable.signal();
+    m_dataAvailable.unlock();
+}
+
+void
+R2Stretcher::ProcessThread::abandon()
+{
+    m_abandoning = true;
+}
+
+#endif
+
+bool
+R2Stretcher::resampleBeforeStretching() const
+{
+    // We can't resample before stretching in offline mode, because
+    // the stretch calculation is based on doing it the other way
+    // around.  It would take more work (and testing) to enable this.
+    if (!m_realtime) return false;
+
+    if (m_options & RubberBandStretcher::OptionPitchHighQuality) {
+        return (m_pitchScale < 1.0); // better sound
+    } else if (m_options & RubberBandStretcher::OptionPitchHighConsistency) {
+        return false;
+    } else {
+        return (m_pitchScale > 1.0); // better performance
+    }
+}
+
+void
+R2Stretcher::prepareChannelMS(size_t c,
+                              const float *const *inputs,
+                              size_t offset,
+                              size_t samples, 
+                              float *prepared)
+{
+    for (size_t i = 0; i < samples; ++i) {
+        float left = inputs[0][i + offset];
+        float right = inputs[1][i + offset];
+        float mid = (left + right) / 2;
+        float side = (left - right) / 2;
+        if (c == 0) {
+            prepared[i] = mid;
+        } else {
+            prepared[i] = side;
+        }
+    }
+}
+    
+size_t
+R2Stretcher::consumeChannel(size_t c,
+                            const float *const *inputs,
+                            size_t offset,
+                            size_t samples,
+                            bool final)
+{
+    Profiler profiler("R2Stretcher::consumeChannel");
+
+    ChannelData &cd = *m_channelData[c];
+    RingBuffer<float> &inbuf = *cd.inbuf;
+
+    size_t toWrite = samples;
+    size_t writable = inbuf.getWriteSpace();
+
+    bool resampling = resampleBeforeStretching();
+
+    const float *input = 0;
+
+    bool useMidSide =
+        ((m_options & RubberBandStretcher::OptionChannelsTogether) &&
+         (m_channels >= 2) &&
+         (c < 2));
+
+    if (resampling) {
+
+        Profiler profiler2("R2Stretcher::resample");
+        
+        toWrite = int(ceil(samples / m_pitchScale));
+        bool shortened = false;
+        if (writable < toWrite) {
+            samples = int(floor(writable * m_pitchScale));
+            shortened = true;
+            if (samples == 0) return 0;
+        }
+
+        if (useMidSide) {
+            // Our pre-resample buffer size is also constrained by a
+            // buffer (cd.ms) of the same size as cd.inbuf
+            size_t ibsz = cd.inbuf->getSize();
+            if (ibsz < samples) {
+                samples = ibsz;
+            }
+        }
+
+        size_t reqSize = int(ceil(samples / m_pitchScale));
+        if (reqSize > cd.resamplebufSize) {
+            m_log.log(0, "WARNING: R2Stretcher::consumeChannel: resizing resampler buffer from and to", cd.resamplebufSize, reqSize);
+            cd.setResampleBufSize(reqSize);
+        }
+
+#if defined(STRETCHER_IMPL_RESAMPLER_MUTEX_REQUIRED)
+        if (m_threaded) {
+            m_resamplerMutex.lock();
+        }
+#endif
+
+        if (useMidSide) {
+            prepareChannelMS(c, inputs, offset, samples, cd.ms);
+            input = cd.ms;
+        } else {
+            input = inputs[c] + offset;
+        }
+
+        toWrite = cd.resampler->resample(&cd.resamplebuf,
+                                         cd.resamplebufSize,
+                                         &input,
+                                         samples,
+                                         1.0 / m_pitchScale,
+                                         final && !shortened);
+
+#if defined(STRETCHER_IMPL_RESAMPLER_MUTEX_REQUIRED)
+        if (m_threaded) {
+            m_resamplerMutex.unlock();
+        }
+#endif
+    }
+
+    if (writable < toWrite) {
+        if (resampling) {
+            m_log.log(1, "consumeChannel: resampler produced too much output, cannot use", toWrite, writable);
+            return 0;
+        }
+        toWrite = writable;
+    }
+
+    if (resampling) {
+
+        inbuf.write(cd.resamplebuf, toWrite);
+        cd.inCount += samples;
+
+        m_log.log(2, "consumeChannel: wrote to inbuf from resamplebuf, inCount now", toWrite, cd.inCount);
+        
+        return samples;
+
+    } else {
+
+        if (useMidSide) {
+            prepareChannelMS(c, inputs, offset, toWrite, cd.ms);
+            input = cd.ms;
+        } else {
+            input = inputs[c] + offset;
+        }
+
+        inbuf.write(input, toWrite);
+        cd.inCount += toWrite;
+
+        m_log.log(2, "consumeChannel: wrote to inbuf from input, inCount now", toWrite, cd.inCount);
+        
+        return toWrite;
+    }
+}
+
+void
+R2Stretcher::processChunks(size_t c, bool &any, bool &last)
+{
+    Profiler profiler("R2Stretcher::processChunks");
+
+    // Process as many chunks as there are available on the input
+    // buffer for channel c.  This requires that the increments have
+    // already been calculated.
+
+    // This is the normal process method in offline mode.
+
+    ChannelData &cd = *m_channelData[c];
+
+    last = false;
+    any = false;
+
+    float *tmp = 0;
+
+    while (!last) {
+
+        if (!testInbufReadSpace(c)) {
+            m_log.log(2, "processChunks: out of input");
+            break;
+        }
+
+        any = true;
+
+        if (!cd.draining) {
+            size_t ready = cd.inbuf->getReadSpace();
+            assert(ready >= m_aWindowSize || cd.inputSize >= 0);
+            cd.inbuf->peek(cd.fltbuf, std::min(ready, m_aWindowSize));
+            cd.inbuf->skip(m_increment);
+        }
+
+        bool phaseReset = false;
+        size_t phaseIncrement, shiftIncrement;
+        getIncrements(c, phaseIncrement, shiftIncrement, phaseReset);
+
+        if (shiftIncrement <= m_aWindowSize) {
+            analyseChunk(c);
+            last = processChunkForChannel
+                (c, phaseIncrement, shiftIncrement, phaseReset);
+        } else {
+            size_t bit = m_aWindowSize/4;
+            m_log.log(2, "breaking down overlong increment into chunks from and to", shiftIncrement, bit);
+            if (!tmp) tmp = allocate<float>(m_aWindowSize);
+            analyseChunk(c);
+            v_copy(tmp, cd.fltbuf, m_aWindowSize);
+            for (size_t i = 0; i < shiftIncrement; i += bit) {
+                v_copy(cd.fltbuf, tmp, m_aWindowSize);
+                size_t thisIncrement = bit;
+                if (i + thisIncrement > shiftIncrement) {
+                    thisIncrement = shiftIncrement - i;
+                }
+                last = processChunkForChannel
+                    (c, phaseIncrement + i, thisIncrement, phaseReset);
+                phaseReset = false;
+            }
+        }
+
+        cd.chunkCount++;
+        m_log.log(3, "channel/last", c, last);
+        m_log.log(3, "channel/chunkCount", c, cd.chunkCount);
+    }
+
+    if (tmp) deallocate(tmp);
+}
+
+bool
+R2Stretcher::processOneChunk()
+{
+    Profiler profiler("R2Stretcher::processOneChunk");
+
+    m_log.log(3, "R2Stretcher::processOneChunk");
+
+    // Process a single chunk for all channels, provided there is
+    // enough data on each channel for at least one chunk.  This is
+    // able to calculate increments as it goes along.
+
+    // This is the normal process method in RT mode.
+
+    for (size_t c = 0; c < m_channels; ++c) {
+        if (!testInbufReadSpace(c)) {
+            m_log.log(2, "processOneChunk: out of input");
+            return false;
+        }
+        ChannelData &cd = *m_channelData[c];
+        m_log.log(2, "read space and draining", cd.inbuf->getReadSpace(), cd.draining);
+        if (!cd.draining) {
+            size_t ready = cd.inbuf->getReadSpace();
+            assert(ready >= m_aWindowSize || cd.inputSize >= 0);
+            cd.inbuf->peek(cd.fltbuf, std::min(ready, m_aWindowSize));
+            cd.inbuf->skip(m_increment);
+            analyseChunk(c);
+        }
+    }
+    
+    bool phaseReset = false;
+    size_t phaseIncrement, shiftIncrement;
+    if (!getIncrements(0, phaseIncrement, shiftIncrement, phaseReset)) {
+        calculateIncrements(phaseIncrement, shiftIncrement, phaseReset);
+    }
+
+    bool last = false;
+    for (size_t c = 0; c < m_channels; ++c) {
+        last = processChunkForChannel(c, phaseIncrement, shiftIncrement, phaseReset);
+        m_channelData[c]->chunkCount++;
+    }
+
+    m_log.log(3, "R2Stretcher::processOneChunk returning", last);
+    return last;
+}
+
+bool
+R2Stretcher::testInbufReadSpace(size_t c)
+{
+    Profiler profiler("R2Stretcher::testInbufReadSpace");
+
+    ChannelData &cd = *m_channelData[c];
+    RingBuffer<float> &inbuf = *cd.inbuf;
+
+    size_t rs = inbuf.getReadSpace();
+
+    if (rs < m_aWindowSize && !cd.draining) {
+            
+        if (cd.inputSize == -1) {
+
+            // Not all the input data has been written to the inbuf
+            // (that's why the input size is not yet set).  We can't
+            // process, because we don't have a full chunk of data, so
+            // our process chunk would contain some empty padding in
+            // its input -- and that would give incorrect output, as
+            // we know there is more input to come.
+
+#ifndef NO_THREADING
+            if (!m_threaded) {
+#endif
+                m_log.log(2, "Note: read space < chunk size when not all input written", inbuf.getReadSpace(), m_aWindowSize);
+
+#ifndef NO_THREADING
+            }
+#endif
+            return false;
+        }
+        
+        if (rs == 0) {
+            m_log.log(2, "read space = 0, giving up");
+            return false;
+        } else if (rs < m_aWindowSize/2) {
+            m_log.log(2, "setting draining true with read space and window size", rs, m_aWindowSize);
+            m_log.log(2, "outbuf read space is", cd.outbuf->getReadSpace());
+            m_log.log(2, "accumulator fill is", cd.accumulatorFill);
+            cd.draining = true;
+        }
+    }
+
+    return true;
+}
+
+bool 
+R2Stretcher::processChunkForChannel(size_t c,
+                                    size_t phaseIncrement,
+                                    size_t shiftIncrement,
+                                    bool phaseReset)
+{
+    Profiler profiler("R2Stretcher::processChunkForChannel");
+
+    // Process a single chunk on a single channel.  This assumes
+    // enough input data is available; caller must have tested this
+    // using e.g. testInbufReadSpace first.  Return true if this is
+    // the last chunk on the channel.
+
+    if (phaseReset) {
+        m_log.log(2, "processChunkForChannel: phase reset found, increments",
+                  phaseIncrement, shiftIncrement);
+    }
+
+    ChannelData &cd = *m_channelData[c];
+
+    if (!cd.draining) {
+        
+        // This is the normal processing case -- draining is only
+        // set when all the input has been used and we only need
+        // to write from the existing accumulator into the output.
+        
+        // We know we have enough samples available in m_inbuf --
+        // this is usually m_aWindowSize, but we know that if fewer
+        // are available, it's OK to use zeroes for the rest
+        // (which the ring buffer will provide) because we've
+        // reached the true end of the data.
+        
+        // We need to peek m_aWindowSize samples for processing, and
+        // then skip m_increment to advance the read pointer.
+
+        modifyChunk(c, phaseIncrement, phaseReset);
+        synthesiseChunk(c, shiftIncrement); // reads from cd.mag, cd.phase
+
+        if (m_log.getDebugLevel() > 2) {
+            if (phaseReset) {
+                for (int i = 0; i < 10; ++i) {
+                    cd.accumulator[i] = 1.2f - (i % 3) * 1.2f;
+                }
+            }
+        }
+    }
+
+    bool last = false;
+
+    if (cd.draining) {
+        m_log.log(2, "draining: accumulator fill and shift increment", cd.accumulatorFill, shiftIncrement);
+        m_log.log(2, "outbuf read space is", cd.outbuf->getReadSpace());
+        if (cd.accumulatorFill == 0) {
+            m_log.log(2, "draining: accumulator empty");
+            return true;
+        }
+        if (shiftIncrement == 0) {
+            m_log.log(0, "WARNING: draining: shiftIncrement == 0, can't handle that in this context: setting to", m_increment);
+            shiftIncrement = m_increment;
+        }
+        if (cd.accumulatorFill <= shiftIncrement) {
+            m_log.log(2, "draining: marking as last and reducing shift increment from and to", shiftIncrement, cd.accumulatorFill);
+            shiftIncrement = cd.accumulatorFill;
+            last = true;
+        }
+    }
+        
+    int required = shiftIncrement;
+
+    if (m_pitchScale != 1.0) {
+        required = int(required / m_pitchScale) + 1;
+    }
+
+    int ws = cd.outbuf->getWriteSpace();
+    if (ws < required) {
+        m_log.log(1, "Buffer overrun on output for channel", c);
+
+        // The only correct thing we can do here is resize the buffer.
+        // We can't wait for the client thread to read some data out
+        // from the buffer so as to make more space, because the
+        // client thread (if we are threaded at all) is probably stuck
+        // in a process() call waiting for us to stow away enough
+        // input increments to allow the process() call to complete.
+        // This is an unhappy situation.
+
+        RingBuffer<float> *oldbuf = cd.outbuf;
+        cd.outbuf = oldbuf->resized(oldbuf->getSize() * 2);
+
+        m_log.log(2, "write space and space needed", ws, required);
+        m_log.log(2, "resized output buffer from and to", oldbuf->getSize(),
+                  cd.outbuf->getSize());
+        
+        m_emergencyScavenger.claim(oldbuf);
+    }
+
+    writeChunk(c, shiftIncrement, last);
+    m_log.log(3, "processChunkForChannel: accumulatorFill now; returning", cd.accumulatorFill, last);
+    return last;
+}
+
+void
+R2Stretcher::calculateIncrements(size_t &phaseIncrementRtn,
+                                 size_t &shiftIncrementRtn,
+                                 bool &phaseReset)
+{
+    Profiler profiler("R2Stretcher::calculateIncrements");
+
+    // Calculate the next upcoming phase and shift increment, on the
+    // basis that both channels are in sync.  This is in contrast to
+    // getIncrements, which requires that all the increments have been
+    // calculated in advance but can then return increments
+    // corresponding to different chunks in different channels.
+
+    // Requires frequency domain representations of channel data in
+    // the mag and phase buffers in the channel.
+
+    // This function is only used in real-time mode.
+
+    phaseIncrementRtn = m_increment;
+    shiftIncrementRtn = m_increment;
+    phaseReset = false;
+
+    if (m_channels == 0) return;
+
+    ChannelData &cd = *m_channelData[0];
+
+    size_t bc = cd.chunkCount;
+    for (size_t c = 1; c < m_channels; ++c) {
+        if (m_channelData[c]->chunkCount != bc) {
+            m_log.log(0, "ERROR: R2Stretcher::calculateIncrements: Channels are not in sync");
+            return;
+        }
+    }
+
+    const int hs = m_fftSize/2 + 1;
+
+    // Normally we would mix down the time-domain signal and apply a
+    // single FFT, or else mix down the Cartesian form of the
+    // frequency-domain signal.  Both of those would be inefficient
+    // from this position.  Fortunately, the onset detectors should
+    // work reasonably well (maybe even better?) if we just sum the
+    // magnitudes of the frequency-domain channel signals and forget
+    // about phase entirely.  Normally we don't expect the channel
+    // phases to cancel each other, and broadband effects will still
+    // be apparent.
+
+    float df = 0.f;
+    bool silent = false;
+
+    if (m_channels == 1) {
+
+        if (sizeof(process_t) == sizeof(double)) {
+            df = m_phaseResetAudioCurve->processDouble((double *)cd.mag, m_increment);
+            silent = (m_silentAudioCurve->processDouble((double *)cd.mag, m_increment) > 0.f);
+        } else {
+            df = m_phaseResetAudioCurve->processFloat((float *)cd.mag, m_increment);
+            silent = (m_silentAudioCurve->processFloat((float *)cd.mag, m_increment) > 0.f);
+        }
+
+    } else {
+
+        process_t *tmp = (process_t *)alloca(hs * sizeof(process_t));
+
+        v_zero(tmp, hs);
+        for (size_t c = 0; c < m_channels; ++c) {
+            v_add(tmp, m_channelData[c]->mag, hs);
+        }
+
+        if (sizeof(process_t) == sizeof(double)) {
+            df = m_phaseResetAudioCurve->processDouble((double *)tmp, m_increment);
+            silent = (m_silentAudioCurve->processDouble((double *)tmp, m_increment) > 0.f);
+        } else {
+            df = m_phaseResetAudioCurve->processFloat((float *)tmp, m_increment);
+            silent = (m_silentAudioCurve->processFloat((float *)tmp, m_increment) > 0.f);
+        }
+    }
+
+    double effectivePitchRatio = 1.0 / m_pitchScale;
+    if (cd.resampler) {
+        effectivePitchRatio = cd.resampler->getEffectiveRatio(effectivePitchRatio);
+    }
+    
+    int incr = m_stretchCalculator->calculateSingle
+        (m_timeRatio, effectivePitchRatio, df, m_increment,
+         m_aWindowSize, m_sWindowSize, false);
+
+    if (m_lastProcessPhaseResetDf.getWriteSpace() > 0) {
+        m_lastProcessPhaseResetDf.write(&df, 1);
+    }
+    if (m_lastProcessOutputIncrements.getWriteSpace() > 0) {
+        m_lastProcessOutputIncrements.write(&incr, 1);
+    }
+
+    if (incr < 0) {
+        phaseReset = true;
+        incr = -incr;
+    }
+    
+    // The returned increment is the phase increment.  The shift
+    // increment for one chunk is the same as the phase increment for
+    // the following chunk (see comment below).  This means we don't
+    // actually know the shift increment until we see the following
+    // phase increment... which is a bit of a problem.
+
+    // This implies we should use this increment for the shift
+    // increment, and make the following phase increment the same as
+    // it.  This means in RT mode we'll be one chunk later with our
+    // phase reset than we would be in non-RT mode.  The sensitivity
+    // of the broadband onset detector may mean that this isn't a
+    // problem -- test it and see.
+
+    shiftIncrementRtn = incr;
+
+    if (cd.prevIncrement == 0) {
+        phaseIncrementRtn = shiftIncrementRtn;
+    } else {
+        phaseIncrementRtn = cd.prevIncrement;
+    }
+
+    cd.prevIncrement = shiftIncrementRtn;
+
+    if (silent) ++m_silentHistory;
+    else m_silentHistory = 0;
+
+    if (m_silentHistory >= int(m_aWindowSize / m_increment) && !phaseReset) {
+        phaseReset = true;
+        m_log.log(2, "calculateIncrements: phase reset on silence: silent history", m_silentHistory);
+    }
+}
+
+bool
+R2Stretcher::getIncrements(size_t channel,
+                           size_t &phaseIncrementRtn,
+                           size_t &shiftIncrementRtn,
+                           bool &phaseReset)
+{
+    Profiler profiler("R2Stretcher::getIncrements");
+
+    if (channel >= m_channels) {
+        phaseIncrementRtn = m_increment;
+        shiftIncrementRtn = m_increment;
+        phaseReset = false;
+        return false;
+    }
+
+    // There are two relevant output increments here.  The first is
+    // the phase increment which we use when recalculating the phases
+    // for the current chunk; the second is the shift increment used
+    // to determine how far to shift the processing buffer after
+    // writing the chunk.  The shift increment for one chunk is the
+    // same as the phase increment for the following chunk.
+    
+    // When an onset occurs for which we need to reset phases, the
+    // increment given will be negative.
+    
+    // When we reset phases, the previous shift increment (and so
+    // current phase increments) must have been m_increment to ensure
+    // consistency.
+    
+    // m_outputIncrements stores phase increments.
+
+    ChannelData &cd = *m_channelData[channel];
+    bool gotData = true;
+
+    if (cd.chunkCount >= m_outputIncrements.size()) {
+        if (m_outputIncrements.size() == 0) {
+            phaseIncrementRtn = m_increment;
+            shiftIncrementRtn = m_increment;
+            phaseReset = false;
+            return false;
+        } else {
+            cd.chunkCount = m_outputIncrements.size()-1;
+            gotData = false;
+        }
+    }
+    
+    int phaseIncrement = m_outputIncrements[cd.chunkCount];
+    
+    int shiftIncrement = phaseIncrement;
+    if (cd.chunkCount + 1 < m_outputIncrements.size()) {
+        shiftIncrement = m_outputIncrements[cd.chunkCount + 1];
+    }
+    
+    if (phaseIncrement < 0) {
+        phaseIncrement = -phaseIncrement;
+        phaseReset = true;
+    }
+    
+    if (shiftIncrement < 0) {
+        shiftIncrement = -shiftIncrement;
+    }
+
+    if (shiftIncrement >= int(m_aWindowSize)) {
+        m_log.log(1, "WARNING: shiftIncrement >= analysis window size", shiftIncrement, m_aWindowSize);
+        m_log.log(1, "at chunk of total", cd.chunkCount, m_outputIncrements.size());
+    }
+
+    phaseIncrementRtn = phaseIncrement;
+    shiftIncrementRtn = shiftIncrement;
+    if (cd.chunkCount == 0) phaseReset = true; // don't mess with the first chunk
+    return gotData;
+}
+
+void
+R2Stretcher::analyseChunk(size_t channel)
+{
+    Profiler profiler("R2Stretcher::analyseChunk");
+
+    ChannelData &cd = *m_channelData[channel];
+
+    process_t *const R__ dblbuf = cd.dblbuf;
+    float *const R__ fltbuf = cd.fltbuf;
+
+    // cd.fltbuf is known to contain m_aWindowSize samples
+
+    if (m_aWindowSize > m_fftSize) {
+        m_afilter->cut(fltbuf);
+    }
+
+    cutShiftAndFold(dblbuf, m_fftSize, fltbuf, m_awindow);
+
+    cd.fft->forwardPolar(dblbuf, cd.mag, cd.phase);
+}
+
+void
+R2Stretcher::modifyChunk(size_t channel,
+                         size_t outputIncrement,
+                         bool phaseReset)
+{
+    Profiler profiler("R2Stretcher::modifyChunk");
+
+    ChannelData &cd = *m_channelData[channel];
+
+    if (phaseReset) {
+        m_log.log(2, "phase reset: leaving phases unmodified");
+    }
+
+    const process_t rate = process_t(m_sampleRate);
+    const int count = m_fftSize / 2;
+
+    bool unchanged = cd.unchanged && (outputIncrement == m_increment);
+    bool fullReset = phaseReset;
+    bool laminar = !(m_options & RubberBandStretcher::OptionPhaseIndependent);
+    bool bandlimited = (m_options & RubberBandStretcher::OptionTransientsMixed);
+    int bandlow = lrint((150 * m_fftSize) / rate);
+    int bandhigh = lrint((1000 * m_fftSize) / rate);
+
+    float r = getEffectiveRatio();
+
+    bool unity = (fabsf(r - 1.f) < 1.e-6f);
+    if (unity) {
+        if (!phaseReset) {
+            phaseReset = true;
+            bandlimited = true;
+            bandlow = lrint((cd.unityResetLow * m_fftSize) / rate);
+            bandhigh = count;
+            if (bandlow > 0) {
+                m_log.log(2, "unity: bandlow & high", bandlow, bandhigh);
+            }
+        }
+        cd.unityResetLow *= 0.9f;
+    } else {
+        cd.unityResetLow = 16000.f;
+    }
+
+    float freq0 = m_freq0;
+    float freq1 = m_freq1;
+    float freq2 = m_freq2;
+    
+    if (laminar) {
+        if (r > 1) {
+            float rf0 = 600 + (600 * ((r-1)*(r-1)*(r-1)*2));
+            float f1ratio = freq1 / freq0;
+            float f2ratio = freq2 / freq0;
+            freq0 = std::max(freq0, rf0);
+            freq1 = freq0 * f1ratio;
+            freq2 = freq0 * f2ratio;
+        }
+    }
+
+    int limit0 = lrint((freq0 * m_fftSize) / rate);
+    int limit1 = lrint((freq1 * m_fftSize) / rate);
+    int limit2 = lrint((freq2 * m_fftSize) / rate);
+
+    if (limit1 < limit0) limit1 = limit0;
+    if (limit2 < limit1) limit2 = limit1;
+    
+    process_t prevInstability = 0.0;
+    bool prevDirection = false;
+
+    process_t distance = 0.0;
+    const process_t maxdist = 8.0;
+
+    const int lookback = 1;
+
+    process_t distacc = 0.0;
+
+    for (int i = count; i >= 0; i -= lookback) {
+
+        bool resetThis = phaseReset;
+
+        if (bandlimited) {
+            if (resetThis) {
+                if (i > bandlow && i < bandhigh) {
+                    resetThis = false;
+                    fullReset = false;
+                }
+            }
+        }
+
+        process_t p = cd.phase[i];
+        process_t perr = 0.0;
+        process_t outphase = p;
+
+        process_t mi = maxdist;
+        if (i <= limit0) mi = 0.0;
+        else if (i <= limit1) mi = 1.0;
+        else if (i <= limit2) mi = 3.0;
+
+        if (!resetThis) {
+
+            process_t omega = (2 * M_PI * m_increment * i) / (m_fftSize);
+
+            process_t pp = cd.prevPhase[i];
+            process_t ep = pp + omega;
+            perr = princarg(p - ep);
+
+            process_t instability = fabs(perr - cd.prevError[i]);
+            bool direction = (perr > cd.prevError[i]);
+
+            bool inherit = false;
+
+            if (laminar) {
+                if (distance >= mi || i == count) {
+                    inherit = false;
+                } else if (bandlimited && (i == bandhigh || i == bandlow)) {
+                    inherit = false;
+                } else if (instability > prevInstability &&
+                           direction == prevDirection) {
+                    inherit = true;
+                }
+            }
+
+            process_t advance = outputIncrement * ((omega + perr) / m_increment);
+
+            if (inherit) {
+                process_t inherited =
+                    cd.unwrappedPhase[i + lookback] - cd.prevPhase[i + lookback];
+                advance = ((advance * distance) +
+                           (inherited * (maxdist - distance)))
+                    / maxdist;
+                outphase = p + advance;
+                distacc += distance;
+                distance += 1.0;
+            } else {
+                outphase = cd.unwrappedPhase[i] + advance;
+                distance = 0.0;
+            }
+
+            prevInstability = instability;
+            prevDirection = direction;
+
+        } else {
+            distance = 0.0;
+        }
+
+        cd.prevError[i] = perr;
+        cd.prevPhase[i] = p;
+        cd.phase[i] = outphase;
+        cd.unwrappedPhase[i] = outphase;
+    }
+
+    m_log.log(3, "mean inheritance distance", distacc / count);
+
+    if (fullReset) unchanged = true;
+    cd.unchanged = unchanged;
+
+    if (unchanged) {
+        m_log.log(2, "frame unchanged on channel", channel);
+    }
+}    
+
+
+void
+R2Stretcher::formantShiftChunk(size_t channel)
+{
+    Profiler profiler("R2Stretcher::formantShiftChunk");
+
+    ChannelData &cd = *m_channelData[channel];
+
+    process_t *const R__ mag = cd.mag;
+    process_t *const R__ envelope = cd.envelope;
+    process_t *const R__ dblbuf = cd.dblbuf;
+
+    const int sz = m_fftSize;
+    const int hs = sz / 2;
+    const process_t factor = 1.0 / sz;
+
+    cd.fft->inverseCepstral(mag, dblbuf);
+
+    const int cutoff = m_sampleRate / 700;
+
+    dblbuf[0] /= 2;
+    dblbuf[cutoff-1] /= 2;
+
+    for (int i = cutoff; i < sz; ++i) {
+        dblbuf[i] = 0.0;
+    }
+
+    v_scale(dblbuf, factor, cutoff);
+
+    process_t *spare = (process_t *)alloca((hs + 1) * sizeof(process_t));
+    cd.fft->forward(dblbuf, envelope, spare);
+
+    v_exp(envelope, hs + 1);
+    v_divide(mag, envelope, hs + 1);
+
+    if (m_pitchScale > 1.0) {
+        // scaling up, we want a new envelope that is lower by the pitch factor
+        for (int target = 0; target <= hs; ++target) {
+            int source = lrint(target * m_pitchScale);
+            if (source > hs) {
+                envelope[target] = 0.0;
+            } else {
+                envelope[target] = envelope[source];
+            }
+        }
+    } else {
+        // scaling down, we want a new envelope that is higher by the pitch factor
+        for (int target = hs; target > 0; ) {
+            --target;
+            int source = lrint(target * m_pitchScale);
+            envelope[target] = envelope[source];
+        }
+    }
+
+    v_multiply(mag, envelope, hs+1);
+
+    cd.unchanged = false;
+}
+
+void
+R2Stretcher::synthesiseChunk(size_t channel,
+                             size_t shiftIncrement)
+{
+    Profiler profiler("R2Stretcher::synthesiseChunk");
+
+    if ((m_options & RubberBandStretcher::OptionFormantPreserved) &&
+        (m_pitchScale != 1.0)) {
+        formantShiftChunk(channel);
+    }
+
+    ChannelData &cd = *m_channelData[channel];
+
+    process_t *const R__ dblbuf = cd.dblbuf;
+    float *const R__ fltbuf = cd.fltbuf;
+    float *const R__ accumulator = cd.accumulator;
+    float *const R__ windowAccumulator = cd.windowAccumulator;
+    
+    const int fsz = m_fftSize;
+    const int hs = fsz / 2;
+
+    const int wsz = m_sWindowSize;
+
+    if (!cd.unchanged) {
+
+        // Our FFTs produced unscaled results. Scale before inverse
+        // transform rather than after, to avoid overflow if using a
+        // fixed-point FFT.
+        float factor = 1.f / fsz;
+        v_scale(cd.mag, factor, hs + 1);
+
+        cd.fft->inversePolar(cd.mag, cd.phase, cd.dblbuf);
+
+        if (wsz == fsz) {
+            v_convert(fltbuf, dblbuf + hs, hs);
+            v_convert(fltbuf + hs, dblbuf, hs);
+        } else {
+            v_zero(fltbuf, wsz);
+            int j = fsz - wsz/2;
+            while (j < 0) j += fsz;
+            for (int i = 0; i < wsz; ++i) {
+                fltbuf[i] += dblbuf[j];
+                if (++j == fsz) j = 0;
+            }
+        }
+    }
+
+    if (wsz > fsz) {
+        int p = shiftIncrement * 2;
+        if (cd.interpolatorScale != p) {
+            SincWindow<float>::write(cd.interpolator, wsz, p);
+            cd.interpolatorScale = p;
+        }
+        v_multiply(fltbuf, cd.interpolator, wsz);
+    }
+
+    m_swindow->cut(fltbuf);
+    v_add(accumulator, fltbuf, wsz);
+    cd.accumulatorFill = std::max(cd.accumulatorFill, size_t(wsz));
+
+    if (wsz > fsz) {
+        // reuse fltbuf to calculate interpolating window shape for
+        // window accumulator
+        v_copy(fltbuf, cd.interpolator, wsz);
+        m_swindow->cut(fltbuf);
+        v_add(windowAccumulator, fltbuf, wsz);
+    } else {
+        m_swindow->add(windowAccumulator, m_awindow->getArea() * 1.5f);
+    }
+}
+
+void
+R2Stretcher::writeChunk(size_t channel, size_t shiftIncrement, bool last)
+{
+    Profiler profiler("R2Stretcher::writeChunk");
+
+    ChannelData &cd = *m_channelData[channel];
+    
+    float *const R__ accumulator = cd.accumulator;
+    float *const R__ windowAccumulator = cd.windowAccumulator;
+
+    const int sz = cd.accumulatorFill;
+    const int si = shiftIncrement;
+
+    m_log.log(3, "writeChunk: channel and shiftIncrement",
+              channel, shiftIncrement);
+    if (last) {
+        m_log.log(3, "writeChunk: last true");
+    }
+
+    v_divide(accumulator, windowAccumulator, si);
+
+    // for exact sample scaling (probably not meaningful if we
+    // were running in RT mode)
+    size_t theoreticalOut = 0;
+    if (cd.inputSize >= 0) {
+        theoreticalOut = lrint(cd.inputSize * m_timeRatio);
+    }
+
+    bool resampledAlready = resampleBeforeStretching();
+
+    if (!resampledAlready &&
+        (m_pitchScale != 1.0 ||
+         (m_options & RubberBandStretcher::OptionPitchHighConsistency)) &&
+        cd.resampler) {
+
+        Profiler profiler2("R2Stretcher::resample");
+
+        size_t reqSize = int(ceil(si / m_pitchScale));
+        if (reqSize > cd.resamplebufSize) {
+            // This shouldn't normally happen -- the buffer is
+            // supposed to be initialised with enough space in the
+            // first place.  But we retain this check in case the
+            // pitch scale has changed since then, or the stretch
+            // calculator has gone mad, or something.
+            m_log.log(0, "WARNING: R2Stretcher::writeChunk: resizing resampler buffer from and to", cd.resamplebufSize, reqSize);
+            cd.setResampleBufSize(reqSize);
+        }
+
+#if defined(STRETCHER_IMPL_RESAMPLER_MUTEX_REQUIRED)
+        if (m_threaded) {
+            m_resamplerMutex.lock();
+        }
+#endif
+
+        size_t outframes = cd.resampler->resample(&cd.resamplebuf,
+                                                  cd.resamplebufSize,
+                                                  &cd.accumulator,
+                                                  si,
+                                                  1.0 / m_pitchScale,
+                                                  last);
+        
+#if defined(STRETCHER_IMPL_RESAMPLER_MUTEX_REQUIRED)
+        if (m_threaded) {
+            m_resamplerMutex.unlock();
+        }
+#endif
+
+        writeOutput(*cd.outbuf, cd.resamplebuf,
+                    outframes, cd.outCount, theoreticalOut);
+
+    } else {
+        writeOutput(*cd.outbuf, accumulator,
+                    si, cd.outCount, theoreticalOut);
+    }
+
+    v_move(accumulator, accumulator + si, sz - si);
+    v_zero(accumulator + sz - si, si);
+    
+    v_move(windowAccumulator, windowAccumulator + si, sz - si);
+    v_zero(windowAccumulator + sz - si, si);
+    
+    if (int(cd.accumulatorFill) > si) {
+        cd.accumulatorFill -= si;
+    } else {
+        cd.accumulatorFill = 0;
+        if (cd.draining) {
+            m_log.log(2, "writeChunk: setting outputComplete to true");
+            cd.outputComplete = true;
+        }
+    }
+
+    m_log.log(3, "writeChunk: accumulatorFill now", cd.accumulatorFill);
+}
+
+void
+R2Stretcher::writeOutput(RingBuffer<float> &to,
+                         float *from, size_t qty,
+                         size_t &outCount, size_t theoreticalOut)
+{
+    Profiler profiler("R2Stretcher::writeOutput");
+
+    // In non-RT mode, we don't want to write the first startSkip
+    // samples, because the first chunk is centred on the start of the
+    // output.  In RT mode we didn't apply any pre-padding in
+    // configure(), so we don't want to remove any here.
+
+    size_t startSkip = 0;
+    if (!m_realtime) {
+        startSkip = lrintf((m_sWindowSize/2) / m_pitchScale);
+    }
+
+    if (outCount > startSkip) {
+        
+        // this is the normal case
+
+        if (theoreticalOut > 0) {
+            m_log.log(2, "theoreticalOut and outCount",
+                      theoreticalOut, outCount);
+            m_log.log(2, "startSkip and qty",
+                      startSkip, qty);
+            if (outCount - startSkip <= theoreticalOut &&
+                outCount - startSkip + qty > theoreticalOut) {
+                qty = theoreticalOut - (outCount - startSkip);
+                m_log.log(2, "reducing qty to", qty);
+            }
+        }
+
+        m_log.log(3, "writing", qty);
+
+        size_t written = to.write(from, qty);
+
+        if (written < qty) {
+            m_log.log(0, "WARNING: writeOutput: buffer overrun: wanted to write and able to write", qty, written);
+        }
+
+        outCount += written;
+
+        m_log.log(3, "written and new outCount", written, outCount);
+        return;
+    }
+
+    // the rest of this is only used during the first startSkip samples
+
+    if (outCount + qty <= startSkip) {
+        m_log.log(2, "discarding with startSkip", startSkip);
+        m_log.log(2, "qty and outCount", qty, outCount);
+        outCount += qty;
+        return;
+    }
+
+    size_t off = startSkip - outCount;
+    m_log.log(2, "shortening with startSkip", startSkip);
+    m_log.log(2, "qty and outCount", qty, outCount);
+    m_log.log(2, "start offset and number written", off, qty - off);
+    to.write(from + off, qty - off);
+    outCount += qty;
+}
+
+int
+R2Stretcher::available() const
+{
+    Profiler profiler("R2Stretcher::available");
+
+    m_log.log(3, "R2Stretcher::available");
+    
+#ifndef NO_THREADING
+    if (m_threaded) {
+        MutexLocker locker(&m_threadSetMutex);
+        if (m_channelData.empty()) return 0;
+    } else {
+        if (m_channelData.empty()) return 0;
+    }
+#endif
+
+#ifndef NO_THREADING
+    if (!m_threaded) {
+#endif
+        if (m_channelData[0]->inputSize >= 0) {
+            //!!! do we ever actually do this? if so, this method should not be const
+            // ^^^ yes, we do sometimes -- e.g. when fed a very short file
+            if (m_realtime) {
+                while (m_channelData[0]->inbuf->getReadSpace() > 0 ||
+                       m_channelData[0]->draining) {
+                    m_log.log(2, "calling processOneChunk from available");
+                    if (((R2Stretcher *)this)->processOneChunk()) {
+                        break;
+                    }
+                }
+            } else {
+                for (size_t c = 0; c < m_channels; ++c) {
+                    if (m_channelData[c]->inbuf->getReadSpace() > 0) {
+                        m_log.log(2, "calling processChunks from available, channel" , c);
+                        bool any = false, last = false;
+                        ((R2Stretcher *)this)->processChunks(c, any, last);
+                    }
+                }
+            }
+        }
+#ifndef NO_THREADING
+    }
+#endif
+
+    size_t min = 0;
+    bool consumed = true;
+    bool haveResamplers = false;
+
+    for (size_t i = 0; i < m_channels; ++i) {
+        size_t availIn = m_channelData[i]->inbuf->getReadSpace();
+        size_t availOut = m_channelData[i]->outbuf->getReadSpace();
+        m_log.log(3, "available in and out", availIn, availOut);
+        if (i == 0 || availOut < min) min = availOut;
+        if (!m_channelData[i]->outputComplete) consumed = false;
+        if (m_channelData[i]->resampler) haveResamplers = true;
+    }
+
+    if (min == 0 && consumed) {
+        m_log.log(2, "R2Stretcher::available: end of stream");
+        return -1;
+    }
+    if (m_pitchScale == 1.0) {
+        m_log.log(3, "R2Stretcher::available (not shifting): returning", min);
+        return min;
+    }
+
+    int rv;
+    if (haveResamplers) {
+        rv = min; // resampling has already happened
+    } else {
+        rv = int(floor(min / m_pitchScale));
+    }
+    m_log.log(3, "R2Stretcher::available (shifting): returning", rv);
+    return rv;
+}
+
+size_t
+R2Stretcher::retrieve(float *const *output, size_t samples) const
+{
+    Profiler profiler("R2Stretcher::retrieve");
+
+    m_log.log(3, "R2Stretcher::retrieve", samples);
+    
+    size_t got = samples;
+
+    for (size_t c = 0; c < m_channels; ++c) {
+        size_t gotHere = m_channelData[c]->outbuf->read(output[c], got);
+        if (gotHere < got) {
+            if (c > 0) {
+                m_log.log(0, "R2Stretcher::retrieve: WARNING: channel imbalance detected");
+            }
+            got = gotHere;
+        }
+    }
+
+    if ((m_options & RubberBandStretcher::OptionChannelsTogether) &&
+        (m_channels >= 2)) {
+        for (size_t i = 0; i < got; ++i) {
+            float mid = output[0][i];
+            float side = output[1][i];
+            float left = mid + side;
+            float right = mid - side;
+            output[0][i] = left;
+            output[1][i] = right;
+        }
+    }            
+
+    m_log.log(3, "R2Stretcher::retrieve returning", got);
+    
+    return got;
+}
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/BinClassifier.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/BinClassifier.h
@@ -1,0 +1,163 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_BIN_CLASSIFIER_H
+#define RUBBERBAND_BIN_CLASSIFIER_H
+
+#include "../common/Allocators.h"
+#include "../common/MovingMedian.h"
+#include "../common/RingBuffer.h"
+#include "../common/Profiler.h"
+
+#include <vector>
+#include <memory>
+
+namespace RubberBand {
+
+class BinClassifier
+{
+public:
+    enum class Classification {
+        Harmonic = 0,
+        Percussive = 1,
+        Residual = 2
+    };
+
+    struct Parameters {
+        int binCount;
+        int horizontalFilterLength;
+        int horizontalFilterLag;
+        int verticalFilterLength;
+        double harmonicThreshold;
+        double percussiveThreshold;
+        Parameters(int _binCount, int _horizontalFilterLength,
+                   int _horizontalFilterLag, int _verticalFilterLength,
+                   double _harmonicThreshold, double _percussiveThreshold) :
+            binCount(_binCount),
+            horizontalFilterLength(_horizontalFilterLength),
+            horizontalFilterLag(_horizontalFilterLag),
+            verticalFilterLength(_verticalFilterLength),
+            harmonicThreshold(_harmonicThreshold),
+            percussiveThreshold(_percussiveThreshold) { }
+    };
+    
+    BinClassifier(Parameters parameters) :
+        m_parameters(parameters),
+        m_hFilters(new MovingMedianStack<process_t>(m_parameters.binCount,
+                                                    m_parameters.horizontalFilterLength)),
+        m_vFilter(new MovingMedian<process_t>(m_parameters.verticalFilterLength)),
+        m_vfQueue(parameters.horizontalFilterLag)
+    {
+        int n = m_parameters.binCount;
+
+        m_hf = allocate_and_zero<process_t>(n);
+        m_vf = allocate_and_zero<process_t>(n);
+        
+        for (int i = 0; i < m_parameters.horizontalFilterLag; ++i) {
+            process_t *entry = allocate_and_zero<process_t>(n);
+            m_vfQueue.write(&entry, 1);
+        }
+    }
+
+    ~BinClassifier()
+    {
+        while (m_vfQueue.getReadSpace() > 0) {
+            process_t *entry = m_vfQueue.readOne();
+            deallocate(entry);
+        }
+
+        deallocate(m_hf);
+        deallocate(m_vf);
+    }
+
+    void reset()
+    {
+        while (m_vfQueue.getReadSpace() > 0) {
+            process_t *entry = m_vfQueue.readOne();
+            deallocate(entry);
+        }
+        
+        for (int i = 0; i < m_parameters.horizontalFilterLag; ++i) {
+            process_t *entry =
+                allocate_and_zero<process_t>(m_parameters.binCount);
+            m_vfQueue.write(&entry, 1);
+        }
+
+        m_hFilters->reset();
+    }
+    
+    void classify(const process_t *const mag, // input, of at least binCount bins
+                  Classification *classification) // output, of binCount bins
+    {
+        Profiler profiler("BinClassifier::classify");
+        
+        const int n = m_parameters.binCount;
+
+        for (int i = 0; i < n; ++i) {
+            m_hFilters->push(i, mag[i]);
+            m_hf[i] = m_hFilters->get(i);
+        }
+
+        v_copy(m_vf, mag, n);
+        MovingMedian<process_t>::filter(*m_vFilter, m_vf, n);
+
+        if (m_parameters.horizontalFilterLag > 0) {
+            process_t *lagged = m_vfQueue.readOne();
+            m_vfQueue.write(&m_vf, 1);
+            m_vf = lagged;
+        }
+
+        process_t eps = 1.0e-7;
+            
+        for (int i = 0; i < n; ++i) {
+            Classification c;
+            if (process_t(m_hf[i]) / (process_t(m_vf[i]) + eps) >
+                m_parameters.harmonicThreshold) {
+                c = Classification::Harmonic;
+            } else if (process_t(m_vf[i]) / (process_t(m_hf[i]) + eps) >
+                       m_parameters.percussiveThreshold) {
+                c = Classification::Percussive;
+            } else {
+                c = Classification::Residual;
+            }
+            classification[i] = c;
+        }
+    }
+
+protected:
+    Parameters m_parameters;
+    std::unique_ptr<MovingMedianStack<process_t>> m_hFilters;
+    std::unique_ptr<MovingMedian<process_t>> m_vFilter;
+    // We manage the queued frames through pointer swapping, hence
+    // bare pointers here
+    process_t *m_hf;
+    process_t *m_vf;
+    RingBuffer<process_t *> m_vfQueue;
+
+    BinClassifier(const BinClassifier &) =delete;
+    BinClassifier &operator=(const BinClassifier &) =delete;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/BinSegmenter.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/BinSegmenter.h
@@ -1,0 +1,150 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_BIN_SEGMENTER_H
+#define RUBBERBAND_BIN_SEGMENTER_H
+
+#include "BinClassifier.h"
+
+#include "../common/HistogramFilter.h"
+#include "../common/mathmisc.h"
+#include "../common/Profiler.h"
+
+#include <vector>
+
+namespace RubberBand {
+
+class BinSegmenter
+{
+public:
+    struct Segmentation {
+        double percussiveBelow;
+        double percussiveAbove;
+        double residualAbove;
+        explicit Segmentation() :
+            percussiveBelow(0.0), percussiveAbove(0.0), residualAbove(0.0) { }
+        Segmentation(double _pb, double _pa, double _ra) :
+            percussiveBelow(_pb), percussiveAbove(_pa), residualAbove(_ra) { }
+    };
+
+    struct Parameters {
+        int fftSize;
+        int binCount;
+        double sampleRate;
+        int classFilterLength;
+        Parameters(int _fftSize, int _binCount, double _sampleRate,
+                   int _classFilterLength) :
+            fftSize(_fftSize), binCount(_binCount), sampleRate(_sampleRate),
+            classFilterLength(_classFilterLength) { }
+    };
+    
+    BinSegmenter(Parameters parameters) :
+        m_parameters(parameters),
+        m_numeric(m_parameters.binCount, 0),
+        m_classFilter(3, m_parameters.classFilterLength)
+    {
+    }
+
+    Segmentation segment(const BinClassifier::Classification *classification) {
+
+        Profiler profiler("BinSegmenter::segment");
+        
+        int n = m_parameters.binCount;
+        for (int i = 0; i < n; ++i) {
+            switch (classification[i]) {
+            case BinClassifier::Classification::Harmonic:
+                m_numeric[i] = 0; break;
+            case BinClassifier::Classification::Percussive:
+                m_numeric[i] = 1; break;
+            default:
+                m_numeric[i] = 2; break;
+            }
+        }
+        HistogramFilter::modalFilter(m_classFilter, m_numeric);
+/*
+        std::cout << "c:";
+        for (int i = 0; i < n; ++i) {
+            if (i > 0) std::cout << ",";
+            std::cout << m_numeric[i];
+        }
+        std::cout << std::endl;
+*/
+        double f0 = 0.0;
+        for (int i = 1; i < n; ++i) {
+            if (m_numeric[i] != 1) { // percussive
+                if (i == 1 && m_numeric[0] != 1) { // percussive
+                    f0 = 0.0;
+                } else {
+                    f0 = frequencyForBin
+                        (i, m_parameters.fftSize, m_parameters.sampleRate);
+                }
+                break;
+            }
+        }
+        double nyquist = m_parameters.sampleRate / 2.0;
+        double f1 = nyquist;
+        double f2 = nyquist;
+        bool inPercussive = false;
+        for (int i = n - 1; i > 0; --i) {
+            int c = m_numeric[i];
+            if (!inPercussive) {
+                if (c == 2) { // residual
+                    continue;
+                } else if (c == 1) { // percussive
+                    inPercussive = true;
+                    f2 = frequencyForBin
+                        (i, m_parameters.fftSize, m_parameters.sampleRate);
+                } else { // harmonic
+                    f1 = f2 = frequencyForBin
+                        (i, m_parameters.fftSize, m_parameters.sampleRate);
+                    break;
+                }
+            } else { // inPercussive
+                if (c != 1) { // non-percussive
+                    f1 = frequencyForBin
+                        (i, m_parameters.fftSize, m_parameters.sampleRate);
+                    break;
+                }
+            }
+        }
+        if (f1 == nyquist && f2 < nyquist) {
+            f1 = 0.0;
+        }
+
+//        std::cout << "f0 = " << f0 << ", f1 = " << f1 << ", f2 = " << f2 << std::endl;
+        
+        return Segmentation(f0, f1, f2);
+    }
+
+protected:
+    Parameters m_parameters;
+    std::vector<int> m_numeric;
+    HistogramFilter m_classFilter;
+
+    BinSegmenter(const BinSegmenter &) =delete;
+    BinSegmenter &operator=(const BinSegmenter &) =delete;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/Guide.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/Guide.h
@@ -1,0 +1,611 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_GUIDE_H
+#define RUBBERBAND_GUIDE_H
+
+#include "../common/Log.h"
+#include "../common/Profiler.h"
+
+#include <functional>
+#include <sstream>
+
+namespace RubberBand
+{
+
+class Guide
+{
+public:
+    struct FftBand {
+        int fftSize;
+        double f0;
+        double f1;
+        FftBand(int _s, double _f0, double _f1) :
+            fftSize(_s), f0(_f0), f1(_f1) { }
+        FftBand() :
+            fftSize(0), f0(0.f), f1(0.f) { }
+    };
+
+    struct PhaseLockBand {
+        int p;
+        double beta;
+        double f0;
+        double f1;
+        PhaseLockBand(int _p, double _beta, double _f0, double _f1) :
+            p(_p), beta(_beta), f0(_f0), f1(_f1) { }
+        PhaseLockBand() :
+            p(0), beta(1.0), f0(0.f), f1(0.f) { }
+    };
+
+    struct Range {
+        bool present;
+        double f0;
+        double f1;
+        Range(bool _present, double _f0, double _f1) :
+            present(_present), f0(_f0), f1(_f1) { }
+        Range() :
+            present(false), f0(0.f), f1(0.f) { }
+    };
+        
+    struct Guidance {
+        FftBand fftBands[3];
+        int fftBandCount;
+        PhaseLockBand phaseLockBands[4];
+        int phaseLockBandCount;
+        Range kick;
+        Range preKick;
+        Range highUnlocked;
+        Range phaseReset;
+        Range channelLock;
+    };
+
+    struct BandLimits {
+        int fftSize;
+        double f0min;
+        double f1max;
+        int b0min;
+        int b1max;
+        BandLimits(int _fftSize, double _rate, double _f0min, double _f1max) :
+            fftSize(_fftSize), f0min(_f0min), f1max(_f1max),
+            b0min(int(floor(f0min * fftSize / _rate))),
+            b1max(int(ceil(f1max * fftSize / _rate))) { }
+        BandLimits() :
+            fftSize(0), f0min(0.f), f1max(0.f), b0min(0), b1max(0) { }
+    };
+
+    struct Configuration {
+        int longestFftSize;
+        int shortestFftSize;
+        int classificationFftSize;
+        BandLimits fftBandLimits[3];
+        int fftBandLimitCount;
+        Configuration() :
+            longestFftSize(0), shortestFftSize(0), classificationFftSize(0),
+            fftBandLimitCount(0) { }
+    };
+    
+    struct Parameters {
+        double sampleRate;
+        bool singleWindowMode;
+        Parameters(double _sampleRate, bool _singleWindow) :
+            sampleRate(_sampleRate),
+            singleWindowMode(_singleWindow) { }
+    };
+
+    Guide(Parameters parameters, Log log) :
+        m_parameters(parameters),
+        m_log(log)
+    {
+        double rate = m_parameters.sampleRate;
+        double nyquist = rate / 2.0;
+
+        m_log.log(1, "Guide: rate and single-window mode",
+                  rate, m_parameters.singleWindowMode);
+
+        int classificationFftSize = roundUpDiv(parameters.sampleRate, 32);
+
+        int minClassificationFftSize = 1024;
+        if (classificationFftSize < minClassificationFftSize) {
+            m_log.log(1, "Guide: sample rate is too low to work well");
+            m_log.log(1, "Guide: rounding up classification FFT size from and to", classificationFftSize, minClassificationFftSize);
+            classificationFftSize = minClassificationFftSize;
+        }
+        
+        m_configuration.classificationFftSize = classificationFftSize;
+        
+        m_log.log(1, "Guide: classification FFT size",
+                  m_configuration.classificationFftSize);
+
+        if (m_parameters.singleWindowMode) {
+
+            // Single-window mode
+            
+            m_configuration.longestFftSize = classificationFftSize;
+            m_configuration.shortestFftSize = classificationFftSize;
+
+            m_defaultLower = nyquist;
+            m_minLower = m_defaultLower;
+            m_maxLower = m_defaultLower;
+
+            m_defaultHigher = nyquist;
+            m_minHigher = m_defaultHigher;
+            m_maxHigher = m_defaultHigher;
+
+            m_configuration.fftBandLimitCount = 1;
+
+            m_configuration.fftBandLimits[0] = 
+                BandLimits(classificationFftSize, rate, 0.0, nyquist);
+
+        } else {
+            
+            // The normal multi-window mode
+
+            m_configuration.longestFftSize = classificationFftSize * 2;
+            m_configuration.shortestFftSize = classificationFftSize / 2;
+            
+            m_defaultLower = 700.0;
+            m_minLower = 500.0;
+            m_maxLower = 1100.0;
+
+            m_defaultHigher = 4800.0;
+            m_minHigher = 4000.0;
+            m_maxHigher = 7000.0;
+            
+            m_configuration.fftBandLimitCount = 3;
+
+            m_configuration.fftBandLimits[0] =
+                BandLimits(m_configuration.longestFftSize,
+                           rate, 0.0, m_maxLower);
+        
+            // This is the classification and fallback FFT: we need it
+            // to go up to Nyquist so we can seamlessly switch to it
+            // for longer stretches, and down to 0.0 so we can use it
+            // for unity in offline mode
+
+            m_configuration.fftBandLimits[1] =
+                BandLimits(classificationFftSize,
+                           rate, 0.0, nyquist);
+        
+            m_configuration.fftBandLimits[2] =
+                BandLimits(m_configuration.shortestFftSize,
+                           rate, m_minHigher, nyquist);
+        }
+    }
+
+    const Configuration &getConfiguration() const {
+        return m_configuration;
+    }
+    
+    void updateGuidance(double ratio,
+                        int outhop,
+                        const process_t *const magnitudes,
+                        const process_t *const prevMagnitudes,
+                        const process_t *const nextMagnitudes,
+                        const BinSegmenter::Segmentation &segmentation,
+                        const BinSegmenter::Segmentation &prevSegmentation,
+                        const BinSegmenter::Segmentation &nextSegmentation,
+                        process_t meanMagnitude,
+                        int unityCount,
+                        bool realtime,
+                        bool tighterChannelLock,
+                        bool resetOnSilence,
+                        Guidance &guidance) const {
+
+        Profiler profiler("Guide::updateGuidance");
+        
+        bool hadPhaseReset = guidance.phaseReset.present;
+
+        guidance.phaseReset.present = false;
+        guidance.kick.present = false;
+        guidance.preKick.present = false;
+        guidance.highUnlocked.present = false;
+        guidance.channelLock.present = false;
+
+        double nyquist = m_parameters.sampleRate / 2.0;
+
+        if (m_parameters.singleWindowMode) {
+
+            // All the fft and phase-lock bands are fixed in this
+            // mode. We'll still need to continue to set up phase
+            // reset ranges etc, including the unity case.
+
+            guidance.fftBandCount = 1;
+            guidance.fftBands[0].fftSize = m_configuration.classificationFftSize;
+            guidance.fftBands[0].f0 = 0.0;
+            guidance.fftBands[0].f1 = nyquist;
+
+            guidance.phaseLockBandCount = 3;
+
+            guidance.phaseLockBands[0].p = 1;
+            guidance.phaseLockBands[0].beta = betaFor(1200.0, ratio);
+            guidance.phaseLockBands[0].f0 = 0.0;
+            guidance.phaseLockBands[0].f1 = 1600.0;
+            
+            guidance.phaseLockBands[1].p = 2;
+            guidance.phaseLockBands[1].beta = betaFor(5000.0, ratio);
+            guidance.phaseLockBands[1].f0 = 1600.0;
+            guidance.phaseLockBands[1].f1 = 7000.0;
+            
+            guidance.phaseLockBands[2].p = 5;
+            guidance.phaseLockBands[2].beta = betaFor(10000.0, ratio);
+            guidance.phaseLockBands[2].f0 = 7000.0;
+            guidance.phaseLockBands[2].f1 = nyquist;
+
+            if (outhop > 256) {
+                guidance.phaseLockBands[2].p = 4;
+            }
+
+            for (int i = 0; i < 3; ++i) {
+                if (guidance.phaseLockBands[i].f0 > nyquist) {
+                    guidance.phaseLockBands[i].f0 = nyquist;
+                }
+                if (guidance.phaseLockBands[i].f1 > nyquist) {
+                    guidance.phaseLockBands[i].f1 = nyquist;
+                }
+            }
+            
+        } else {
+
+            // The normal multi-window mode
+            
+            guidance.fftBandCount = 3;
+            guidance.fftBands[0].fftSize = m_configuration.longestFftSize;
+            guidance.fftBands[1].fftSize = m_configuration.classificationFftSize;
+            guidance.fftBands[2].fftSize = m_configuration.shortestFftSize;
+            
+            guidance.phaseLockBandCount = 4;
+        
+            // This is a vital stop case for PhaseAdvance
+            guidance.phaseLockBands[3].f1 = nyquist;
+        }
+
+        // We've set the counts, and for single-window mode we've set
+        // the band ranges as well - in normal multi-window mode we
+        // still have to do that, but we should do these first
+        
+        if (resetOnSilence && meanMagnitude < 1.0e-6) {
+            updateForSilence(guidance);
+            return;
+        }
+
+        if (unityCount > 0) {
+            updateForUnity(guidance,
+                           hadPhaseReset,
+                           segmentation,
+                           realtime);
+            return;
+        }
+
+        guidance.channelLock.present = true;
+        guidance.channelLock.f0 = 0.0;
+
+        if (tighterChannelLock) {
+            guidance.channelLock.f1 = nyquist;
+        } else {
+            guidance.channelLock.f1 = 600.0;
+        }
+
+        if (!m_parameters.singleWindowMode) {
+            
+            bool kick =
+                (segmentation.percussiveBelow > 40.0) &&
+                (prevSegmentation.percussiveBelow < 40.0) &&
+                checkPotentialKick(magnitudes, prevMagnitudes);
+
+            bool futureKick = !kick &&
+                (nextSegmentation.percussiveBelow > 40.0) &&
+                (segmentation.percussiveBelow < 40.0) &&
+                checkPotentialKick(nextMagnitudes, magnitudes);
+
+            if (kick) {
+                guidance.kick.present = true;
+                guidance.kick.f0 = 0.0;
+                guidance.kick.f1 = segmentation.percussiveBelow;
+            } else if (futureKick) {
+                guidance.preKick.present = true;
+                guidance.preKick.f0 = 0.0;
+                guidance.preKick.f1 = nextSegmentation.percussiveBelow;
+            }
+        }
+        
+/*
+        std::cout << "d:"
+                  << prevSegmentation.percussiveBelow << ","
+                  << segmentation.percussiveBelow << ","
+                  << nextSegmentation.percussiveBelow << ","
+                  << checkPotentialKick(magnitudes, prevMagnitudes) << ","
+                  << checkPotentialKick(nextMagnitudes, magnitudes) << ","
+                  << (kick ? "K" : "N") << ","
+                  << (futureKick ? "F" : "N") << std::endl;
+*/        
+        
+        if (segmentation.residualAbove > segmentation.percussiveAbove) {
+            guidance.highUnlocked.present = true;
+            guidance.highUnlocked.f0 = segmentation.percussiveAbove;
+            guidance.highUnlocked.f1 = segmentation.residualAbove;
+        }
+
+        double bigGap = 4000.0;
+        if (segmentation.residualAbove >
+            segmentation.percussiveAbove + bigGap &&
+            prevSegmentation.residualAbove <
+            prevSegmentation.percussiveAbove + bigGap) {
+            guidance.phaseReset.present = true;
+            guidance.phaseReset.f0 = std::min(segmentation.percussiveAbove,
+                                              nextSegmentation.percussiveAbove);
+            guidance.phaseReset.f1 = std::max(segmentation.residualAbove,
+                                              nextSegmentation.residualAbove);
+            if (guidance.phaseReset.f0 < 200.0) {
+                guidance.phaseReset.f0 = 0.0;
+            }
+        }
+
+        if (!m_parameters.singleWindowMode) {
+
+            // The normal multi-window mode. For single-window we did
+            // this already.
+            
+            double prevLower = guidance.fftBands[0].f1;
+            double lower = descendToValley(prevLower, magnitudes);
+            if (lower > m_maxLower || lower < m_minLower) {
+                lower = m_defaultLower;
+            }
+        
+            double prevHigher = guidance.fftBands[1].f1;
+            double higher = descendToValley(prevHigher, magnitudes);
+            if (higher > m_maxHigher || higher < m_minHigher) {
+                higher = m_defaultHigher;
+            }
+
+            guidance.fftBands[0].f0 = 0.0;
+            guidance.fftBands[0].f1 = lower;
+
+            guidance.fftBands[1].f0 = lower;
+            guidance.fftBands[1].f1 = higher;
+        
+            guidance.fftBands[2].f0 = higher;
+            guidance.fftBands[2].f1 = nyquist;
+
+            if (outhop > 256) {
+                guidance.fftBands[1].f1 = nyquist;
+                guidance.fftBands[2].f0 = nyquist;
+            }
+        
+            double mid = std::max(lower, 1600.0);
+
+            guidance.phaseLockBands[0].p = 1;
+            guidance.phaseLockBands[0].beta = betaFor(300.0, ratio);
+            guidance.phaseLockBands[0].f0 = 0.0;
+            guidance.phaseLockBands[0].f1 = lower;
+        
+            guidance.phaseLockBands[1].p = 2;
+            guidance.phaseLockBands[1].beta = betaFor(1600.0, ratio);
+            guidance.phaseLockBands[1].f0 = lower;
+            guidance.phaseLockBands[1].f1 = mid;
+        
+            guidance.phaseLockBands[2].p = 3;
+            guidance.phaseLockBands[2].beta = betaFor(5000.0, ratio);
+            guidance.phaseLockBands[2].f0 = mid;
+            guidance.phaseLockBands[2].f1 = higher;
+            
+            guidance.phaseLockBands[3].p = 4;
+            guidance.phaseLockBands[3].beta = betaFor(10000.0, ratio);
+            guidance.phaseLockBands[3].f0 = higher;
+            guidance.phaseLockBands[3].f1 = nyquist;
+        
+            if (outhop > 256) {
+                guidance.phaseLockBands[3].p = 3;
+            }
+        }
+        
+        if (ratio > 2.0) {
+            
+            // For very long stretches, diffuse is better than
+            // metallic - gradually unlock the higher frequencies and
+            // reduce the channel lock
+            
+            double channelLimit = guidance.channelLock.f1;
+            channelLimit = channelLimit - (ratio - 2.0) * 150.0;
+            if (channelLimit < 100.0) channelLimit = 100.0;
+            guidance.channelLock.f1 = channelLimit;
+            
+            double unlockedAbove = 12000.0 - (ratio - 2.0) * 400.0;
+            if (unlockedAbove < channelLimit) unlockedAbove = channelLimit;
+            if (guidance.highUnlocked.present) {
+                guidance.highUnlocked.f0 = std::min(guidance.highUnlocked.f0,
+                                                    unlockedAbove);
+            } else {
+                guidance.highUnlocked.f0 = unlockedAbove;
+            }
+            guidance.highUnlocked.f1 = nyquist;
+            guidance.highUnlocked.present = true;
+        }
+
+/*
+        std::ostringstream str;
+        str << "Guidance: FFT bands: ["
+            << guidance.fftBands[0].fftSize << " from "
+            << guidance.fftBands[0].f0 << " to " << guidance.fftBands[0].f1
+            << ", "
+            << guidance.fftBands[1].fftSize << " from "
+            << guidance.fftBands[1].f0 << " to " << guidance.fftBands[1].f1
+            << ", "
+            << guidance.fftBands[2].fftSize << " from "
+            << guidance.fftBands[2].f0 << " to " << guidance.fftBands[2].f1
+            << "]; phase reset range: ["
+            << guidance.phaseReset.present << " from "
+            << guidance.phaseReset.f0 << " to " << guidance.phaseReset.f1
+            << "]" << std::endl;
+
+        m_log.log(2, str.str().c_str());
+*/
+    }
+
+    void setDebugLevel(int level) {
+        m_log.setDebugLevel(level);
+    }
+    
+protected:
+    Parameters m_parameters;
+    Log m_log;
+    Configuration m_configuration;
+
+    double m_minLower;
+    double m_minHigher;
+    double m_defaultLower;
+    double m_defaultHigher;
+    double m_maxLower;
+    double m_maxHigher;
+    
+    void updateForSilence(Guidance &guidance) const {
+        
+        m_log.log(2, "Guide::updateForSilence");
+
+        double nyquist = m_parameters.sampleRate / 2.0;
+        if (!m_parameters.singleWindowMode) {
+            guidance.fftBands[0].f0 = 0.0;
+            guidance.fftBands[0].f1 = 0.0;
+            guidance.fftBands[1].f0 = 0.0;
+            guidance.fftBands[1].f1 = nyquist;
+            guidance.fftBands[2].f0 = nyquist;
+            guidance.fftBands[2].f1 = nyquist;
+        }
+        guidance.phaseReset.present = true;
+        guidance.phaseReset.f0 = 0.0;
+        guidance.phaseReset.f1 = nyquist;
+    }
+
+    void updateForUnity(Guidance &guidance,
+                        bool hadPhaseReset,
+                        const BinSegmenter::Segmentation &segmentation,
+                        bool realtime) const {
+        
+        m_log.log(2, "Guide::updateForUnity: realtime and single-window mode", (int)realtime, m_parameters.singleWindowMode);
+        
+        double nyquist = m_parameters.sampleRate / 2.0;
+
+        if (!realtime) {
+            // ratio can't change, so we are just running 1.0 ratio
+            // throughout
+            if (!m_parameters.singleWindowMode) {
+                guidance.fftBands[0].f0 = 0.0;
+                guidance.fftBands[0].f1 = 0.0;
+                guidance.fftBands[1].f0 = 0.0;
+                guidance.fftBands[1].f1 = nyquist;
+                guidance.fftBands[2].f0 = nyquist;
+                guidance.fftBands[2].f1 = nyquist;
+            }
+            guidance.phaseReset.present = true;
+            guidance.phaseReset.f0 = 0.0;
+            guidance.phaseReset.f1 = nyquist;
+            return;
+        }
+
+        if (!m_parameters.singleWindowMode) {
+            guidance.fftBands[0].f0 = 0.0;
+            guidance.fftBands[0].f1 = m_minLower;
+            guidance.fftBands[1].f0 = m_minLower;
+            guidance.fftBands[1].f1 = m_minHigher;
+            guidance.fftBands[2].f0 = m_minHigher;
+            guidance.fftBands[2].f1 = nyquist;
+        }
+        
+        guidance.phaseReset.present = true;
+
+        if (!hadPhaseReset) {
+            guidance.phaseReset.f0 = 16000.0;
+            guidance.phaseReset.f1 = nyquist;
+            return;
+        } else {
+            m_log.log(2, "Guide::updateForUnity: had phase reset");
+            guidance.phaseReset.f0 *= 0.9;
+            guidance.phaseReset.f1 *= 1.1;
+        }
+
+        if (guidance.phaseReset.f0 < segmentation.residualAbove) {
+            guidance.phaseReset.f0 = std::min(guidance.phaseReset.f0,
+                                              segmentation.percussiveAbove);
+        }
+
+        if (guidance.phaseReset.f1 > 16000.0) {
+            guidance.phaseReset.f1 = nyquist;
+        }
+        
+        if (guidance.phaseReset.f0 < 100.0) {
+            guidance.phaseReset.f0 = 0.0;
+        }
+
+        m_log.log(2, "Guide::updateForUnity: f0 and f1", guidance.phaseReset.f0, guidance.phaseReset.f1);
+    }
+
+    bool checkPotentialKick(const process_t *const magnitudes,
+                            const process_t *const prevMagnitudes) const {
+        int b = binForFrequency(200.0, m_configuration.classificationFftSize,
+                                m_parameters.sampleRate);
+        process_t here = 0.0, there = 0.0;
+        for (int i = 1; i <= b; ++i) {
+            here += magnitudes[i];
+        }
+        for (int i = 1; i <= b; ++i) {
+            there += prevMagnitudes[i];
+        }
+        return (here > 10.e-3 && here > there * 1.4);
+    }
+
+    double descendToValley(double f, const process_t *const magnitudes) const {
+        if (f == 0.0 || f == m_parameters.sampleRate/2.0) {
+            // These are special cases
+            return f;
+        }
+        int b = binForFrequency(f, m_configuration.classificationFftSize,
+                                m_parameters.sampleRate);
+        int n = m_configuration.classificationFftSize/2;
+        if (b > n) b = n;
+        for (int i = 0; i < 3; ++i) {
+            if (b < n && magnitudes[b+1] < magnitudes[b]) {
+                ++b;
+            } else if (b > 0 && magnitudes[b-1] < magnitudes[b]) {
+                --b;
+            } else {
+                break;
+            }
+        }
+        double sf = frequencyForBin(b, m_configuration.classificationFftSize,
+                                    m_parameters.sampleRate);
+        return sf;
+    }
+
+    double betaFor(double f, double ratio) const {
+        double b = (2.0 + ratio) / 3.0;
+        double limit = 10000.0;
+        if (f > limit) {
+            return b;
+        } else {
+            return 1.0 + f * (b - 1.0) / limit;
+        }
+    }
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/Peak.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/Peak.h
@@ -1,0 +1,137 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_PEAK_H
+#define RUBBERBAND_PEAK_H
+
+#include <vector>
+
+namespace RubberBand
+{
+
+template <typename T, typename GreaterThan = std::greater<T>>
+class Peak
+{
+public:
+    /** Peak picker for array of length n. This allocates on
+        construction an internal buffer for temporary values, to be
+        used within the peak-picking functions, so that it does not
+        have to allocate when used. It does not have persistent state.
+    */
+    Peak(int n) :
+        m_n(n),
+        m_locations(n, 0) { }
+
+    /** Find the nearest peak to each bin, and optionally the next
+        highest peak above each bin, within an array v, where a peak
+        is a value greater than the p nearest neighbours on each
+        side. The array must have length n where n is the size passed
+        the the constructor.
+    */
+    void findNearestAndNextPeaks(const T *v,
+                                 int p,
+                                 int *nearest,
+                                 int *next = nullptr)
+    {
+        findNearestAndNextPeaks(v, 0, m_n, p, nearest, next);
+    }
+
+    /** As above but consider only the range of size rangeCount from
+        index rangeStart. Write rangeCount results into nearest and
+        optionally next, starting to write at index rangeStart - so
+        these arrays must have the full length even if rangeCount is
+        shorter. Leave the rest of nearest and/or next unmodified.
+    */
+    void findNearestAndNextPeaks(const T *v,
+                                 int rangeStart,
+                                 int rangeCount,
+                                 int p,
+                                 int *nearest,
+                                 int *next = nullptr)
+    {
+        int nPeaks = 0;
+        int n = rangeStart + rangeCount;
+        GreaterThan greater;
+
+        for (int i = rangeStart; i < n; ++i) {
+            T x = v[i];
+            bool good = true;
+            for (int k = i - p; k <= i + p; ++k) {
+                if (k < rangeStart || k == i) continue;
+                if (k >= n) break;
+                if (k < i && !greater(x, v[k])) {
+                    good = false;
+                    break;
+                }
+                if (k > i && greater(v[k], x)) {
+                    good = false;
+                    break;
+                }
+            }
+            if (good) {
+                m_locations[nPeaks++] = i;
+            }
+        }
+
+        int pp = rangeStart - 1;
+        for (int i = rangeStart, j = 0; i < n; ++i) {
+            int np = i;
+            if (j < nPeaks) {
+                np = m_locations[j];
+            } else if (nPeaks > 0) {
+                np = m_locations[nPeaks-1];
+            }
+            if (next) {
+                if (pp == i || j >= nPeaks) {
+                    next[i] = i;
+                } else {
+                    next[i] = np;
+                }
+            }
+            if (nearest) {
+                if (j == 0) {
+                    nearest[i] = np;
+                } else {
+                    if (np - i <= i - pp) {
+                        nearest[i] = np;
+                    } else {
+                        nearest[i] = pp;
+                    }
+                }
+            }
+            while (j < nPeaks && m_locations[j] <= i) {
+                pp = np;
+                ++j;
+            }
+        }
+    }
+
+protected:
+    int m_n;
+    std::vector<int> m_locations;
+};
+
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/PhaseAdvance.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/PhaseAdvance.h
@@ -1,0 +1,274 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_PHASE_ADVANCE_H
+#define RUBBERBAND_PHASE_ADVANCE_H
+
+#include "Guide.h"
+
+#include "../common/Log.h"
+#include "../common/mathmisc.h"
+#include "../common/Profiler.h"
+
+#include <sstream>
+#include <functional>
+
+namespace RubberBand
+{
+
+class GuidedPhaseAdvance
+{
+public:
+    struct Parameters {
+        int fftSize;
+        double sampleRate;
+        int channels;
+        bool singleWindowMode;
+        Parameters(int _fftSize, double _sampleRate, int _channels,
+                   bool _singleWindow) :
+            fftSize(_fftSize), sampleRate(_sampleRate), channels(_channels),
+            singleWindowMode(_singleWindow) { }
+    };
+    
+    GuidedPhaseAdvance(Parameters parameters, Log log) :
+        m_parameters(parameters),
+        m_log(log),
+        m_binCount(parameters.fftSize / 2 + 1),
+        m_peakPicker(m_binCount),
+        m_reported(false) {
+        int ch = m_parameters.channels;
+        m_currentPeaks = allocate_and_zero_channels<int>(ch, m_binCount);
+        m_prevPeaks = allocate_and_zero_channels<int>(ch, m_binCount);
+        m_greatestChannel = allocate_and_zero<int>(m_binCount);
+        m_prevInPhase = allocate_and_zero_channels<process_t>(ch, m_binCount);
+        m_prevOutPhase = allocate_and_zero_channels<process_t>(ch, m_binCount);
+        m_unlocked = allocate_and_zero_channels<process_t>(ch, m_binCount);
+
+        for (int c = 0; c < ch; ++c) {
+            for (int i = 0; i < m_binCount; ++i) {
+                m_prevPeaks[c][i] = i;
+            }
+        }
+    }
+
+    ~GuidedPhaseAdvance() {
+        int ch = m_parameters.channels;
+        deallocate_channels(m_currentPeaks, ch);
+        deallocate_channels(m_prevPeaks, ch);
+        deallocate(m_greatestChannel);
+        deallocate_channels(m_prevInPhase, ch);
+        deallocate_channels(m_prevOutPhase, ch);
+        deallocate_channels(m_unlocked, ch);
+    }
+
+    void reset() {
+        int ch = m_parameters.channels;
+        v_zero_channels(m_prevPeaks, ch, m_binCount);
+        v_zero_channels(m_prevInPhase, ch, m_binCount);
+        v_zero_channels(m_prevOutPhase, ch, m_binCount);
+    }
+    
+    void advance(process_t *const *outPhase,
+                 const process_t *const *mag,
+                 const process_t *const *phase,
+                 const process_t *const *prevMag,
+                 const Guide::Configuration &configuration,
+                 const Guide::Guidance *const *guidance,
+                 bool usingMidSide,
+                 int inhop,
+                 int outhop) {
+
+        Profiler profiler("GuidedPhaseAdvance::advance");
+        
+        int myFftBand = 0;
+        int bandi = 0;
+        for (const auto &fband : guidance[0]->fftBands) {
+            if (fband.fftSize == m_parameters.fftSize) {
+                myFftBand = bandi;
+                break;
+            }
+            ++bandi;
+        }
+
+        int bs = m_parameters.fftSize / 2 + 1;
+        int channels = m_parameters.channels;
+        double ratio = double(outhop) / double(inhop);
+
+        int lowest = configuration.fftBandLimits[myFftBand].b0min;
+        int highest = configuration.fftBandLimits[myFftBand].b1max;
+        
+        if (m_log.getDebugLevel() > 0 && !m_reported) {
+            m_log.log(1, "PhaseAdvance: for fftSize and bins",
+                      m_parameters.fftSize, bs);
+            m_log.log(1, "PhaseAdvance: channels", channels);
+            m_log.log(1, "PhaseAdvance: widest bin range for this size",
+                      lowest, highest);
+            m_log.log(1, "PhaseAdvance: widest freq range for this size",
+                      configuration.fftBandLimits[myFftBand].f0min,
+                      configuration.fftBandLimits[myFftBand].f1max);
+            m_log.log(1, "PhaseAdvance: initial inhop and outhop",
+                      inhop, outhop);
+            m_log.log(1, "PhaseAdvance: initial ratio", ratio);
+            m_reported = true;
+        }
+        
+        for (int c = 0; c < channels; ++c) {
+            for (int i = lowest; i <= highest; ++i) {
+                m_currentPeaks[c][i] = i;
+            }
+            for (int i = 0; i < guidance[c]->phaseLockBandCount; ++i) {
+                const auto &band = guidance[c]->phaseLockBands[i];
+                int startBin = binForFrequency
+                    (band.f0, m_parameters.fftSize, m_parameters.sampleRate);
+                int endBin = binForFrequency
+                    (band.f1, m_parameters.fftSize, m_parameters.sampleRate);
+                if (startBin > highest || endBin < lowest) continue;
+                if (endBin > highest) endBin = highest;
+                int count = endBin - startBin + 1;
+                if (count < 1) continue;
+                m_peakPicker.findNearestAndNextPeaks(mag[c],
+                                                     startBin, count,
+                                                     band.p, m_currentPeaks[c],
+                                                     nullptr);
+            }
+            m_peakPicker.findNearestAndNextPeaks(prevMag[c],
+                                                 lowest, highest - lowest + 1,
+                                                 1, m_prevPeaks[c],
+                                                 nullptr);
+        }
+
+        if (channels > 1) {
+            for (int i = lowest; i <= highest; ++i) {
+                int gc = 0;
+                float gmag = mag[0][i];
+                for (int c = 1; c < channels; ++c) {
+                    if (mag[c][i] > gmag) {
+                        gmag = mag[c][i];
+                        gc = c;
+                    }
+                }
+                m_greatestChannel[i] = gc;
+            }
+        } else {
+            v_zero(m_greatestChannel, bs);
+        }
+
+        process_t omegaFactor = 2.0 * M_PI * process_t(inhop) /
+            process_t(m_parameters.fftSize);
+        for (int c = 0; c < channels; ++c) {
+            for (int i = lowest; i <= highest; ++i) {
+                process_t omega = omegaFactor * process_t(i);
+                process_t expected = m_prevInPhase[c][i] + omega;
+                process_t error = princarg(phase[c][i] - expected);
+                process_t advance = ratio * (omega + error);
+                m_unlocked[c][i] = m_prevOutPhase[c][i] + advance;
+            }
+        }
+
+        for (int c = 0; c < channels; ++c) {
+            const Guide::Guidance *g = guidance[c];
+            int phaseLockBand = 0;
+            for (int i = lowest; i <= highest; ++i) {
+                process_t f = frequencyForBin
+                    (i, m_parameters.fftSize, m_parameters.sampleRate);
+                while (f > g->phaseLockBands[phaseLockBand].f1 &&
+                       phaseLockBand + 1 < g->phaseLockBandCount) {
+                    ++phaseLockBand;
+                }
+                process_t ph = 0.0;
+                if (inRange(f, g->phaseReset) || inRange(f, g->kick)) {
+                    ph = phase[c][i];
+                } else if (usingMidSide && channels == 2 &&
+                           c == 0 && inRange(f, guidance[1]->phaseReset)) {
+                    ph = phase[c][i];
+                } else if (inhop == outhop) {
+                    ph = m_unlocked[c][i];
+                } else if (inRange (f, g->highUnlocked)) {
+                    ph = m_unlocked[c][i];
+                } else {
+                    int peak = m_currentPeaks[c][i];
+                    int prevPeak = m_prevPeaks[c][peak];
+                    int peakCh = c;
+                    if (inRange(f, g->channelLock)) {
+                        int other = m_greatestChannel[i];
+                        if (other != c &&
+                            inRange(f, guidance[other]->channelLock)) {
+                            int otherPeak = m_currentPeaks[other][i];
+                            int otherPrevPeak = m_prevPeaks[other][otherPeak];
+                            if (otherPrevPeak == prevPeak) {
+                                peakCh = other;
+                            }
+                        }
+                    }
+                    process_t peakAdvance =
+                        m_unlocked[peakCh][peak] - m_prevOutPhase[peakCh][peak];
+                    process_t peakNew =
+                        m_prevOutPhase[peakCh][prevPeak] + peakAdvance;
+                    process_t diff =
+                        process_t(phase[c][i]) - process_t(phase[peakCh][peak]);
+                    process_t beta =
+                        process_t(g->phaseLockBands[phaseLockBand].beta);
+                    ph = peakNew + beta * diff;
+                }
+                outPhase[c][i] = princarg(ph);
+            }
+        }
+                
+        for (int c = 0; c < channels; ++c) {
+            for (int i = lowest; i <= highest; ++i) {
+                m_prevInPhase[c][i] = phase[c][i];
+            }
+            for (int i = lowest; i <= highest; ++i) {
+                m_prevOutPhase[c][i] = outPhase[c][i];
+            }
+        }
+    }
+
+    void setDebugLevel(int debugLevel) {
+        m_log.setDebugLevel(debugLevel);
+    }
+    
+protected:
+    Parameters m_parameters;
+    Log m_log;
+    int m_binCount;
+    Peak<process_t> m_peakPicker;
+    int **m_currentPeaks;
+    int **m_prevPeaks;
+    int *m_greatestChannel;
+    process_t **m_prevInPhase;
+    process_t **m_prevOutPhase;
+    process_t **m_unlocked;
+    bool m_reported;
+
+    bool inRange(process_t f, const Guide::Range &r) {
+        return r.present && f >= r.f0 && f < r.f1;
+    }
+
+    GuidedPhaseAdvance(const GuidedPhaseAdvance &) =delete;
+    GuidedPhaseAdvance &operator=(const GuidedPhaseAdvance &) =delete;
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/R3LiveShifter.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/R3LiveShifter.cpp
@@ -1,0 +1,1202 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "R3LiveShifter.h"
+
+#include "../common/VectorOpsComplex.h"
+#include "../common/Profiler.h"
+
+#include <array>
+
+namespace RubberBand {
+
+R3LiveShifter::R3LiveShifter(Parameters parameters, Log log) :
+    m_log(log),
+    m_parameters(validateSampleRate(parameters)),
+    m_limits(parameters.options, m_parameters.sampleRate),
+    m_pitchScale(1.0),
+    m_formantScale(0.0),
+    m_guide(Guide::Parameters
+            (m_parameters.sampleRate, true),
+            m_log),
+    m_guideConfiguration(m_guide.getConfiguration()),
+    m_channelAssembly(m_parameters.channels),
+    m_initialResamplerDelays(32, 32),
+    m_useReadahead(false),
+    m_prevInhop(m_limits.maxInhopWithReadahead / 2),
+    m_prevOuthop(m_prevInhop),
+    m_firstProcess(true),
+    m_unityCount(0)
+{
+    Profiler profiler("R3LiveShifter::R3LiveShifter");
+    initialise();
+}
+
+void
+R3LiveShifter::initialise()
+{
+    m_log.log(1, "R3LiveShifter::R3LiveShifter: rate, options",
+              m_parameters.sampleRate, m_parameters.options);
+
+    if (!isSingleWindowed()) {
+        m_log.log(1, "R3LiveShifter::R3LiveShifter: multi window enabled");
+    }
+
+    if (m_parameters.options & RubberBandLiveShifter::OptionWindowMedium) {
+        m_log.log(1, "R3LiveShifter::R3LiveShifter: readahead enabled");
+        m_useReadahead = true;
+    }
+
+    double maxClassifierFrequency = 16000.0;
+    if (maxClassifierFrequency > m_parameters.sampleRate/2) {
+        maxClassifierFrequency = m_parameters.sampleRate/2;
+    }
+    int classificationBins =
+        int(floor(m_guideConfiguration.classificationFftSize *
+                  maxClassifierFrequency / m_parameters.sampleRate));
+    
+    BinSegmenter::Parameters segmenterParameters
+        (m_guideConfiguration.classificationFftSize,
+         classificationBins, m_parameters.sampleRate, 18);
+    
+    BinClassifier::Parameters classifierParameters
+        (classificationBins, 9, 1, 10, 2.0, 2.0);
+
+    if (isSingleWindowed()) {
+        classifierParameters.horizontalFilterLength = 7;
+    }
+
+    int inRingBufferSize = getWindowSourceSize() * 4;
+    int outRingBufferSize = getWindowSourceSize() * 4;
+
+    m_channelData.clear();
+    
+    for (int c = 0; c < m_parameters.channels; ++c) {
+        m_channelData.push_back(std::make_shared<ChannelData>
+                                (segmenterParameters,
+                                 classifierParameters,
+                                 m_guideConfiguration.longestFftSize,
+                                 getWindowSourceSize(),
+                                 inRingBufferSize,
+                                 outRingBufferSize));
+        for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+            const auto &band = m_guideConfiguration.fftBandLimits[b];
+            int fftSize = band.fftSize;
+            m_channelData[c]->scales[fftSize] =
+                std::make_shared<ChannelScaleData>
+                (fftSize, m_guideConfiguration.longestFftSize);
+        }
+        m_channelData[c]->guidance.phaseReset.present = true;
+        m_channelData[c]->guidance.phaseReset.f0 = 0.0;
+        m_channelData[c]->guidance.phaseReset.f1 = m_parameters.sampleRate / 2.0;
+    }
+
+    m_scaleData.clear();
+    
+    for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+        const auto &band = m_guideConfiguration.fftBandLimits[b];
+        int fftSize = band.fftSize;
+        GuidedPhaseAdvance::Parameters guidedParameters
+            (fftSize, m_parameters.sampleRate, m_parameters.channels,
+             isSingleWindowed());
+        m_scaleData[fftSize] = std::make_shared<ScaleData>
+            (guidedParameters, m_log);
+    }
+
+    createResamplers();
+
+    if (!m_pitchScale.is_lock_free()) {
+        m_log.log(0, "R3LiveShifter: WARNING: std::atomic<double> is not lock-free");
+    }
+}
+
+WindowType
+R3LiveShifter::ScaleData::analysisWindowShape()
+{
+    if (singleWindowMode) {
+        return HannWindow;
+    } else {
+        if (fftSize < 1024 || fftSize > 2048) return HannWindow;
+        else return NiemitaloForwardWindow;
+    }
+}
+
+int
+R3LiveShifter::ScaleData::analysisWindowLength()
+{
+    return fftSize;
+}
+
+WindowType
+R3LiveShifter::ScaleData::synthesisWindowShape()
+{
+    if (singleWindowMode) {
+        return HannWindow;
+    } else {
+        if (fftSize < 1024 || fftSize > 2048) return HannWindow;
+        else return NiemitaloReverseWindow;
+    }
+}
+
+int
+R3LiveShifter::ScaleData::synthesisWindowLength()
+{
+    if (singleWindowMode) {
+        return fftSize;
+    } else {
+        if (fftSize > 2048) return fftSize/2;
+        else return fftSize;
+    }
+}
+
+void
+R3LiveShifter::setPitchScale(double scale)
+{
+    m_log.log(2, "R3LiveShifter::setPitchScale", scale);
+
+    if (scale == m_pitchScale) return;
+    m_pitchScale = scale;
+
+    if (m_firstProcess) {
+        measureResamplerDelay();
+    }
+}
+
+void
+R3LiveShifter::setFormantScale(double scale)
+{
+    m_log.log(2, "R3LiveShifter::setFormantScale", scale);
+    m_formantScale = scale;
+}
+
+void
+R3LiveShifter::setFormantOption(RubberBandLiveShifter::Options options)
+{
+    int mask = (RubberBandLiveShifter::OptionFormantShifted |
+                RubberBandLiveShifter::OptionFormantPreserved);
+    m_parameters.options &= ~mask;
+    options &= mask;
+    m_parameters.options |= options;
+}
+
+void
+R3LiveShifter::createResamplers()
+{
+    Profiler profiler("R3LiveShifter::createResamplers");
+    
+    Resampler::Parameters resamplerParameters;
+    resamplerParameters.quality = Resampler::FastestTolerable;
+    resamplerParameters.initialSampleRate = m_parameters.sampleRate;
+    resamplerParameters.maxBufferSize = m_guideConfiguration.longestFftSize;
+    resamplerParameters.dynamism = Resampler::RatioOftenChanging;
+    resamplerParameters.ratioChange = Resampler::SuddenRatioChange;
+
+    int debug = m_log.getDebugLevel();
+    if (debug > 0) --debug;
+    resamplerParameters.debugLevel = debug;
+    
+    m_inResampler = std::unique_ptr<Resampler>
+        (new Resampler(resamplerParameters, m_parameters.channels));
+
+    m_outResampler = std::unique_ptr<Resampler>
+        (new Resampler(resamplerParameters, m_parameters.channels));
+
+    measureResamplerDelay();
+}
+
+void
+R3LiveShifter::measureResamplerDelay()
+{
+    // Delay in the sense that the resampler at first returns fewer
+    // samples than requested, not that the samples are delayed within
+    // the returned buffer relative to their positions at input. We
+    // actually add the delay ourselves in the first block because we
+    // need a fixed block size and the resampler doesn't return one.
+
+    int bs = getBlockSize();
+    std::vector<float> inbuf(bs * m_parameters.channels, 0.f);
+    auto outbuf = inbuf;
+    
+    int incount = m_inResampler->resampleInterleaved
+        (outbuf.data(), bs, inbuf.data(), bs, getInRatio(), false);
+    m_inResampler->reset();
+
+    int outcount = m_outResampler->resampleInterleaved
+        (outbuf.data(), bs, inbuf.data(), bs, getOutRatio(), false);
+    m_outResampler->reset();
+    
+    m_initialResamplerDelays = { bs - incount, bs - outcount };
+
+    m_log.log(1, "R3LiveShifter::measureResamplerDelay: inRatio, outRatio ", getInRatio(), getOutRatio());
+    m_log.log(1, "R3LiveShifter::measureResamplerDelay: measured delays ", m_initialResamplerDelays.first, m_initialResamplerDelays.second);
+}
+
+double
+R3LiveShifter::getPitchScale() const
+{
+    return m_pitchScale;
+}
+
+double
+R3LiveShifter::getFormantScale() const
+{
+    return m_formantScale;
+}
+
+size_t
+R3LiveShifter::getPreferredStartPad() const
+{
+    return 0;
+}
+
+size_t
+R3LiveShifter::getStartDelay() const
+{
+    int inDelay = getWindowSourceSize() + m_initialResamplerDelays.first;
+    int outDelay = int(floor(inDelay * getOutRatio())) + m_initialResamplerDelays.second;
+
+    int total = outDelay;
+    int bs = getBlockSize();
+    if (m_pitchScale > 1.0) {
+        total += bs * (m_pitchScale - 1.0);
+    } else if (m_pitchScale < 1.0) {
+        total -= bs * (1.0 / m_pitchScale - 1.0);
+    }
+
+    m_log.log(2, "R3LiveShifter::getStartDelay: inDelay, outDelay", inDelay, outDelay);
+    m_log.log(1, "R3LiveShifter::getStartDelay", total);
+    return total;
+}
+
+size_t
+R3LiveShifter::getChannelCount() const
+{
+    return m_parameters.channels;
+}
+
+void
+R3LiveShifter::reset()
+{
+    m_inResampler->reset();
+    m_outResampler->reset();
+
+    m_unityCount = 0;
+
+    m_prevInhop = m_limits.maxInhopWithReadahead / 2;
+    m_prevOuthop = int(round(m_prevInhop * m_pitchScale));
+    m_firstProcess = true;
+
+    for (auto &it : m_scaleData) {
+        it.second->guided.reset();
+    }
+
+    for (auto &cd : m_channelData) {
+        cd->reset();
+    }
+
+    measureResamplerDelay();
+}
+
+size_t
+R3LiveShifter::getBlockSize() const
+{
+    return 512;
+}
+
+void
+R3LiveShifter::shift(const float *const *input, float *const *output)
+{
+    Profiler profiler("R3LiveShifter::shift");
+
+    int incount = int(getBlockSize());
+    
+    m_log.log(2, "R3LiveShifter::shift: start of shift with incount", incount);
+    m_log.log(2, "R3LiveShifter::shift: initially in inbuf", m_channelData[0]->inbuf->getReadSpace());
+    m_log.log(2, "R3LiveShifter::shift: initially in outbuf", m_channelData[0]->outbuf->getReadSpace());
+
+    int pad = 0;
+    if (m_firstProcess) {
+        pad = getWindowSourceSize();
+        if (m_pitchScale > 1.0) {
+            pad = int(ceil(pad * m_pitchScale));
+        }
+        m_log.log(2, "R3LiveShifter::shift: extending input with pre-pad", incount, pad);
+        for (int c = 0; c < m_parameters.channels; ++c) {
+            m_channelData[c]->inbuf->zero(pad);
+        }
+    }        
+    
+    readIn(input);
+
+    double outRatio = getOutRatio();
+    int requiredInOutbuf = int(ceil(incount / outRatio));
+    generate(requiredInOutbuf);
+    
+    int got = readOut(output, incount);
+
+    if (got < incount) {
+        m_log.log(0, "R3LiveShifter::shift: ERROR: internal error: insufficient data at output (wanted, got)", incount, got);
+        for (int c = 0; c < m_parameters.channels; ++c) {
+            for (int i = got; i < incount; ++i) {
+                if (i > 0) output[c][i] = output[c][i-1] * 0.9f;
+                else output[c][i] = 0.f;
+            }
+        }
+    }
+
+    m_log.log(2, "R3LiveShifter::shift: end of process with incount", incount);
+    m_log.log(2, "R3LiveShifter::shift: remaining in inbuf", m_channelData[0]->inbuf->getReadSpace());
+    m_log.log(2, "R3LiveShifter::shift: remaining in outbuf", m_channelData[0]->outbuf->getReadSpace());
+    m_log.log(2, "R3LiveShifter::shift: returning", got);
+
+    m_firstProcess = false;
+}
+
+void
+R3LiveShifter::readIn(const float *const *input)
+{
+    int incount = int(getBlockSize());
+    
+    int ws = m_channelData[0]->inbuf->getWriteSpace();
+    if (ws < incount) {
+        m_log.log(0, "R3LiveShifter::process: ERROR: internal error: insufficient space in inbuf (wanted, got)", incount, ws);
+        return;
+    }
+        
+    for (int c = 0; c < m_parameters.channels; ++c) {
+        auto &cd = m_channelData.at(c);
+        m_channelAssembly.resampled[c] = cd->resampled.data();
+    }
+
+    if (useMidSide()) {
+        auto &c0 = m_channelData.at(0)->mixdown;
+        auto &c1 = m_channelData.at(1)->mixdown;
+        for (int i = 0; i < incount; ++i) {
+            float l = input[0][i];
+            float r = input[1][i];
+            float m = (l + r) / 2.f;
+            float s = (l - r) / 2.f;
+            c0[i] = m;
+            c1[i] = s;
+        }
+        m_channelAssembly.input[0] = m_channelData.at(0)->mixdown.data();
+        m_channelAssembly.input[1] = m_channelData.at(1)->mixdown.data();
+    } else {
+        for (int c = 0; c < m_parameters.channels; ++c) {
+            m_channelAssembly.input[c] = input[c];
+        }
+    }
+    
+    double inRatio = getInRatio();
+    m_log.log(2, "R3LiveShifter::readIn: ratio", inRatio);
+    
+    int resampleBufSize = int(m_channelData.at(0)->resampled.size());
+
+    int resampleOutput = m_inResampler->resample
+        (m_channelAssembly.resampled.data(),
+         resampleBufSize,
+         m_channelAssembly.input.data(),
+         incount,
+         inRatio,
+         false);
+
+    m_log.log(2, "R3LiveShifter::readIn: writing to inbuf from resampled data, former read space and samples being added", m_channelData[0]->inbuf->getReadSpace(), resampleOutput);
+
+    if (m_firstProcess) {
+        int expected = floor(incount * inRatio);
+        if (resampleOutput < expected) {
+            m_log.log(2, "R3LiveShifter::readIn: resampler left us short on first process, pre-padding output: expected and obtained", expected, resampleOutput);
+            for (int c = 0; c < m_parameters.channels; ++c) {
+                m_channelData[c]->inbuf->zero(expected - resampleOutput);
+            }
+        }
+    }
+    
+    for (int c = 0; c < m_parameters.channels; ++c) {
+        m_channelData[c]->inbuf->write
+            (m_channelData.at(c)->resampled.data(),
+             resampleOutput);
+    }
+}
+
+void
+R3LiveShifter::generate(int requiredInOutbuf)
+{
+    Profiler profiler("R3LiveShifter::generate");
+
+    auto &cd0 = m_channelData.at(0);
+    int alreadyGenerated = cd0->outbuf->getReadSpace();
+    if (alreadyGenerated >= requiredInOutbuf) {
+        m_log.log(2, "R3LiveShifter::generate: have already generated required count", alreadyGenerated, requiredInOutbuf);
+        return;
+    }
+
+    m_log.log(2, "R3LiveShifter::generate: alreadyGenerated, requiredInOutbuf", alreadyGenerated, requiredInOutbuf);
+
+    int toGenerate = requiredInOutbuf - alreadyGenerated;
+
+    int channels = m_parameters.channels;
+
+    int ws = getWindowSourceSize();
+
+    // We always leave at least ws in inbuf, and this function is
+    // called after some input has just been written to inbuf, so we
+    // must have more than ws samples in there.
+
+    int atInput = cd0->inbuf->getReadSpace();
+    if (atInput <= ws) {
+        m_log.log(2, "R3LiveShifter::generate: insufficient samples at input: have and require more than", atInput, ws);
+        return;
+    }
+
+    m_log.log(2, "R3LiveShifter::generate: atInput, toLeave", atInput, ws);
+
+    int toConsume = atInput - ws;
+
+    m_log.log(2, "R3LiveShifter::generate: toConsume, toGenerate", toConsume, toGenerate);
+
+    int indicativeInhop = m_limits.maxInhopWithReadahead;
+    int indicativeOuthop = m_limits.maxPreferredOuthop;
+    
+    int minHopsAtInput = 1 + (toConsume - 1) / indicativeInhop;
+    int minHopsAtOutput = 1 + (toGenerate - 1) / indicativeOuthop;
+    
+    int hops = std::max(minHopsAtInput, minHopsAtOutput);
+
+    m_log.log(2, "R3LiveShifter::generate: indicative inhop, outhop", indicativeInhop, indicativeOuthop);
+    m_log.log(2, "R3LiveShifter::generate: minHopsAtInput, minHopsAtOutput", minHopsAtInput, minHopsAtOutput);
+    m_log.log(2, "R3LiveShifter::generate: hops", hops);
+
+    for (int hop = 0; hop < hops; ++hop) {
+
+        Profiler profiler2("R3LiveShifter::generate/loop");
+
+        if (toConsume <= 0) {
+            m_log.log(2, "R3LiveShifter::generate: ERROR: toConsume is zero at top of loop, hop and hops", hop, hops);
+            break;
+        }
+        
+        int inhop = 1 + (toConsume - 1) / hops;
+        int outhop = 1 + (toGenerate - 1) / hops;
+
+        if (inhop > toConsume) {
+            inhop = toConsume;
+        }
+        
+        m_log.log(2, "R3LiveShifter::generate: inhop, outhop", inhop, outhop);
+        
+        // Now inhop is the distance by which the input stream will be
+        // advanced after our current frame has been read, and outhop
+        // is the distance by which the output will be advanced after
+        // it has been emitted; m_prevInhop and m_prevOuthop are the
+        // corresponding values the last time a frame was processed.
+        //
+        // Our phase adjustments need to be based on the distances we
+        // have advanced the input and output since the previous
+        // frame, not the distances we are about to advance them, so
+        // they use the m_prev values.
+
+        if (inhop != m_prevInhop) {
+            m_log.log(2, "R3LiveShifter::generate: change in inhop", m_prevInhop, inhop);
+        }
+        if (outhop != m_prevOuthop) {
+            m_log.log(2, "R3LiveShifter::generate: change in outhop", m_prevOuthop, outhop);
+        }
+        
+        m_log.log(2, "R3LiveShifter::generate: write space and outhop", cd0->outbuf->getWriteSpace(), outhop);
+
+        // NB our ChannelData, ScaleData, and ChannelScaleData maps
+        // contain shared_ptrs; whenever we retain one of them in a
+        // variable, we do so by reference to avoid copying the
+        // shared_ptr (as that is not realtime safe). Same goes for
+        // the map iterators
+
+        // Analysis
+        
+        for (int c = 0; c < channels; ++c) {
+            analyseChannel(c, inhop, m_prevInhop, m_prevOuthop);
+        }
+
+        // Phase update. This is synchronised across all channels
+        
+        for (auto &it : m_channelData[0]->scales) {
+            int fftSize = it.first;
+            for (int c = 0; c < channels; ++c) {
+                auto &cd = m_channelData.at(c);
+                auto &scale = cd->scales.at(fftSize);
+                m_channelAssembly.mag[c] = scale->mag.data();
+                m_channelAssembly.phase[c] = scale->phase.data();
+                m_channelAssembly.prevMag[c] = scale->prevMag.data();
+                m_channelAssembly.guidance[c] = &cd->guidance;
+                m_channelAssembly.outPhase[c] = scale->advancedPhase.data();
+            }
+            m_scaleData.at(fftSize)->guided.advance
+                (m_channelAssembly.outPhase.data(),
+                 m_channelAssembly.mag.data(),
+                 m_channelAssembly.phase.data(),
+                 m_channelAssembly.prevMag.data(),
+                 m_guideConfiguration,
+                 m_channelAssembly.guidance.data(),
+                 useMidSide(),
+                 m_prevInhop,
+                 m_prevOuthop);
+        }
+
+        for (int c = 0; c < channels; ++c) {
+            adjustPreKick(c);
+        }
+        
+        // Resynthesis
+        
+        for (int c = 0; c < channels; ++c) {
+            synthesiseChannel(c, outhop, false);
+        }
+
+        // Emit
+
+        int writeCount = outhop;
+        int advanceCount = inhop;
+        
+        for (int c = 0; c < channels; ++c) {
+            auto &cd = m_channelData.at(c);
+            cd->outbuf->write(cd->mixdown.data(), writeCount);
+            cd->inbuf->skip(advanceCount);
+        }
+
+        m_log.log(2, "R3LiveShifter::generate: writing and advancing", writeCount, advanceCount);
+
+        m_prevInhop = inhop;
+        m_prevOuthop = outhop;
+    }
+
+    m_log.log(2, "R3LiveShifter::generate: returning, now have generated", cd0->outbuf->getReadSpace());
+}
+
+int
+R3LiveShifter::readOut(float *const *output, int outcount)
+{
+    double outRatio = getOutRatio();
+    m_log.log(2, "R3LiveShifter::readOut: outcount and ratio", outcount, outRatio);
+
+    int resampledCount = 0;
+    bool fillingTail = false;
+
+    while (resampledCount < outcount) {
+
+        int fromOutbuf;
+
+        if (fillingTail) {
+            fromOutbuf = 1;
+        } else {
+            fromOutbuf = int(floor(outcount / outRatio));
+            if (fromOutbuf == 0) {
+                fromOutbuf = 1;
+            }
+        }
+        
+        m_log.log(2, "R3LiveShifter::readOut: fillingTail and fromOutbuf", fillingTail, fromOutbuf);
+
+        int got = fromOutbuf;
+    
+        for (int c = 0; c < m_parameters.channels; ++c) {
+            auto &cd = m_channelData.at(c);
+            int available = cd->outbuf->getReadSpace();
+            int gotHere = cd->outbuf->read
+                (cd->resampled.data(), std::min(got, available));
+            if (gotHere < got) {
+                if (c > 0) {
+                    m_log.log(0, "R3LiveShifter::readOut: WARNING: channel imbalance detected");
+                }
+            }
+            got = std::min(got, std::max(gotHere, 0));
+        }
+
+        m_log.log(2, "R3LiveShifter::readOut: requested and got from outbufs", fromOutbuf, got);
+        m_log.log(2, "R3LiveShifter::readOut: leaving behind", m_channelData.at(0)->outbuf->getReadSpace());
+
+        for (int c = 0; c < m_parameters.channels; ++c) {
+            auto &cd = m_channelData.at(c);
+            m_channelAssembly.resampled[c] = cd->resampled.data();
+            m_channelAssembly.mixdown[c] = output[c] + resampledCount;
+        }
+
+        auto resampledHere = m_outResampler->resample
+            (m_channelAssembly.mixdown.data(),
+             outcount - resampledCount,
+             m_channelAssembly.resampled.data(),
+             got,
+             outRatio,
+             false);
+
+        m_log.log(2, "R3LiveShifter::readOut: resampledHere", resampledHere);
+
+        if (got == 0 && resampledHere == 0) {
+            m_log.log(2, "R3LiveShifter::readOut: made no progress, finishing");
+            break;
+        }            
+        
+        resampledCount += resampledHere;
+
+        fillingTail = true;
+    }
+    
+    if (useMidSide()) {
+        for (int i = 0; i < resampledCount; ++i) {
+            float m = output[0][i];
+            float s = output[1][i];
+            float l = m + s;
+            float r = m - s;
+            output[0][i] = l;
+            output[1][i] = r;
+        }
+    }
+
+    m_log.log(2, "R3LiveShifter::readOut: resampled to", resampledCount);
+
+    if (resampledCount < outcount) {
+        if (m_firstProcess) {
+            m_log.log(2, "R3LiveShifter::readOut: resampler left us short on first process, pre-padding output: expected and obtained", outcount, resampledCount);
+            int prepad = outcount - resampledCount;
+            for (int c = 0; c < m_parameters.channels; ++c) {
+                v_move(output[c] + prepad, output[c], resampledCount);
+                v_zero(output[c], prepad);
+            }
+            resampledCount = outcount;
+        } else {
+            m_log.log(0, "R3LiveShifter::readOut: WARNING: Failed to obtain enough samples from resampler", resampledCount, outcount);
+        }
+    }
+
+    m_log.log(2, "R3LiveShifter::readOut: returning", resampledCount);
+    
+    return resampledCount;
+}
+
+void
+R3LiveShifter::analyseChannel(int c, int inhop, int prevInhop, int prevOuthop)
+{
+    Profiler profiler("R3LiveShifter::analyseChannel");
+    
+    auto &cd = m_channelData.at(c);
+
+    int sourceSize = cd->windowSource.size();
+    process_t *buf = cd->windowSource.data();
+
+    int readSpace = cd->inbuf->getReadSpace();
+    if (readSpace < sourceSize) {
+        cd->inbuf->peek(buf, readSpace);
+        v_zero(buf + readSpace, sourceSize - readSpace);
+    } else {
+        cd->inbuf->peek(buf, sourceSize);
+    }
+    
+    // We have an unwindowed time-domain frame in buf that is as long
+    // as required for the union of all FFT sizes and readahead
+    // hops. Populate the various sizes from it with aligned centres,
+    // windowing as we copy. The classification scale is handled
+    // separately because it has readahead, so skip it here. (In
+    // single-window mode that means we do nothing here, since the
+    // classification scale is the only one.)
+
+    int longest = m_guideConfiguration.longestFftSize;
+    int classify = m_guideConfiguration.classificationFftSize;
+
+    for (auto &it: cd->scales) {
+        int fftSize = it.first;
+        if (fftSize == classify) continue;
+        int offset = (longest - fftSize) / 2;
+        m_scaleData.at(fftSize)->analysisWindow.cut
+            (buf + offset, it.second->timeDomain.data());
+    }
+
+    auto &classifyScale = cd->scales.at(classify);
+    ClassificationReadaheadData &readahead = cd->readahead;
+    bool copyFromReadahead = false;
+    
+    if (m_useReadahead) {
+        
+        // The classification scale has a one-hop readahead, so
+        // populate the readahead from further down the long
+        // unwindowed frame.
+
+        m_scaleData.at(classify)->analysisWindow.cut
+            (buf + (longest - classify) / 2 + inhop,
+             readahead.timeDomain.data());
+
+        // If inhop has changed since the previous frame, we must
+        // populate the classification scale (but for
+        // analysis/resynthesis rather than classification) anew
+        // rather than reuse the previous frame's readahead.
+
+        copyFromReadahead = cd->haveReadahead;
+        if (inhop != prevInhop) copyFromReadahead = false;
+    }
+    
+    if (!copyFromReadahead) {
+        m_scaleData.at(classify)->analysisWindow.cut
+            (buf + (longest - classify) / 2,
+             classifyScale->timeDomain.data());
+    }
+
+    // FFT shift, forward FFT, and carry out cartesian-polar
+    // conversion for each FFT size.
+
+    // For the classification scale we need magnitudes for the full
+    // range (polar only in a subset) and we operate in the readahead,
+    // pulling current values from the existing readahead (except
+    // where the inhop has changed as above, in which case we need to
+    // do both readahead and current)
+
+    if (m_useReadahead) {
+
+        if (copyFromReadahead) {
+            v_copy(classifyScale->mag.data(),
+                   readahead.mag.data(),
+                   classifyScale->bufSize);
+            v_copy(classifyScale->phase.data(),
+                   readahead.phase.data(),
+                   classifyScale->bufSize);
+        }
+
+        v_fftshift(readahead.timeDomain.data(), classify);
+        m_scaleData.at(classify)->fft.forward(readahead.timeDomain.data(),
+                                              classifyScale->real.data(),
+                                              classifyScale->imag.data());
+
+        for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+            const auto &band = m_guideConfiguration.fftBandLimits[b];
+            if (band.fftSize == classify) {
+                ToPolarSpec spec;
+                spec.magFromBin = 0;
+                spec.magBinCount = classify/2 + 1;
+                spec.polarFromBin = band.b0min;
+                spec.polarBinCount = band.b1max - band.b0min + 1;
+                convertToPolar(readahead.mag.data(),
+                               readahead.phase.data(),
+                               classifyScale->real.data(),
+                               classifyScale->imag.data(),
+                               spec);
+                    
+                v_scale(classifyScale->mag.data(),
+                        1.0 / double(classify),
+                        classifyScale->mag.size());
+                break;
+            }
+        }
+
+        cd->haveReadahead = true;
+    }
+
+    // For the others (and the classify as well, if the inhop has
+    // changed or we aren't using readahead or haven't filled the
+    // readahead yet) we operate directly in the scale data and
+    // restrict the range for cartesian-polar conversion
+            
+    for (auto &it: cd->scales) {
+        int fftSize = it.first;
+        if (fftSize == classify && copyFromReadahead) {
+            continue;
+        }
+        
+        auto &scale = it.second;
+        
+        v_fftshift(scale->timeDomain.data(), fftSize);
+
+        m_scaleData.at(fftSize)->fft.forward(scale->timeDomain.data(),
+                                             scale->real.data(),
+                                             scale->imag.data());
+
+        for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+            const auto &band = m_guideConfiguration.fftBandLimits[b];
+            if (band.fftSize == fftSize) {
+
+                ToPolarSpec spec;
+
+                // For the classify scale we always want the full
+                // range, as all the magnitudes (though not
+                // necessarily all phases) are potentially relevant to
+                // classification and formant analysis. But this case
+                // here only happens if we don't copyFromReadahead -
+                // the normal case is above and, er, copies from the
+                // previous readahead.
+                if (fftSize == classify) {
+                    spec.magFromBin = 0;
+                    spec.magBinCount = classify/2 + 1;
+                    spec.polarFromBin = band.b0min;
+                    spec.polarBinCount = band.b1max - band.b0min + 1;
+                } else {
+                    spec.magFromBin = band.b0min;
+                    spec.magBinCount = band.b1max - band.b0min + 1;
+                    spec.polarFromBin = spec.magFromBin;
+                    spec.polarBinCount = spec.magBinCount;
+                }
+
+                convertToPolar(scale->mag.data(),
+                               scale->phase.data(),
+                               scale->real.data(),
+                               scale->imag.data(),
+                               spec);
+
+                v_scale(scale->mag.data() + spec.magFromBin,
+                        1.0 / double(fftSize),
+                        spec.magBinCount);
+                
+                break;
+            }
+        }
+    }
+
+    if (m_parameters.options & RubberBandLiveShifter::OptionFormantPreserved) {
+        analyseFormant(c);
+        adjustFormant(c);
+    }
+        
+    // Use the classification scale to get a bin segmentation and
+    // calculate the adaptive frequency guide for this channel
+
+    v_copy(cd->classification.data(), cd->nextClassification.data(),
+           cd->classification.size());
+
+    if (m_useReadahead) {
+        cd->classifier->classify(readahead.mag.data(),
+                                 cd->nextClassification.data());
+    } else {
+        cd->classifier->classify(classifyScale->mag.data(),
+                                 cd->nextClassification.data());
+    }
+
+    cd->prevSegmentation = cd->segmentation;
+    cd->segmentation = cd->nextSegmentation;
+    cd->nextSegmentation = cd->segmenter->segment(cd->nextClassification.data());
+/*
+    if (c == 0) {
+        double pb = cd->nextSegmentation.percussiveBelow;
+        double pa = cd->nextSegmentation.percussiveAbove;
+        double ra = cd->nextSegmentation.residualAbove;
+        int pbb = binForFrequency(pb, classify, m_parameters.sampleRate);
+        int pab = binForFrequency(pa, classify, m_parameters.sampleRate);
+        int rab = binForFrequency(ra, classify, m_parameters.sampleRate);
+        std::cout << "pb = " << pb << ", pbb = " << pbb << std::endl;
+        std::cout << "pa = " << pa << ", pab = " << pab << std::endl;
+        std::cout << "ra = " << ra << ", rab = " << rab << std::endl;
+        std::cout << "s:";
+        for (int i = 0; i <= classify/2; ++i) {
+            if (i > 0) std::cout << ",";
+            if (i < pbb || (i >= pab && i <= rab)) {
+                std::cout << "1";
+            } else {
+                std::cout << "0";
+            }
+        }
+        std::cout << std::endl;
+    }
+*/
+
+    double ratio = m_pitchScale;
+
+    if (fabs(ratio - 1.0) < 1.0e-7) {
+        ++m_unityCount;
+    } else {
+        m_unityCount = 0;
+    }
+
+    bool tighterChannelLock =
+        m_parameters.options & RubberBandLiveShifter::OptionChannelsTogether;
+
+    double magMean = v_mean(classifyScale->mag.data() + 1, classify/2);
+
+    bool resetOnSilence = true;
+    if (useMidSide() && c == 1) {
+        // Do not phase reset on silence in the side channel - the
+        // reset is propagated across to the mid channel, giving
+        // constant resets for e.g. mono material in a stereo
+        // configuration
+        resetOnSilence = false;
+    }
+    
+    if (m_useReadahead) {
+        m_guide.updateGuidance(ratio,
+                               prevOuthop,
+                               classifyScale->mag.data(),
+                               classifyScale->prevMag.data(),
+                               cd->readahead.mag.data(),
+                               cd->segmentation,
+                               cd->prevSegmentation,
+                               cd->nextSegmentation,
+                               magMean,
+                               m_unityCount,
+                               true,
+                               tighterChannelLock,
+                               resetOnSilence,
+                               cd->guidance);
+    } else {
+        m_guide.updateGuidance(ratio,
+                               prevOuthop,
+                               classifyScale->prevMag.data(),
+                               classifyScale->prevMag.data(),
+                               classifyScale->mag.data(),
+                               cd->segmentation,
+                               cd->prevSegmentation,
+                               cd->nextSegmentation,
+                               magMean,
+                               m_unityCount,
+                               true,
+                               tighterChannelLock,
+                               resetOnSilence,
+                               cd->guidance);
+    }
+    
+/*
+    if (c == 0) {
+        if (cd->guidance.kick.present) {
+            std::cout << "k:2" << std::endl;
+        } else if (cd->guidance.preKick.present) {
+            std::cout << "k:1" << std::endl;
+        } else {
+            std::cout << "k:0" << std::endl;
+        }
+    }
+*/
+}
+
+void
+R3LiveShifter::analyseFormant(int c)
+{
+    Profiler profiler("R3LiveShifter::analyseFormant");
+
+    auto &cd = m_channelData.at(c);
+    auto &f = *cd->formant;
+
+    int fftSize = f.fftSize;
+    int binCount = fftSize/2 + 1;
+    
+    auto &scale = cd->scales.at(fftSize);
+    auto &scaleData = m_scaleData.at(fftSize);
+
+    scaleData->fft.inverseCepstral(scale->mag.data(), f.cepstra.data());
+    
+    int cutoff = int(floor(m_parameters.sampleRate / 650.0));
+    if (cutoff < 1) cutoff = 1;
+
+    f.cepstra[0] /= 2.0;
+    f.cepstra[cutoff-1] /= 2.0;
+    for (int i = cutoff; i < fftSize; ++i) {
+        f.cepstra[i] = 0.0;
+    }
+    v_scale(f.cepstra.data(), 1.0 / double(fftSize), cutoff);
+
+    scaleData->fft.forward(f.cepstra.data(), f.envelope.data(), f.spare.data());
+
+    v_exp(f.envelope.data(), binCount);
+    v_square(f.envelope.data(), binCount);
+
+    for (int i = 0; i < binCount; ++i) {
+        if (f.envelope[i] > 1.0e10) f.envelope[i] = 1.0e10;
+    }
+}
+
+void
+R3LiveShifter::adjustFormant(int c)
+{
+    Profiler profiler("R3LiveShifter::adjustFormant");
+
+    auto &cd = m_channelData.at(c);
+        
+    for (auto &it : cd->scales) {
+        
+        int fftSize = it.first;
+        auto &scale = it.second;
+
+        int highBin = int(floor(fftSize * 10000.0 / m_parameters.sampleRate));
+        process_t targetFactor = process_t(cd->formant->fftSize) / process_t(fftSize);
+        process_t formantScale = m_formantScale;
+        if (formantScale == 0.0) formantScale = 1.0 / m_pitchScale;
+        process_t sourceFactor = targetFactor / formantScale;
+        process_t maxRatio = 60.0;
+        process_t minRatio = 1.0 / maxRatio;
+
+        for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+            const auto &band = m_guideConfiguration.fftBandLimits[b];
+            if (band.fftSize != fftSize) continue;
+            for (int i = band.b0min; i < band.b1max && i < highBin; ++i) {
+                process_t source = cd->formant->envelopeAt(i * sourceFactor);
+                process_t target = cd->formant->envelopeAt(i * targetFactor);
+                if (target > 0.0) {
+                    process_t ratio = source / target;
+                    if (ratio < minRatio) ratio = minRatio;
+                    if (ratio > maxRatio) ratio = maxRatio;
+                    scale->mag[i] *= ratio;
+                }
+            }
+        }
+    }
+}
+
+void
+R3LiveShifter::adjustPreKick(int c)
+{
+    if (isSingleWindowed()) return;
+    
+    Profiler profiler("R3LiveShifter::adjustPreKick");
+
+    auto &cd = m_channelData.at(c);
+    auto fftSize = cd->guidance.fftBands[0].fftSize;
+    if (cd->guidance.preKick.present) {
+        auto &scale = cd->scales.at(fftSize);
+        int from = binForFrequency(cd->guidance.preKick.f0,
+                                   fftSize, m_parameters.sampleRate);
+        int to = binForFrequency(cd->guidance.preKick.f1,
+                                 fftSize, m_parameters.sampleRate);
+        for (int i = from; i <= to; ++i) {
+            process_t diff = scale->mag[i] - scale->prevMag[i];
+            if (diff > 0.0) {
+                scale->pendingKick[i] = diff;
+                scale->mag[i] -= diff;
+            }
+        }
+    } else if (cd->guidance.kick.present) {
+        auto &scale = cd->scales.at(fftSize);
+        int from = binForFrequency(cd->guidance.preKick.f0,
+                                   fftSize, m_parameters.sampleRate);
+        int to = binForFrequency(cd->guidance.preKick.f1,
+                                 fftSize, m_parameters.sampleRate);
+        for (int i = from; i <= to; ++i) {
+            scale->mag[i] += scale->pendingKick[i];
+            scale->pendingKick[i] = 0.0;
+        }
+    }                
+}
+
+void
+R3LiveShifter::synthesiseChannel(int c, int outhop, bool draining)
+{
+    Profiler profiler("R3LiveShifter::synthesiseChannel");
+    
+    int longest = m_guideConfiguration.longestFftSize;
+
+    auto &cd = m_channelData.at(c);
+
+    for (int b = 0; b < cd->guidance.fftBandCount; ++b) {
+
+        const auto &band = cd->guidance.fftBands[b];
+        int fftSize = band.fftSize;
+        
+        auto &scale = cd->scales.at(fftSize);
+        auto &scaleData = m_scaleData.at(fftSize);
+
+        // copy to prevMag before filtering
+        v_copy(scale->prevMag.data(),
+               scale->mag.data(),
+               scale->bufSize);
+
+        process_t winscale = process_t(outhop) / scaleData->windowScaleFactor;
+
+        m_log.log(2, "R3LiveShifter::synthesiseChannel: outhop and winscale", outhop, winscale);
+        
+        // The frequency filter is applied naively in the frequency
+        // domain. Aliasing is reduced by the shorter resynthesis
+        // window. We resynthesise each scale individually, then sum -
+        // it's easier to manage scaling for in situations with a
+        // varying resynthesis hop
+            
+        int lowBin = binForFrequency(band.f0, fftSize, m_parameters.sampleRate);
+        int highBin = binForFrequency(band.f1, fftSize, m_parameters.sampleRate);
+        if (highBin % 2 == 0 && highBin > 0) --highBin;
+
+        int n = scale->mag.size();
+        if (lowBin >= n) lowBin = n - 1;
+        if (highBin >= n) highBin = n - 1;
+        if (highBin < lowBin) highBin = lowBin;
+        
+        if (lowBin > 0) {
+            v_zero(scale->real.data(), lowBin);
+            v_zero(scale->imag.data(), lowBin);
+        }
+
+        v_scale(scale->mag.data() + lowBin, winscale, highBin - lowBin);
+
+        v_polar_to_cartesian(scale->real.data() + lowBin,
+                             scale->imag.data() + lowBin,
+                             scale->mag.data() + lowBin,
+                             scale->advancedPhase.data() + lowBin,
+                             highBin - lowBin);
+        
+        if (highBin < scale->bufSize) {
+            v_zero(scale->real.data() + highBin, scale->bufSize - highBin);
+            v_zero(scale->imag.data() + highBin, scale->bufSize - highBin);
+        }
+
+        scaleData->fft.inverse(scale->real.data(),
+                               scale->imag.data(),
+                               scale->timeDomain.data());
+        
+        v_fftshift(scale->timeDomain.data(), fftSize);
+
+        // Synthesis window may be shorter than analysis window, so
+        // copy and cut only from the middle of the time-domain frame;
+        // and the accumulator length always matches the longest FFT
+        // size, so as to make mixing straightforward, so there is an
+        // additional offset needed for the target
+                
+        int synthesisWindowSize = scaleData->synthesisWindow.getSize();
+        int fromOffset = (fftSize - synthesisWindowSize) / 2;
+        int toOffset = (longest - synthesisWindowSize) / 2;
+
+        scaleData->synthesisWindow.cutAndAdd
+            (scale->timeDomain.data() + fromOffset,
+             scale->accumulator.data() + toOffset);
+    }
+
+    // Mix this channel and move the accumulator along
+            
+    float *mixptr = cd->mixdown.data();
+    v_zero(mixptr, outhop);
+
+    for (auto &it : cd->scales) {
+        auto &scale = it.second;
+
+        process_t *accptr = scale->accumulator.data();
+        for (int i = 0; i < outhop; ++i) {
+            mixptr[i] += float(accptr[i]);
+        }
+
+        int n = scale->accumulator.size() - outhop;
+        v_move(accptr, accptr + outhop, n);
+        v_zero(accptr + n, outhop);
+
+        if (draining) {
+            if (scale->accumulatorFill > outhop) {
+                auto newFill = scale->accumulatorFill - outhop;
+                m_log.log(2, "draining: reducing accumulatorFill from, to", scale->accumulatorFill, newFill);
+                scale->accumulatorFill = newFill;
+            } else {
+                scale->accumulatorFill = 0;
+            }
+        } else {
+            scale->accumulatorFill = scale->accumulator.size();
+        }
+    }
+}
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/R3LiveShifter.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/R3LiveShifter.h
@@ -1,0 +1,423 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_R3_LIVE_SHIFTERIMPL_H
+#define RUBBERBAND_R3_LIVE_SHIFTERIMPL_H
+
+#include "BinSegmenter.h"
+#include "Guide.h"
+#include "Peak.h"
+#include "PhaseAdvance.h"
+
+#include "../common/Resampler.h"
+#include "../common/FFT.h"
+#include "../common/FixedVector.h"
+#include "../common/Allocators.h"
+#include "../common/Window.h"
+#include "../common/VectorOpsComplex.h"
+#include "../common/Log.h"
+
+#include "../../rubberband/RubberBandLiveShifter.h"
+
+#include <map>
+#include <memory>
+#include <atomic>
+
+namespace RubberBand
+{
+
+class R3LiveShifter
+{
+public:
+    struct Parameters {
+        double sampleRate;
+        int channels;
+        RubberBandLiveShifter::Options options;
+        Parameters(double _sampleRate, int _channels,
+                   RubberBandLiveShifter::Options _options) :
+            sampleRate(_sampleRate), channels(_channels), options(_options) { }
+    };
+    
+    R3LiveShifter(Parameters parameters, Log log);
+    ~R3LiveShifter() { }
+
+    void reset();
+    
+    void setPitchScale(double scale);
+    void setFormantScale(double scale);
+
+    double getPitchScale() const;
+    double getFormantScale() const;
+
+    void setFormantOption(RubberBandLiveShifter::Options);
+
+    size_t getBlockSize() const;
+    void shift(const float *const *input, float *const *output);
+
+    size_t getPreferredStartPad() const;
+    size_t getStartDelay() const;
+    
+    size_t getChannelCount() const;
+    
+    void setDebugLevel(int level) {
+        m_log.setDebugLevel(level);
+        for (auto &sd : m_scaleData) {
+            sd.second->guided.setDebugLevel(level);
+        }
+        m_guide.setDebugLevel(level);
+    }
+
+protected:
+    struct Limits {
+        int minPreferredOuthop;
+        int maxPreferredOuthop;
+        int minInhop;
+        int maxInhopWithReadahead;
+        int maxInhop;
+        Limits(RubberBandLiveShifter::Options, double rate) :
+            // commented values are results when rate = 44100 or 48000
+            minInhop(1)
+        {
+            minPreferredOuthop = roundUpDiv(rate, 256); // 256
+            maxPreferredOuthop = (roundUpDiv(rate, 128) * 5) / 4; // 640
+            maxInhopWithReadahead = roundUpDiv(rate, 128); // 512
+            maxInhop = (roundUpDiv(rate, 64) * 3) / 2; // 1536
+        }
+    };
+    
+    struct ClassificationReadaheadData {
+        FixedVector<process_t> timeDomain;
+        FixedVector<process_t> mag;
+        FixedVector<process_t> phase;
+        ClassificationReadaheadData(int _fftSize) :
+            timeDomain(_fftSize, 0.f),
+            mag(_fftSize/2 + 1, 0.f),
+            phase(_fftSize/2 + 1, 0.f)
+        { }
+
+    private:
+        ClassificationReadaheadData(const ClassificationReadaheadData &) =delete;
+        ClassificationReadaheadData &operator=(const ClassificationReadaheadData &) =delete;
+    };
+    
+    struct ChannelScaleData {
+        int fftSize;
+        int bufSize; // size of every freq-domain array here: fftSize/2 + 1
+        FixedVector<process_t> timeDomain;
+        FixedVector<process_t> real;
+        FixedVector<process_t> imag;
+        FixedVector<process_t> mag;
+        FixedVector<process_t> phase;
+        FixedVector<process_t> advancedPhase;
+        FixedVector<process_t> prevMag;
+        FixedVector<process_t> pendingKick;
+        FixedVector<process_t> accumulator;
+        int accumulatorFill;
+
+        ChannelScaleData(int _fftSize, int _longestFftSize) :
+            fftSize(_fftSize),
+            bufSize(fftSize/2 + 1),
+            timeDomain(fftSize, 0.f),
+            real(bufSize, 0.f),
+            imag(bufSize, 0.f),
+            mag(bufSize, 0.f),
+            phase(bufSize, 0.f),
+            advancedPhase(bufSize, 0.f),
+            prevMag(bufSize, 0.f),
+            pendingKick(bufSize, 0.f),
+            accumulator(_longestFftSize, 0.f),
+            accumulatorFill(0)
+        { }
+
+        void reset() {
+            v_zero(prevMag.data(), prevMag.size());
+            v_zero(pendingKick.data(), pendingKick.size());
+            v_zero(accumulator.data(), accumulator.size());
+            accumulatorFill = 0;
+        }
+
+    private:
+        ChannelScaleData(const ChannelScaleData &) =delete;
+        ChannelScaleData &operator=(const ChannelScaleData &) =delete;
+    };
+
+    struct FormantData {
+        int fftSize;
+        FixedVector<process_t> cepstra;
+        FixedVector<process_t> envelope;
+        FixedVector<process_t> spare;
+
+        FormantData(int _fftSize) :
+            fftSize(_fftSize),
+            cepstra(_fftSize, 0.0),
+            envelope(_fftSize/2 + 1, 0.0),
+            spare(_fftSize/2 + 1, 0.0) { }
+
+        process_t envelopeAt(process_t bin) const {
+            int b0 = int(floor(bin)), b1 = int(ceil(bin));
+            if (b0 < 0 || b0 > fftSize/2) {
+                return 0.0;
+            } else if (b1 == b0 || b1 > fftSize/2) {
+                return envelope.at(b0);
+            } else {
+                process_t diff = bin - process_t(b0);
+                return envelope.at(b0) * (1.0 - diff) + envelope.at(b1) * diff;
+            }
+        }
+    };
+
+    struct ChannelData {
+        std::map<int, std::shared_ptr<ChannelScaleData>> scales;
+        FixedVector<process_t> windowSource;
+        ClassificationReadaheadData readahead;
+        bool haveReadahead;
+        std::unique_ptr<BinClassifier> classifier;
+        FixedVector<BinClassifier::Classification> classification;
+        FixedVector<BinClassifier::Classification> nextClassification;
+        std::unique_ptr<BinSegmenter> segmenter;
+        BinSegmenter::Segmentation segmentation;
+        BinSegmenter::Segmentation prevSegmentation;
+        BinSegmenter::Segmentation nextSegmentation;
+        Guide::Guidance guidance;
+        FixedVector<float> mixdown;
+        FixedVector<float> resampled;
+        std::unique_ptr<RingBuffer<float>> inbuf;
+        std::unique_ptr<RingBuffer<float>> outbuf;
+        std::unique_ptr<FormantData> formant;
+        ChannelData(BinSegmenter::Parameters segmenterParameters,
+                    BinClassifier::Parameters classifierParameters,
+                    int longestFftSize,
+                    int windowSourceSize,
+                    int inRingBufferSize,
+                    int outRingBufferSize) :
+            scales(),
+            windowSource(windowSourceSize, 0.0),
+            readahead(segmenterParameters.fftSize),
+            haveReadahead(false),
+            classifier(new BinClassifier(classifierParameters)),
+            classification(classifierParameters.binCount,
+                           BinClassifier::Classification::Residual),
+            nextClassification(classifierParameters.binCount,
+                               BinClassifier::Classification::Residual),
+            segmenter(new BinSegmenter(segmenterParameters)),
+            segmentation(), prevSegmentation(), nextSegmentation(),
+            mixdown(longestFftSize, 0.f),
+            resampled(outRingBufferSize, 0.f),
+            inbuf(new RingBuffer<float>(inRingBufferSize)),
+            outbuf(new RingBuffer<float>(outRingBufferSize)),
+            formant(new FormantData(segmenterParameters.fftSize)) { }
+        void reset() {
+            haveReadahead = false;
+            classifier->reset();
+            segmentation = BinSegmenter::Segmentation();
+            prevSegmentation = BinSegmenter::Segmentation();
+            nextSegmentation = BinSegmenter::Segmentation();
+            for (size_t i = 0; i < nextClassification.size(); ++i) {
+                nextClassification[i] = BinClassifier::Classification::Residual;
+            }
+            inbuf->reset();
+            outbuf->reset();
+            for (auto &s : scales) {
+                s.second->reset();
+            }
+        }
+    };
+
+    struct ChannelAssembly {
+        // Vectors of bare pointers, used to package container data
+        // from different channels into arguments for PhaseAdvance
+        FixedVector<const float *> input;
+        FixedVector<process_t *> mag;
+        FixedVector<process_t *> phase;
+        FixedVector<process_t *> prevMag;
+        FixedVector<Guide::Guidance *> guidance;
+        FixedVector<process_t *> outPhase;
+        FixedVector<float *> mixdown;
+        FixedVector<float *> resampled;
+        ChannelAssembly(int channels) :
+            input(channels, nullptr),
+            mag(channels, nullptr), phase(channels, nullptr),
+            prevMag(channels, nullptr), guidance(channels, nullptr),
+            outPhase(channels, nullptr), mixdown(channels, nullptr),
+            resampled(channels, nullptr) { }
+    };
+
+    struct ScaleData {
+        int fftSize;
+        bool singleWindowMode;
+        FFT fft;
+        Window<process_t> analysisWindow;
+        Window<process_t> synthesisWindow;
+        process_t windowScaleFactor;
+        GuidedPhaseAdvance guided;
+
+        ScaleData(GuidedPhaseAdvance::Parameters guidedParameters,
+                  Log log) :
+            fftSize(guidedParameters.fftSize),
+            singleWindowMode(guidedParameters.singleWindowMode),
+            fft(fftSize),
+            analysisWindow(analysisWindowShape(),
+                           analysisWindowLength()),
+            synthesisWindow(synthesisWindowShape(),
+                            synthesisWindowLength()),
+            windowScaleFactor(0.0),
+            guided(guidedParameters, log)
+        {
+            int asz = analysisWindow.getSize(), ssz = synthesisWindow.getSize();
+            int off = (asz - ssz) / 2;
+            for (int i = 0; i < ssz; ++i) {
+                windowScaleFactor += analysisWindow.getValue(i + off) *
+                    synthesisWindow.getValue(i);
+            }
+        }
+
+        WindowType analysisWindowShape();
+        int analysisWindowLength();
+        WindowType synthesisWindowShape();
+        int synthesisWindowLength();
+    };
+    
+    Log m_log;
+    Parameters m_parameters;
+    const Limits m_limits;
+
+    std::atomic<double> m_pitchScale;
+    std::atomic<double> m_formantScale;
+    
+    std::vector<std::shared_ptr<ChannelData>> m_channelData;
+    std::map<int, std::shared_ptr<ScaleData>> m_scaleData;
+    Guide m_guide;
+    Guide::Configuration m_guideConfiguration;
+    ChannelAssembly m_channelAssembly;
+    std::unique_ptr<Resampler> m_inResampler;
+    std::unique_ptr<Resampler> m_outResampler;
+    std::pair<int, int> m_initialResamplerDelays;
+    bool m_useReadahead;
+    int m_prevInhop;
+    int m_prevOuthop;
+    bool m_firstProcess;
+    uint32_t m_unityCount;
+
+    void initialise();
+
+    void readIn(const float *const *input);
+    void generate(int required);
+    int readOut(float *const *output, int outcount);
+    
+    void createResamplers();
+    void measureResamplerDelay();
+    void analyseChannel(int channel, int inhop, int prevInhop, int prevOuthop);
+    void analyseFormant(int channel);
+    void adjustFormant(int channel);
+    void adjustPreKick(int channel);
+    void synthesiseChannel(int channel, int outhop, bool draining);
+
+    struct ToPolarSpec {
+        int magFromBin;
+        int magBinCount;
+        int polarFromBin;
+        int polarBinCount;
+    };
+
+    Parameters validateSampleRate(const Parameters &params) {
+        Parameters validated { params };
+        double minRate = 8000.0, maxRate = 192000.0;
+        if (params.sampleRate < minRate) {
+            m_log.log(0, "R3LiveShifter: WARNING: Unsupported sample rate", params.sampleRate);
+            m_log.log(0, "R3LiveShifter: Minimum rate is", minRate);
+            validated.sampleRate = minRate;
+        } else if (params.sampleRate > maxRate) {
+            m_log.log(0, "R3LiveShifter: WARNING: Unsupported sample rate", params.sampleRate);
+            m_log.log(0, "R3LiveShifter: Maximum rate is", maxRate);
+            validated.sampleRate = maxRate;
+        }
+        return validated;
+    }
+    
+    void convertToPolar(process_t *mag, process_t *phase,
+                        const process_t *real, const process_t *imag,
+                        const ToPolarSpec &s) const {
+        v_cartesian_to_polar(mag + s.polarFromBin,
+                             phase + s.polarFromBin,
+                             real + s.polarFromBin,
+                             imag + s.polarFromBin,
+                             s.polarBinCount);
+        if (s.magFromBin < s.polarFromBin) {
+            v_cartesian_to_magnitudes(mag + s.magFromBin,
+                                      real + s.magFromBin,
+                                      imag + s.magFromBin,
+                                      s.polarFromBin - s.magFromBin);
+        }
+        if (s.magFromBin + s.magBinCount > s.polarFromBin + s.polarBinCount) {
+            v_cartesian_to_magnitudes(mag + s.polarFromBin + s.polarBinCount,
+                                      real + s.polarFromBin + s.polarBinCount,
+                                      imag + s.polarFromBin + s.polarBinCount,
+                                      s.magFromBin + s.magBinCount -
+                                      s.polarFromBin - s.polarBinCount);
+        }
+    }
+
+    bool useMidSide() const {
+        return m_parameters.channels == 2 &&
+            (m_parameters.options &
+             RubberBandLiveShifter::OptionChannelsTogether);
+    }
+    
+    bool isSingleWindowed() const {
+        return true;
+    }
+
+    double getInRatio() const {
+        if (m_pitchScale > 1.0) {
+            return 1.0 / m_pitchScale;
+        } else {
+            return 1.0;
+        }
+    }
+
+    double getOutRatio() const {
+        if (m_pitchScale < 1.0) {
+            return 1.0 / m_pitchScale;
+        } else {
+            return 1.0;
+        }
+    }
+    
+    int getWindowSourceSize() const {
+        if (m_useReadahead) {
+            int sz = m_guideConfiguration.classificationFftSize +
+                m_limits.maxInhopWithReadahead;
+            if (m_guideConfiguration.longestFftSize > sz) {
+                return m_guideConfiguration.longestFftSize;
+            } else {
+                return sz;
+            }
+        } else {
+            return m_guideConfiguration.longestFftSize;
+        }
+    }
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/R3Stretcher.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/R3Stretcher.cpp
@@ -1,0 +1,1671 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "R3Stretcher.h"
+
+#include "../common/VectorOpsComplex.h"
+#include "../common/Profiler.h"
+
+#include <array>
+
+namespace RubberBand {
+
+R3Stretcher::R3Stretcher(Parameters parameters,
+                         double initialTimeRatio,
+                         double initialPitchScale,
+                         Log log) :
+    m_log(log),
+    m_parameters(validateSampleRate(parameters)),
+    m_limits(parameters.options, m_parameters.sampleRate),
+    m_timeRatio(initialTimeRatio),
+    m_pitchScale(initialPitchScale),
+    m_formantScale(0.0),
+    m_guide(Guide::Parameters
+            (m_parameters.sampleRate,
+             m_parameters.options & RubberBandStretcher::OptionWindowShort),
+            m_log),
+    m_guideConfiguration(m_guide.getConfiguration()),
+    m_channelAssembly(m_parameters.channels),
+    m_useReadahead(true),
+    m_inhop(1),
+    m_prevInhop(1),
+    m_prevOuthop(1),
+    m_unityCount(0),
+    m_startSkip(0),
+    m_studyInputDuration(0),
+    m_suppliedInputDuration(0),
+    m_totalTargetDuration(0),
+    m_consumedInputDuration(0),
+    m_lastKeyFrameSurpassed(0),
+    m_totalOutputDuration(0),
+    m_mode(ProcessMode::JustCreated)
+{
+    Profiler profiler("R3Stretcher::R3Stretcher");
+
+    initialise();
+}
+
+void
+R3Stretcher::initialise()
+{
+    m_log.log(1, "R3Stretcher::R3Stretcher: rate, options",
+              m_parameters.sampleRate, m_parameters.options);
+    m_log.log(1, "R3Stretcher::R3Stretcher: initial time ratio and pitch scale",
+              m_timeRatio, m_pitchScale);
+
+    if (isRealTime()) {
+        m_log.log(1, "R3Stretcher::R3Stretcher: real-time mode");
+    } else {
+        m_log.log(1, "R3Stretcher::R3Stretcher: offline mode");
+    }
+
+    if (isSingleWindowed()) {
+        m_log.log(1, "R3Stretcher::R3Stretcher: intermediate shorter-window mode requested");
+    }
+    
+    double maxClassifierFrequency = 16000.0;
+    if (maxClassifierFrequency > m_parameters.sampleRate/2) {
+        maxClassifierFrequency = m_parameters.sampleRate/2;
+    }
+    int classificationBins =
+        int(floor(m_guideConfiguration.classificationFftSize *
+                  maxClassifierFrequency / m_parameters.sampleRate));
+    
+    BinSegmenter::Parameters segmenterParameters
+        (m_guideConfiguration.classificationFftSize,
+         classificationBins, m_parameters.sampleRate, 18);
+    
+    BinClassifier::Parameters classifierParameters
+        (classificationBins, 9, 1, 10, 2.0, 2.0);
+
+    if (isSingleWindowed()) {
+        classifierParameters.horizontalFilterLength = 7;
+    }
+
+    int inRingBufferSize = getWindowSourceSize() * 16;
+    int outRingBufferSize = getWindowSourceSize() * 16;
+
+    int hopBufferSize =
+        2 * std::max(m_limits.maxInhop, m_limits.maxPreferredOuthop);
+    
+    m_channelData.clear();
+    
+    for (int c = 0; c < m_parameters.channels; ++c) {
+        m_channelData.push_back(std::make_shared<ChannelData>
+                                (segmenterParameters,
+                                 classifierParameters,
+                                 getWindowSourceSize(),
+                                 inRingBufferSize,
+                                 outRingBufferSize,
+                                 hopBufferSize));
+        for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+            const auto &band = m_guideConfiguration.fftBandLimits[b];
+            int fftSize = band.fftSize;
+            m_channelData[c]->scales[fftSize] =
+                std::make_shared<ChannelScaleData>
+                (fftSize, m_guideConfiguration.longestFftSize);
+        }
+    }
+
+    m_scaleData.clear();
+    
+    for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+        const auto &band = m_guideConfiguration.fftBandLimits[b];
+        int fftSize = band.fftSize;
+        GuidedPhaseAdvance::Parameters guidedParameters
+            (fftSize, m_parameters.sampleRate, m_parameters.channels,
+             isSingleWindowed());
+        m_scaleData[fftSize] = std::make_shared<ScaleData>
+            (guidedParameters, m_log);
+    }
+
+    m_calculator = std::unique_ptr<StretchCalculator>
+        (new StretchCalculator(int(round(m_parameters.sampleRate)), //!!! which is a double...
+                               1, false, // no fixed inputIncrement
+                               m_log));
+
+    if (isRealTime()) {
+        createResampler();
+        // In offline mode we don't create the resampler yet - we
+        // don't want to have one at all if the pitch ratio is 1.0,
+        // but that could change before the first process call, so we
+        // create the resampler if needed then
+    }
+
+    calculateHop();
+
+    if (!m_inhop.is_lock_free()) {
+        m_log.log(0, "R3Stretcher: WARNING: std::atomic<int> is not lock-free");
+    }
+    if (!m_timeRatio.is_lock_free()) {
+        m_log.log(0, "R3Stretcher: WARNING: std::atomic<double> is not lock-free");
+    }
+}
+
+WindowType
+R3Stretcher::ScaleData::analysisWindowShape()
+{
+    if (singleWindowMode) {
+        return HannWindow;
+    } else {
+        if (fftSize < 1024 || fftSize > 2048) return HannWindow;
+        else return NiemitaloForwardWindow;
+    }
+}
+
+int
+R3Stretcher::ScaleData::analysisWindowLength()
+{
+    return fftSize;
+}
+
+WindowType
+R3Stretcher::ScaleData::synthesisWindowShape()
+{
+    if (singleWindowMode) {
+        return HannWindow;
+    } else {
+        if (fftSize < 1024 || fftSize > 2048) return HannWindow;
+        else return NiemitaloReverseWindow;
+    }
+}
+
+int
+R3Stretcher::ScaleData::synthesisWindowLength()
+{
+    if (singleWindowMode) {
+        return fftSize;
+    } else {
+        if (fftSize > 2048) return fftSize/2;
+        else return fftSize;
+    }
+}
+
+void
+R3Stretcher::setTimeRatio(double ratio)
+{
+    if (!isRealTime()) {
+        if (m_mode == ProcessMode::Studying ||
+            m_mode == ProcessMode::Processing) {
+            m_log.log(0, "R3Stretcher::setTimeRatio: Cannot set time ratio while studying or processing in non-RT mode");
+            return;
+        }
+    }
+
+    if (ratio == m_timeRatio) return;
+    m_timeRatio = ratio;
+    calculateHop();
+}
+
+void
+R3Stretcher::setPitchScale(double scale)
+{
+    if (!isRealTime()) {
+        if (m_mode == ProcessMode::Studying ||
+            m_mode == ProcessMode::Processing) {
+            m_log.log(0, "R3Stretcher::setPitchScale: Cannot set pitch scale while studying or processing in non-RT mode");
+            return;
+        }
+    }
+
+    if (scale == m_pitchScale) return;
+    m_pitchScale = scale;
+    calculateHop();
+}
+
+void
+R3Stretcher::setFormantScale(double scale)
+{
+    if (!isRealTime()) {
+        if (m_mode == ProcessMode::Studying ||
+            m_mode == ProcessMode::Processing) {
+            m_log.log(0, "R3Stretcher::setFormantScale: Cannot set formant scale while studying or processing in non-RT mode");
+            return;
+        }
+    }
+
+    m_formantScale = scale;
+}
+
+void
+R3Stretcher::setFormantOption(RubberBandStretcher::Options options)
+{
+    int mask = (RubberBandStretcher::OptionFormantShifted |
+                RubberBandStretcher::OptionFormantPreserved);
+    m_parameters.options &= ~mask;
+    options &= mask;
+    m_parameters.options |= options;
+}
+
+void
+R3Stretcher::setPitchOption(RubberBandStretcher::Options)
+{
+    m_log.log(0, "R3Stretcher::setPitchOption: Option change after construction is not supported in R3 engine");
+}
+
+void
+R3Stretcher::setKeyFrameMap(const std::map<size_t, size_t> &mapping)
+{
+    if (isRealTime()) {
+        m_log.log(0, "R3Stretcher::setKeyFrameMap: Cannot specify key frame map in RT mode");
+        return;
+    }
+    if (m_mode == ProcessMode::Processing || m_mode == ProcessMode::Finished) {
+        m_log.log(0, "R3Stretcher::setKeyFrameMap: Cannot specify key frame map after process() has begun");
+        return;
+    }
+
+    m_keyFrameMap = mapping;
+}
+
+void
+R3Stretcher::createResampler()
+{
+    Profiler profiler("R3Stretcher::createResampler");
+    
+    Resampler::Parameters resamplerParameters;
+    resamplerParameters.quality = Resampler::FastestTolerable;
+    resamplerParameters.initialSampleRate = m_parameters.sampleRate;
+    resamplerParameters.maxBufferSize = m_guideConfiguration.longestFftSize;
+
+    if (isRealTime()) {
+        // If we knew the caller would never change ratio, we could
+        // supply RatioMostlyFixed - but it can have such overhead
+        // when the ratio *does* change (and it's not RT-safe overhead
+        // either) that a single call would kill RT use
+        resamplerParameters.dynamism = Resampler::RatioOftenChanging;
+        resamplerParameters.ratioChange = Resampler::SmoothRatioChange;
+    } else {
+        resamplerParameters.dynamism = Resampler::RatioMostlyFixed;
+        resamplerParameters.ratioChange = Resampler::SuddenRatioChange;
+    }
+
+    int debug = m_log.getDebugLevel();
+    if (debug > 0) --debug;
+    resamplerParameters.debugLevel = debug;
+    
+    m_resampler = std::unique_ptr<Resampler>
+        (new Resampler(resamplerParameters, m_parameters.channels));
+
+    bool before, after;
+    areWeResampling(&before, &after);
+    if (before) {
+        if (after) {
+            m_log.log(0, "R3Stretcher: WARNING: we think we are resampling both before and after!");
+        } else {
+            m_log.log(1, "createResampler: resampling before");
+        }
+    } else {
+        if (after) {
+            m_log.log(1, "createResampler: resampling after");
+        }
+    }
+}
+
+void
+R3Stretcher::calculateHop()
+{
+    if (m_pitchScale <= 0.0) {
+        // This special case is likelier than one might hope, because
+        // of naive initialisations in programs that set it from a
+        // variable
+        m_log.log(0, "WARNING: Pitch scale must be greater than zero! Resetting it to default, no pitch shift will happen", m_pitchScale);
+        m_pitchScale = 1.0;
+    }
+    if (m_timeRatio <= 0.0) {
+        // Likewise
+        m_log.log(0, "WARNING: Time ratio must be greater than zero! Resetting it to default, no time stretch will happen", m_timeRatio);
+        m_timeRatio = 1.0;
+    }
+    if (m_pitchScale != m_pitchScale || m_timeRatio != m_timeRatio ||
+        m_pitchScale == m_pitchScale/2.0 || m_timeRatio == m_timeRatio/2.0) {
+        m_log.log(0, "WARNING: NaN or Inf presented for time ratio or pitch scale! Resetting it to default, no time stretch will happen", m_timeRatio, m_pitchScale);
+        m_timeRatio = 1.0;
+        m_pitchScale = 1.0;
+    }
+
+    double ratio = getEffectiveRatio();
+
+    // In R2 we generally targeted a certain inhop, and calculated
+    // outhop from that. Here we are the other way around. We aim for
+    // outhop = 256 at ratios around 1, reducing down to 128 for
+    // ratios far below 1 and up to 512 for ratios far above. As soon
+    // as outhop exceeds 256 we have to drop the 1024-bin FFT, as the
+    // overlap will be inadequate for it (that's among the jobs of the
+    // Guide class) so we don't want to go above 256 until at least
+    // factor 1.5. Also we can't go above 512 without changing the
+    // window shape or dropping the 2048-bin FFT, and we can't do
+    // either of those dynamically.
+
+    double proposedOuthop = 256.0;
+    if (ratio > 1.5) {
+        proposedOuthop = pow(2.0, 8.0 + 2.0 * log10(ratio - 0.5));
+    } else if (ratio < 1.0) {
+        proposedOuthop = pow(2.0, 8.0 + 2.0 * log10(ratio));
+    }
+
+    if (isSingleWindowed()) {
+        // the single (shorter) window mode actually uses a longer
+        // synthesis window for the 2048-bin FFT and drops the
+        // 1024-bin one, so it can survive longer hops, which is good
+        // because reduced CPU consumption is the whole motivation
+        proposedOuthop *= 2.0;
+    }
+    
+    if (proposedOuthop > m_limits.maxPreferredOuthop) {
+        proposedOuthop = m_limits.maxPreferredOuthop;
+    }
+    if (proposedOuthop < m_limits.minPreferredOuthop) {
+        proposedOuthop = m_limits.minPreferredOuthop;
+    }
+    
+    m_log.log(1, "calculateHop: ratio and proposed outhop", ratio, proposedOuthop);
+    
+    double inhop = proposedOuthop / ratio;
+    if (inhop < m_limits.minInhop) {
+        m_log.log(0, "R3Stretcher: WARNING: Ratio yields ideal inhop < minimum, results may be suspect", inhop, m_limits.minInhop);
+        inhop = m_limits.minInhop;
+    }
+    if (inhop > m_limits.maxInhop) {
+        // Log level 1, this is not as big a deal as < minInhop above
+        m_log.log(1, "R3Stretcher: WARNING: Ratio yields ideal inhop > maximum, results may be suspect", inhop, m_limits.maxInhop);
+        inhop = m_limits.maxInhop;
+    }
+
+    m_inhop = int(floor(inhop));
+    m_log.log(1, "calculateHop: inhop and mean outhop", m_inhop, m_inhop * ratio);
+
+    if (m_inhop < m_limits.maxInhopWithReadahead) {
+        m_log.log(1, "calculateHop: using readahead; maxInhopWithReadahead", m_limits.maxInhopWithReadahead);
+        m_useReadahead = true;
+    } else {
+        m_log.log(1, "calculateHop: not using readahead; maxInhopWithReadahead", m_limits.maxInhopWithReadahead);
+        m_useReadahead = false;
+    }
+
+    if (m_mode == ProcessMode::JustCreated) {
+        m_prevInhop = m_inhop;
+        m_prevOuthop = int(round(m_inhop * getEffectiveRatio()));
+    }
+}
+
+void
+R3Stretcher::updateRatioFromMap()
+{
+    if (m_keyFrameMap.empty()) return;
+
+    if (m_consumedInputDuration == 0) {
+        m_timeRatio = double(m_keyFrameMap.begin()->second) /
+            double(m_keyFrameMap.begin()->first);
+
+        m_log.log(1, "initial key-frame map entry ",
+                   double(m_keyFrameMap.begin()->first),
+                   double(m_keyFrameMap.begin()->second));
+        m_log.log(1, "giving initial ratio ", m_timeRatio);
+        
+        calculateHop();
+        m_lastKeyFrameSurpassed = 0;
+        return;
+    }
+    
+    auto i0 = m_keyFrameMap.upper_bound(m_lastKeyFrameSurpassed);
+
+    if (i0 == m_keyFrameMap.end()) {
+        return;
+    }
+
+    if (m_consumedInputDuration >= i0->first) {
+
+        m_log.log(1, "input duration surpasses pending key frame",
+                   double(m_consumedInputDuration), double(i0->first));
+        
+        auto i1 = m_keyFrameMap.upper_bound(m_consumedInputDuration);
+
+        size_t keyFrameAtInput, keyFrameAtOutput;
+    
+        if (i1 != m_keyFrameMap.end()) {
+            keyFrameAtInput = i1->first;
+            keyFrameAtOutput = i1->second;
+        } else {
+            keyFrameAtInput = m_studyInputDuration;
+            keyFrameAtOutput = m_totalTargetDuration;
+        }
+
+        m_log.log(1, "current input and output",
+                   double(m_consumedInputDuration), double(m_totalOutputDuration));
+        m_log.log(1, "next key frame input and output",
+                   double(keyFrameAtInput), double(keyFrameAtOutput));
+        
+        double ratio;
+
+        if (keyFrameAtInput > i0->first) {
+        
+            size_t toKeyFrameAtInput, toKeyFrameAtOutput;
+            
+            toKeyFrameAtInput = keyFrameAtInput - i0->first;
+            
+            if (keyFrameAtOutput > i0->second) {
+                toKeyFrameAtOutput = keyFrameAtOutput - i0->second;
+            } else {
+                m_log.log(1, "previous target key frame overruns next key frame (or total output duration)", i0->second, keyFrameAtOutput);
+                toKeyFrameAtOutput = 1;
+            }
+
+            m_log.log(1, "diff to next key frame input and output",
+                      double(toKeyFrameAtInput), double(toKeyFrameAtOutput));
+
+            ratio = double(toKeyFrameAtOutput) / double(toKeyFrameAtInput);
+
+        } else {
+            m_log.log(1, "source key frame overruns following key frame or total input duration", i0->first, keyFrameAtInput);
+            ratio = 1.0;
+        }
+        
+        m_log.log(1, "new ratio", ratio);
+    
+        m_timeRatio = ratio;
+        calculateHop();
+
+        m_lastKeyFrameSurpassed = i0->first;
+    }
+}
+
+double
+R3Stretcher::getTimeRatio() const
+{
+    return m_timeRatio;
+}
+
+double
+R3Stretcher::getPitchScale() const
+{
+    return m_pitchScale;
+}
+
+double
+R3Stretcher::getFormantScale() const
+{
+    return m_formantScale;
+}
+
+size_t
+R3Stretcher::getPreferredStartPad() const
+{
+    if (!isRealTime()) {
+        return 0;
+    } else {
+        bool resamplingBefore = false;
+        areWeResampling(&resamplingBefore, nullptr);
+        size_t pad = getWindowSourceSize() / 2;
+        if (resamplingBefore) {
+            return size_t(ceil(pad * m_pitchScale));
+        } else {
+            return pad;
+        }
+    }
+}
+
+size_t
+R3Stretcher::getStartDelay() const
+{
+    if (!isRealTime()) {
+        return 0;
+    } else {
+        bool resamplingBefore = false;
+        areWeResampling(&resamplingBefore, nullptr);
+        size_t delay = getWindowSourceSize() / 2;
+        if (resamplingBefore) {
+            return delay;
+        } else {
+            return size_t(ceil(delay / m_pitchScale));
+        }
+    }
+}
+
+size_t
+R3Stretcher::getChannelCount() const
+{
+    return m_parameters.channels;
+}
+
+void
+R3Stretcher::reset()
+{
+    m_inhop = 1;
+    m_prevInhop = 1;
+    m_prevOuthop = 1;
+    m_unityCount = 0;
+    m_startSkip = 0;
+    m_studyInputDuration = 0;
+    m_suppliedInputDuration = 0;
+    m_totalTargetDuration = 0;
+    m_consumedInputDuration = 0;
+    m_lastKeyFrameSurpassed = 0;
+    m_totalOutputDuration = 0;
+    m_keyFrameMap.clear();
+
+    m_mode = ProcessMode::JustCreated;
+
+    m_calculator->reset();
+    
+    if (m_resampler) {
+        m_resampler->reset();
+    }
+
+    for (auto &it : m_scaleData) {
+        it.second->guided.reset();
+    }
+
+    for (auto &cd : m_channelData) {
+        cd->reset();
+    }
+
+    calculateHop();
+}
+
+void
+R3Stretcher::study(const float *const *, size_t samples, bool)
+{
+    Profiler profiler("R3Stretcher::study");
+    
+    if (isRealTime()) {
+        m_log.log(0, "R3Stretcher::study: Not meaningful in realtime mode");
+        return;
+    }
+
+    if (m_mode == ProcessMode::Processing || m_mode == ProcessMode::Finished) {
+        m_log.log(0, "R3Stretcher::study: Cannot study after processing");
+        return;
+    }
+    
+    if (m_mode == ProcessMode::JustCreated) {
+        m_studyInputDuration = 0;
+    }
+
+    m_mode = ProcessMode::Studying;
+    m_studyInputDuration += samples;
+}
+
+void
+R3Stretcher::setExpectedInputDuration(size_t samples)
+{
+    m_suppliedInputDuration = samples;
+}
+
+size_t
+R3Stretcher::getSamplesRequired() const
+{
+    if (available() != 0) return 0;
+    int rs = m_channelData[0]->inbuf->getReadSpace();
+
+    m_log.log(2, "getSamplesRequired: read space and window source size", rs, getWindowSourceSize());
+
+    if (rs < getWindowSourceSize()) {
+
+        int req = getWindowSourceSize() - rs;
+        
+        bool resamplingBefore = false;
+        areWeResampling(&resamplingBefore, nullptr);
+
+        if (!resamplingBefore) {
+            return req;
+        } else {
+            int adjusted = int(ceil(double(req) * m_pitchScale));
+            m_log.log(2, "getSamplesRequired: resamplingBefore is true, req and adjusted", req, adjusted);
+            return adjusted;
+        }
+            
+    } else {
+        return 0;
+    }
+}
+
+void
+R3Stretcher::setMaxProcessSize(size_t requested)
+{
+    m_log.log(2, "R3Stretcher::setMaxProcessSize", requested);
+    
+    int n = m_limits.overallMaxProcessSize;
+    if (requested > size_t(n)) {
+        m_log.log(0, "R3Stretcher::setMaxProcessSize: request exceeds overall limit", requested, n);
+    } else {
+        n = int(requested);
+    }
+
+    ensureInbuf(n * 2, false);
+    ensureOutbuf(n * 8, false);
+}
+
+size_t
+R3Stretcher::getProcessSizeLimit() const
+{
+    return m_limits.overallMaxProcessSize;
+}
+
+void
+R3Stretcher::ensureInbuf(int required, bool warn)
+{
+    int ws = m_channelData[0]->inbuf->getWriteSpace();
+    if (required < ws) {
+        return;
+    }
+    if (warn) {
+        m_log.log(0, "R3Stretcher::ensureInbuf: WARNING: Forced to increase input buffer size. Either setMaxProcessSize was not properly called, process is being called repeatedly without retrieve, or an internal error has led to an incorrect resampler output calculation. Samples to write and space available", required, ws);
+    }
+    size_t oldSize = m_channelData[0]->inbuf->getSize();
+    size_t newSize = oldSize - ws + required;
+    if (newSize < oldSize * 2) newSize = oldSize * 2;
+    m_log.log(warn ? 0 : 2, "R3Stretcher::ensureInbuf: old and new sizes", oldSize, newSize);
+    for (int c = 0; c < m_parameters.channels; ++c) {
+        auto newBuf = m_channelData[c]->inbuf->resized(newSize);
+        m_channelData[c]->inbuf = std::unique_ptr<RingBuffer<float>>(newBuf);
+        // mixdown is used for mid-side mixing as well as the single
+        // hop output mix, so it needs to be enough to match the inbuf
+        m_channelData[c]->mixdown.resize(newSize, 0.f);
+    }
+}
+
+void
+R3Stretcher::ensureOutbuf(int required, bool warn)
+{
+    int ws = m_channelData[0]->outbuf->getWriteSpace();
+    if (required < ws) {
+        return;
+    }
+    if (warn) {
+        m_log.log(0, "R3Stretcher::ensureOutbuf: WARNING: Forced to increase output buffer size. Using smaller process blocks or an artificially larger value for setMaxProcessSize may avoid this. Samples to write and space available", required, ws);
+    }
+    size_t oldSize = m_channelData[0]->outbuf->getSize();
+    size_t newSize = oldSize - ws + required;
+    if (newSize < oldSize * 2) newSize = oldSize * 2;
+    m_log.log(warn ? 0 : 2, "R3Stretcher::ensureOutbuf: old and new sizes", oldSize, newSize);
+    for (int c = 0; c < m_parameters.channels; ++c) {
+        auto newBuf = m_channelData[c]->outbuf->resized(newSize);
+        m_channelData[c]->outbuf = std::unique_ptr<RingBuffer<float>>(newBuf);
+    }
+}
+
+void
+R3Stretcher::process(const float *const *input, size_t samples, bool final)
+{
+    Profiler profiler("R3Stretcher::process");
+    
+    if (m_mode == ProcessMode::Finished) {
+        m_log.log(0, "R3Stretcher::process: Cannot process again after final chunk");
+        return;
+    }
+
+    int n = m_limits.overallMaxProcessSize;
+    if (samples > size_t(n)) {
+        m_log.log(0, "R3Stretcher::process: request exceeds overall limit", samples, n);
+    } else {
+        n = int(samples);
+    }
+
+    if (!isRealTime()) {
+
+        if (m_mode == ProcessMode::Studying) {
+            m_totalTargetDuration =
+                size_t(round(m_studyInputDuration * m_timeRatio));
+            m_log.log(1, "study duration and target duration",
+                      m_studyInputDuration, m_totalTargetDuration);
+        } else if (m_mode == ProcessMode::JustCreated) {
+            if (m_suppliedInputDuration != 0) {
+                m_totalTargetDuration =
+                    size_t(round(m_suppliedInputDuration * m_timeRatio));
+                m_log.log(1, "supplied duration and target duration",
+                          m_suppliedInputDuration, m_totalTargetDuration);
+            }
+        }
+
+        // Update this on every process round, checking whether we've
+        // surpassed the next key frame yet. This must follow the
+        // overall target calculation above, which uses the "global"
+        // time ratio, but precede any other use of the time ratio.
+        
+        if (!m_keyFrameMap.empty()) {
+            updateRatioFromMap();
+        }
+
+        if (m_mode == ProcessMode::JustCreated ||
+            m_mode == ProcessMode::Studying) {
+
+            if (m_pitchScale != 1.0 && !m_resampler) {
+                createResampler();
+            }
+
+            // Pad to half the frame. As with R2, in real-time mode we
+            // don't do this -- it's better to start with a swoosh
+            // than introduce more latency, and we don't want gaps
+            // when the ratio changes.
+            int pad = getWindowSourceSize() / 2;
+            m_log.log(1, "offline mode: prefilling with", pad);
+            ensureInbuf(pad);
+            for (int c = 0; c < m_parameters.channels; ++c) {
+                int zeroed = m_channelData[c]->inbuf->zero(pad);
+                if (zeroed != pad) {
+                    m_log.log(0, "R3Stretcher: WARNING: too few padding samples written", zeroed, pad);
+                }
+            }
+
+            // NB by the time we skip this later we may have resampled
+            // as well as stretched
+            m_startSkip = int(round(pad / m_pitchScale));
+            m_log.log(1, "start skip is", m_startSkip);
+        }
+    }
+
+    bool resamplingBefore = false;
+    areWeResampling(&resamplingBefore, nullptr);
+
+    int channels = m_parameters.channels;
+    int inputIx = 0;
+
+    if (n == 0 && final) {
+
+        m_log.log(2, "process: no samples but final specified, consuming");
+        
+        consume(true);
+
+    } else while (inputIx < n) {
+
+        int remaining = n - inputIx;
+
+        int ws = m_channelData[0]->inbuf->getWriteSpace();
+        if (ws == 0) {
+            consume(false);
+        }
+        ensureInbuf(remaining);
+        ws = m_channelData[0]->inbuf->getWriteSpace();
+        
+        if (resamplingBefore) {
+
+            for (int c = 0; c < channels; ++c) {
+                auto &cd = m_channelData.at(c);
+                m_channelAssembly.resampled[c] = cd->resampled.data();
+            }
+
+            int resampleBufSize = int(m_channelData.at(0)->resampled.size());
+            int maxResampleOutput = std::min(ws, resampleBufSize);
+            
+            int maxResampleInput = int(floor(maxResampleOutput * m_pitchScale));
+            int resampleInput = std::min(remaining, maxResampleInput);
+            if (resampleInput == 0) resampleInput = 1;
+
+            m_log.log(2, "R3Stretcher::process: resamplingBefore is true, resampleInput and maxResampleOutput", resampleInput, maxResampleOutput);
+            
+            prepareInput(input, inputIx, resampleInput);
+
+            bool finalHop = (final && inputIx + resampleInput >= n);
+            
+            int resampleOutput = m_resampler->resample
+                (m_channelAssembly.resampled.data(),
+                 maxResampleOutput,
+                 m_channelAssembly.input.data(),
+                 resampleInput,
+                 1.0 / m_pitchScale,
+                 finalHop);
+
+            inputIx += resampleInput;
+            
+            for (int c = 0; c < m_parameters.channels; ++c) {
+
+                int written = m_channelData[c]->inbuf->write
+                    (m_channelData.at(c)->resampled.data(),
+                     resampleOutput);
+
+                if (written != resampleOutput) {
+                    m_log.log(0, "R3Stretcher: WARNING: too few samples written to input buffer from resampler", written, resampleOutput);
+                }
+            }
+
+        } else {
+            int toWrite = std::min(ws, remaining);
+
+            m_log.log(2, "process: resamplingBefore is false, writing to inbuf from supplied data, former read space and samples being added", m_channelData[0]->inbuf->getReadSpace(), toWrite);
+
+            prepareInput(input, inputIx, toWrite);
+            
+            for (int c = 0; c < m_parameters.channels; ++c) {
+
+                int written = m_channelData[c]->inbuf->write
+                    (m_channelAssembly.input[c], toWrite);
+
+                if (written != toWrite) {
+                    m_log.log(0, "R3Stretcher: WARNING: too few samples written to input buffer", written, toWrite);
+                }
+            }
+            
+            inputIx += toWrite;
+        }
+        
+        consume(final && inputIx >= n);
+    }
+
+    if (final) {
+        // We don't distinguish between Finished and "draining, but
+        // haven't yet delivered all the samples" because the
+        // distinction is meaningless internally - it only affects
+        // whether available() finds any samples in the buffer
+        m_log.log(1, "final is set, entering Finished mode");
+        m_mode = ProcessMode::Finished;
+    } else {
+        m_mode = ProcessMode::Processing;
+    }
+}
+
+int
+R3Stretcher::available() const
+{
+    int av = int(m_channelData[0]->outbuf->getReadSpace());
+    if (av == 0 && m_mode == ProcessMode::Finished) {
+        return -1;
+    } else {
+        return av;
+    }
+}
+
+size_t
+R3Stretcher::retrieve(float *const *output, size_t samples) const
+{
+    Profiler profiler("R3Stretcher::retrieve");
+    
+    int got = samples;
+    
+    m_log.log(2, "retrieve: requested, outbuf has", samples, m_channelData[0]->outbuf->getReadSpace());
+    
+    for (int c = 0; c < m_parameters.channels; ++c) {
+        int gotHere = m_channelData[c]->outbuf->read(output[c], got);
+        if (gotHere < got) {
+            if (c > 0) {
+                m_log.log(0, "R3Stretcher::retrieve: WARNING: channel imbalance detected");
+            }
+            got = std::min(got, std::max(gotHere, 0));
+        }
+    }
+
+    if (useMidSide()) {
+        for (int i = 0; i < got; ++i) {
+            float m = output[0][i];
+            float s = output[1][i];
+            float l = m + s;
+            float r = m - s;
+            output[0][i] = l;
+            output[1][i] = r;
+        }
+    }
+    
+    m_log.log(2, "retrieve: returning, outbuf now has", got, m_channelData[0]->outbuf->getReadSpace());
+
+    return got;
+}
+
+void
+R3Stretcher::prepareInput(const float *const *input, int ix, int n)
+{
+    if (useMidSide()) {
+        auto &c0 = m_channelData.at(0)->mixdown;
+        auto &c1 = m_channelData.at(1)->mixdown;
+        int bufsize = c0.size();
+        if (n > bufsize) {
+            m_log.log(0, "R3Stretcher::prepareInput: WARNING: called with size greater than mixdown buffer length", n, bufsize);
+            n = bufsize;
+        }
+        for (int i = 0; i < n; ++i) {
+            float l = input[0][i + ix];
+            float r = input[1][i + ix];
+            float m = (l + r) / 2.f;
+            float s = (l - r) / 2.f;
+            c0[i] = m;
+            c1[i] = s;
+        }
+        m_channelAssembly.input[0] = m_channelData.at(0)->mixdown.data();
+        m_channelAssembly.input[1] = m_channelData.at(1)->mixdown.data();
+    } else {
+        for (int c = 0; c < m_parameters.channels; ++c) {
+            m_channelAssembly.input[c] = input[c] + ix;
+        }
+    }
+}
+
+void
+R3Stretcher::consume(bool final)
+{
+    Profiler profiler("R3Stretcher::consume");
+    
+    int longest = m_guideConfiguration.longestFftSize;
+    int channels = m_parameters.channels;
+    int inhop = m_inhop;
+
+    bool resamplingAfter = false;
+    areWeResampling(nullptr, &resamplingAfter);
+
+    double effectivePitchRatio = 1.0 / m_pitchScale;
+    if (m_resampler) {
+        effectivePitchRatio =
+            m_resampler->getEffectiveRatio(effectivePitchRatio);
+    }
+    
+    int outhop = m_calculator->calculateSingle(m_timeRatio,
+                                               effectivePitchRatio,
+                                               1.f,
+                                               inhop,
+                                               longest,
+                                               longest,
+                                               true);
+
+    if (outhop < 1) {
+        m_log.log(0, "R3Stretcher::consume: WARNING: outhop calculated as", outhop);
+        outhop = 1;
+    }
+    
+    // Now inhop is the distance by which the input stream will be
+    // advanced after our current frame has been read, and outhop is
+    // the distance by which the output will be advanced after it has
+    // been emitted; m_prevInhop and m_prevOuthop are the
+    // corresponding values the last time a frame was processed (*not*
+    // just the last time this function was called, since we can
+    // return without doing anything if the output buffer is full).
+    //
+    // Our phase adjustments need to be based on the distances we have
+    // advanced the input and output since the previous frame, not the
+    // distances we are about to advance them, so they use the m_prev
+    // values.
+
+    if (inhop != m_prevInhop) {
+        m_log.log(2, "change in inhop", double(m_prevInhop), double(inhop));
+    }
+    if (outhop != m_prevOuthop) {
+        m_log.log(2, "change in outhop", double(m_prevOuthop), double(outhop));
+    }
+
+    auto &cd0 = m_channelData.at(0);
+
+    m_log.log(2, "consume: write space and outhop", cd0->outbuf->getWriteSpace(), outhop);
+        
+    // NB our ChannelData, ScaleData, and ChannelScaleData maps
+    // contain shared_ptrs; whenever we retain one of them in a
+    // variable, we do so by reference to avoid copying the shared_ptr
+    // (as that is not realtime safe). Same goes for the map iterators
+
+    while (true) {
+
+        Profiler profiler2("R3Stretcher::consume/loop");
+
+        int readSpace = cd0->inbuf->getReadSpace();
+        m_log.log(2, "consume: read space", readSpace);
+
+        if (readSpace < getWindowSourceSize()) {
+            if (final) {
+                if (readSpace == 0) {
+                    int fill = cd0->scales.at(longest)->accumulatorFill;
+                    if (fill == 0) {
+                        break;
+                    } else {
+                        m_log.log(1, "finished reading input, but samples remaining in output accumulator", fill);
+                    }
+                }
+            } else {
+                // await more input
+                break;
+            }
+        }
+
+        ensureOutbuf(outhop);
+        
+        // Analysis
+        
+        for (int c = 0; c < channels; ++c) {
+            analyseChannel(c, inhop, m_prevInhop, m_prevOuthop);
+        }
+
+        // Phase update. This is synchronised across all channels
+        
+        for (auto &it : m_channelData[0]->scales) {
+            int fftSize = it.first;
+            for (int c = 0; c < channels; ++c) {
+                auto &cd = m_channelData.at(c);
+                auto &scale = cd->scales.at(fftSize);
+                m_channelAssembly.mag[c] = scale->mag.data();
+                m_channelAssembly.phase[c] = scale->phase.data();
+                m_channelAssembly.prevMag[c] = scale->prevMag.data();
+                m_channelAssembly.guidance[c] = &cd->guidance;
+                m_channelAssembly.outPhase[c] = scale->advancedPhase.data();
+            }
+            m_scaleData.at(fftSize)->guided.advance
+                (m_channelAssembly.outPhase.data(),
+                 m_channelAssembly.mag.data(),
+                 m_channelAssembly.phase.data(),
+                 m_channelAssembly.prevMag.data(),
+                 m_guideConfiguration,
+                 m_channelAssembly.guidance.data(),
+                 useMidSide(),
+                 m_prevInhop,
+                 m_prevOuthop);
+        }
+
+        for (int c = 0; c < channels; ++c) {
+            adjustPreKick(c);
+        }
+        
+        // Resynthesis
+        
+        for (int c = 0; c < channels; ++c) {
+            synthesiseChannel(c, outhop, readSpace == 0);
+        }
+        
+        // Resample
+
+        int resampledCount = 0;
+        if (resamplingAfter) {
+            for (int c = 0; c < channels; ++c) {
+                auto &cd = m_channelData.at(c);
+                m_channelAssembly.mixdown[c] = cd->mixdown.data();
+                m_channelAssembly.resampled[c] = cd->resampled.data();
+            }
+
+            bool finalHop = (final &&
+                             readSpace < inhop &&
+                             cd0->scales.at(longest)->accumulatorFill <= outhop);
+            
+            resampledCount = m_resampler->resample
+                (m_channelAssembly.resampled.data(),
+                 m_channelData[0]->resampled.size(),
+                 m_channelAssembly.mixdown.data(),
+                 outhop,
+                 1.0 / m_pitchScale,
+                 finalHop);
+        }
+
+        // Emit
+
+        int writeCount = outhop;
+        if (resamplingAfter) {
+            writeCount = resampledCount;
+        }
+        if (!isRealTime()) {
+            if (m_totalTargetDuration > 0 &&
+                m_totalOutputDuration + writeCount > m_totalTargetDuration) {
+                m_log.log(1, "writeCount would take output beyond target",
+                          m_totalOutputDuration, m_totalTargetDuration);
+                auto reduced = m_totalTargetDuration - m_totalOutputDuration;
+                m_log.log(1, "reducing writeCount from and to", writeCount, reduced);
+                writeCount = reduced;
+            }
+        }
+
+        int advanceCount = inhop;
+        if (advanceCount > readSpace) {
+            // This should happen only when draining
+            if (!final) {
+                m_log.log(0, "R3Stretcher: WARNING: readSpace < inhop when processing is not yet finished", readSpace, inhop);
+            }
+            advanceCount = readSpace;
+        }
+        
+        for (int c = 0; c < channels; ++c) {
+            auto &cd = m_channelData.at(c);
+            int written = 0;
+            if (resamplingAfter) {
+                written = cd->outbuf->write(cd->resampled.data(), writeCount);
+            } else {
+                written = cd->outbuf->write(cd->mixdown.data(), writeCount);
+            }
+            if (written != writeCount) {
+                m_log.log(0, "R3Stretcher: WARNING: too few samples written to output buffer", written, writeCount);
+            }
+            int skipped = cd->inbuf->skip(advanceCount);
+            if (skipped != advanceCount) {
+                m_log.log(0, "R3Stretcher: WARNING: too few samples advanced", skipped, advanceCount);
+            }
+        }
+
+        m_consumedInputDuration += advanceCount;
+        m_totalOutputDuration += writeCount;
+        
+        if (m_startSkip > 0) {
+            int rs = cd0->outbuf->getReadSpace();
+            int toSkip = std::min(m_startSkip, rs);
+            for (int c = 0; c < channels; ++c) {
+                int skipped = m_channelData.at(c)->outbuf->skip(toSkip);
+                if (skipped != toSkip) {
+                    m_log.log(0, "R3Stretcher: WARNING: too few samples skipped at output", skipped, toSkip);
+                }
+            }
+            m_startSkip -= toSkip;
+            m_totalOutputDuration = rs - toSkip;
+        }
+        
+        m_prevInhop = inhop;
+        m_prevOuthop = outhop;
+    }
+
+    m_log.log(2, "consume: write space reduced to", cd0->outbuf->getWriteSpace());
+}
+
+void
+R3Stretcher::analyseChannel(int c, int inhop, int prevInhop, int prevOuthop)
+{
+    Profiler profiler("R3Stretcher::analyseChannel");
+    
+    auto &cd = m_channelData.at(c);
+
+    int sourceSize = cd->windowSource.size();
+    process_t *buf = cd->windowSource.data();
+
+    int readSpace = cd->inbuf->getReadSpace();
+    if (readSpace < sourceSize) {
+        cd->inbuf->peek(buf, readSpace);
+        v_zero(buf + readSpace, sourceSize - readSpace);
+    } else {
+        cd->inbuf->peek(buf, sourceSize);
+    }
+    
+    // We have an unwindowed time-domain frame in buf that is as long
+    // as required for the union of all FFT sizes and readahead
+    // hops. Populate the various sizes from it with aligned centres,
+    // windowing as we copy. The classification scale is handled
+    // separately because it has readahead, so skip it here. (In
+    // single-window mode that means we do nothing here, since the
+    // classification scale is the only one.)
+
+    int longest = m_guideConfiguration.longestFftSize;
+    int classify = m_guideConfiguration.classificationFftSize;
+
+    for (auto &it: cd->scales) {
+        int fftSize = it.first;
+        if (fftSize == classify) continue;
+        int offset = (longest - fftSize) / 2;
+        m_scaleData.at(fftSize)->analysisWindow.cut
+            (buf + offset, it.second->timeDomain.data());
+    }
+
+    auto &classifyScale = cd->scales.at(classify);
+    ClassificationReadaheadData &readahead = cd->readahead;
+    bool copyFromReadahead = false;
+    
+    if (m_useReadahead) {
+        
+        // The classification scale has a one-hop readahead, so
+        // populate the readahead from further down the long
+        // unwindowed frame.
+
+        m_scaleData.at(classify)->analysisWindow.cut
+            (buf + (longest - classify) / 2 + inhop,
+             readahead.timeDomain.data());
+
+        // If inhop has changed since the previous frame, we must
+        // populate the classification scale (but for
+        // analysis/resynthesis rather than classification) anew
+        // rather than reuse the previous frame's readahead.
+
+        copyFromReadahead = cd->haveReadahead;
+        if (inhop != prevInhop) copyFromReadahead = false;
+    }
+    
+    if (!copyFromReadahead) {
+        m_scaleData.at(classify)->analysisWindow.cut
+            (buf + (longest - classify) / 2,
+             classifyScale->timeDomain.data());
+    }
+
+    // FFT shift, forward FFT, and carry out cartesian-polar
+    // conversion for each FFT size.
+
+    // For the classification scale we need magnitudes for the full
+    // range (polar only in a subset) and we operate in the readahead,
+    // pulling current values from the existing readahead (except
+    // where the inhop has changed as above, in which case we need to
+    // do both readahead and current)
+
+    if (m_useReadahead) {
+
+        if (copyFromReadahead) {
+            v_copy(classifyScale->mag.data(),
+                   readahead.mag.data(),
+                   classifyScale->bufSize);
+            v_copy(classifyScale->phase.data(),
+                   readahead.phase.data(),
+                   classifyScale->bufSize);
+        }
+
+        v_fftshift(readahead.timeDomain.data(), classify);
+        m_scaleData.at(classify)->fft.forward(readahead.timeDomain.data(),
+                                              classifyScale->real.data(),
+                                              classifyScale->imag.data());
+
+        for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+            const auto &band = m_guideConfiguration.fftBandLimits[b];
+            if (band.fftSize == classify) {
+                ToPolarSpec spec;
+                spec.magFromBin = 0;
+                spec.magBinCount = classify/2 + 1;
+                spec.polarFromBin = band.b0min;
+                spec.polarBinCount = band.b1max - band.b0min + 1;
+                convertToPolar(readahead.mag.data(),
+                               readahead.phase.data(),
+                               classifyScale->real.data(),
+                               classifyScale->imag.data(),
+                               spec);
+                    
+                v_scale(classifyScale->mag.data(),
+                        1.0 / double(classify),
+                        classifyScale->mag.size());
+                break;
+            }
+        }
+
+        cd->haveReadahead = true;
+    }
+
+    // For the others (and the classify as well, if the inhop has
+    // changed or we aren't using readahead or haven't filled the
+    // readahead yet) we operate directly in the scale data and
+    // restrict the range for cartesian-polar conversion
+            
+    for (auto &it: cd->scales) {
+        int fftSize = it.first;
+        if (fftSize == classify && copyFromReadahead) {
+            continue;
+        }
+        
+        auto &scale = it.second;
+        
+        v_fftshift(scale->timeDomain.data(), fftSize);
+
+        m_scaleData.at(fftSize)->fft.forward(scale->timeDomain.data(),
+                                             scale->real.data(),
+                                             scale->imag.data());
+
+        for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+            const auto &band = m_guideConfiguration.fftBandLimits[b];
+            if (band.fftSize == fftSize) {
+
+                ToPolarSpec spec;
+
+                // For the classify scale we always want the full
+                // range, as all the magnitudes (though not
+                // necessarily all phases) are potentially relevant to
+                // classification and formant analysis. But this case
+                // here only happens if we don't copyFromReadahead -
+                // the normal case is above and, er, copies from the
+                // previous readahead.
+                if (fftSize == classify) {
+                    spec.magFromBin = 0;
+                    spec.magBinCount = classify/2 + 1;
+                    spec.polarFromBin = band.b0min;
+                    spec.polarBinCount = band.b1max - band.b0min + 1;
+                } else {
+                    spec.magFromBin = band.b0min;
+                    spec.magBinCount = band.b1max - band.b0min + 1;
+                    spec.polarFromBin = spec.magFromBin;
+                    spec.polarBinCount = spec.magBinCount;
+                }
+
+                convertToPolar(scale->mag.data(),
+                               scale->phase.data(),
+                               scale->real.data(),
+                               scale->imag.data(),
+                               spec);
+
+                v_scale(scale->mag.data() + spec.magFromBin,
+                        1.0 / double(fftSize),
+                        spec.magBinCount);
+                
+                break;
+            }
+        }
+    }
+
+    if (m_parameters.options & RubberBandStretcher::OptionFormantPreserved) {
+        analyseFormant(c);
+        adjustFormant(c);
+    }
+        
+    // Use the classification scale to get a bin segmentation and
+    // calculate the adaptive frequency guide for this channel
+
+    v_copy(cd->classification.data(), cd->nextClassification.data(),
+           cd->classification.size());
+
+    if (m_useReadahead) {
+        cd->classifier->classify(readahead.mag.data(),
+                                 cd->nextClassification.data());
+    } else {
+        cd->classifier->classify(classifyScale->mag.data(),
+                                 cd->nextClassification.data());
+    }
+
+    cd->prevSegmentation = cd->segmentation;
+    cd->segmentation = cd->nextSegmentation;
+    cd->nextSegmentation = cd->segmenter->segment(cd->nextClassification.data());
+/*
+    if (c == 0) {
+        double pb = cd->nextSegmentation.percussiveBelow;
+        double pa = cd->nextSegmentation.percussiveAbove;
+        double ra = cd->nextSegmentation.residualAbove;
+        int pbb = binForFrequency(pb, classify, m_parameters.sampleRate);
+        int pab = binForFrequency(pa, classify, m_parameters.sampleRate);
+        int rab = binForFrequency(ra, classify, m_parameters.sampleRate);
+        std::cout << "pb = " << pb << ", pbb = " << pbb << std::endl;
+        std::cout << "pa = " << pa << ", pab = " << pab << std::endl;
+        std::cout << "ra = " << ra << ", rab = " << rab << std::endl;
+        std::cout << "s:";
+        for (int i = 0; i <= classify/2; ++i) {
+            if (i > 0) std::cout << ",";
+            if (i < pbb || (i >= pab && i <= rab)) {
+                std::cout << "1";
+            } else {
+                std::cout << "0";
+            }
+        }
+        std::cout << std::endl;
+    }
+*/
+
+    double ratio = getEffectiveRatio();
+
+    if (fabs(ratio - 1.0) < 1.0e-7) {
+        ++m_unityCount;
+    } else {
+        m_unityCount = 0;
+    }
+
+    bool tighterChannelLock =
+        m_parameters.options & RubberBandStretcher::OptionChannelsTogether;
+
+    double magMean = v_mean(classifyScale->mag.data() + 1, classify/2);
+
+    bool resetOnSilence = true;
+    if (useMidSide() && c == 1) {
+        // Do not phase reset on silence in the side channel - the
+        // reset is propagated across to the mid channel, giving
+        // constant resets for e.g. mono material in a stereo
+        // configuration
+        resetOnSilence = false;
+    }
+    
+    if (m_useReadahead) {
+        m_guide.updateGuidance(ratio,
+                               prevOuthop,
+                               classifyScale->mag.data(),
+                               classifyScale->prevMag.data(),
+                               cd->readahead.mag.data(),
+                               cd->segmentation,
+                               cd->prevSegmentation,
+                               cd->nextSegmentation,
+                               magMean,
+                               m_unityCount,
+                               isRealTime(),
+                               tighterChannelLock,
+                               resetOnSilence,
+                               cd->guidance);
+    } else {
+        m_guide.updateGuidance(ratio,
+                               prevOuthop,
+                               classifyScale->prevMag.data(),
+                               classifyScale->prevMag.data(),
+                               classifyScale->mag.data(),
+                               cd->segmentation,
+                               cd->prevSegmentation,
+                               cd->nextSegmentation,
+                               magMean,
+                               m_unityCount,
+                               isRealTime(),
+                               tighterChannelLock,
+                               resetOnSilence,
+                               cd->guidance);
+    }
+    
+/*
+    if (c == 0) {
+        if (cd->guidance.kick.present) {
+            std::cout << "k:2" << std::endl;
+        } else if (cd->guidance.preKick.present) {
+            std::cout << "k:1" << std::endl;
+        } else {
+            std::cout << "k:0" << std::endl;
+        }
+    }
+*/
+}
+
+void
+R3Stretcher::analyseFormant(int c)
+{
+    Profiler profiler("R3Stretcher::analyseFormant");
+
+    auto &cd = m_channelData.at(c);
+    auto &f = *cd->formant;
+
+    int fftSize = f.fftSize;
+    int binCount = fftSize/2 + 1;
+    
+    auto &scale = cd->scales.at(fftSize);
+    auto &scaleData = m_scaleData.at(fftSize);
+
+    scaleData->fft.inverseCepstral(scale->mag.data(), f.cepstra.data());
+    
+    int cutoff = int(floor(m_parameters.sampleRate / 650.0));
+    if (cutoff < 1) cutoff = 1;
+
+    f.cepstra[0] /= 2.0;
+    f.cepstra[cutoff-1] /= 2.0;
+    for (int i = cutoff; i < fftSize; ++i) {
+        f.cepstra[i] = 0.0;
+    }
+    v_scale(f.cepstra.data(), 1.0 / double(fftSize), cutoff);
+
+    scaleData->fft.forward(f.cepstra.data(), f.envelope.data(), f.spare.data());
+
+    v_exp(f.envelope.data(), binCount);
+    v_square(f.envelope.data(), binCount);
+
+    for (int i = 0; i < binCount; ++i) {
+        if (f.envelope[i] > 1.0e10) f.envelope[i] = 1.0e10;
+    }
+}
+
+void
+R3Stretcher::adjustFormant(int c)
+{
+    Profiler profiler("R3Stretcher::adjustFormant");
+
+    auto &cd = m_channelData.at(c);
+        
+    for (auto &it : cd->scales) {
+        
+        int fftSize = it.first;
+        auto &scale = it.second;
+
+        int highBin = int(floor(fftSize * 10000.0 / m_parameters.sampleRate));
+        process_t targetFactor = process_t(cd->formant->fftSize) / process_t(fftSize);
+        process_t formantScale = m_formantScale;
+        if (formantScale == 0.0) formantScale = 1.0 / m_pitchScale;
+        process_t sourceFactor = targetFactor / formantScale;
+        process_t maxRatio = 60.0;
+        process_t minRatio = 1.0 / maxRatio;
+
+        for (int b = 0; b < m_guideConfiguration.fftBandLimitCount; ++b) {
+            const auto &band = m_guideConfiguration.fftBandLimits[b];
+            if (band.fftSize != fftSize) continue;
+            for (int i = band.b0min; i < band.b1max && i < highBin; ++i) {
+                process_t source = cd->formant->envelopeAt(i * sourceFactor);
+                process_t target = cd->formant->envelopeAt(i * targetFactor);
+                if (target > 0.0) {
+                    process_t ratio = source / target;
+                    if (ratio < minRatio) ratio = minRatio;
+                    if (ratio > maxRatio) ratio = maxRatio;
+                    scale->mag[i] *= ratio;
+                }
+            }
+        }
+    }
+}
+
+void
+R3Stretcher::adjustPreKick(int c)
+{
+    if (isSingleWindowed()) return;
+    
+    Profiler profiler("R3Stretcher::adjustPreKick");
+
+    auto &cd = m_channelData.at(c);
+    auto fftSize = cd->guidance.fftBands[0].fftSize;
+    if (cd->guidance.preKick.present) {
+        auto &scale = cd->scales.at(fftSize);
+        int from = binForFrequency(cd->guidance.preKick.f0,
+                                   fftSize, m_parameters.sampleRate);
+        int to = binForFrequency(cd->guidance.preKick.f1,
+                                 fftSize, m_parameters.sampleRate);
+        for (int i = from; i <= to; ++i) {
+            process_t diff = scale->mag[i] - scale->prevMag[i];
+            if (diff > 0.0) {
+                scale->pendingKick[i] = diff;
+                scale->mag[i] -= diff;
+            }
+        }
+    } else if (cd->guidance.kick.present) {
+        auto &scale = cd->scales.at(fftSize);
+        int from = binForFrequency(cd->guidance.preKick.f0,
+                                   fftSize, m_parameters.sampleRate);
+        int to = binForFrequency(cd->guidance.preKick.f1,
+                                 fftSize, m_parameters.sampleRate);
+        for (int i = from; i <= to; ++i) {
+            scale->mag[i] += scale->pendingKick[i];
+            scale->pendingKick[i] = 0.0;
+        }
+    }                
+}
+
+void
+R3Stretcher::synthesiseChannel(int c, int outhop, bool draining)
+{
+    Profiler profiler("R3Stretcher::synthesiseChannel");
+    
+    int longest = m_guideConfiguration.longestFftSize;
+
+    auto &cd = m_channelData.at(c);
+
+    for (int b = 0; b < cd->guidance.fftBandCount; ++b) {
+
+        const auto &band = cd->guidance.fftBands[b];
+        int fftSize = band.fftSize;
+        
+        auto &scale = cd->scales.at(fftSize);
+        auto &scaleData = m_scaleData.at(fftSize);
+
+        // copy to prevMag before filtering
+        v_copy(scale->prevMag.data(),
+               scale->mag.data(),
+               scale->bufSize);
+
+        process_t winscale = process_t(outhop) / scaleData->windowScaleFactor;
+
+        // The frequency filter is applied naively in the frequency
+        // domain. Aliasing is reduced by the shorter resynthesis
+        // window. We resynthesise each scale individually, then sum -
+        // it's easier to manage scaling for in situations with a
+        // varying resynthesis hop
+            
+        int lowBin = binForFrequency(band.f0, fftSize, m_parameters.sampleRate);
+        int highBin = binForFrequency(band.f1, fftSize, m_parameters.sampleRate);
+        if (highBin % 2 == 0 && highBin > 0) --highBin;
+
+        int n = scale->mag.size();
+        if (lowBin >= n) lowBin = n - 1;
+        if (highBin >= n) highBin = n - 1;
+        if (highBin < lowBin) highBin = lowBin;
+        
+        if (lowBin > 0) {
+            v_zero(scale->real.data(), lowBin);
+            v_zero(scale->imag.data(), lowBin);
+        }
+
+        v_scale(scale->mag.data() + lowBin, winscale, highBin - lowBin);
+
+        v_polar_to_cartesian(scale->real.data() + lowBin,
+                             scale->imag.data() + lowBin,
+                             scale->mag.data() + lowBin,
+                             scale->advancedPhase.data() + lowBin,
+                             highBin - lowBin);
+        
+        if (highBin < scale->bufSize) {
+            v_zero(scale->real.data() + highBin, scale->bufSize - highBin);
+            v_zero(scale->imag.data() + highBin, scale->bufSize - highBin);
+        }
+
+        scaleData->fft.inverse(scale->real.data(),
+                               scale->imag.data(),
+                               scale->timeDomain.data());
+        
+        v_fftshift(scale->timeDomain.data(), fftSize);
+
+        // Synthesis window may be shorter than analysis window, so
+        // copy and cut only from the middle of the time-domain frame;
+        // and the accumulator length always matches the longest FFT
+        // size, so as to make mixing straightforward, so there is an
+        // additional offset needed for the target
+                
+        int synthesisWindowSize = scaleData->synthesisWindow.getSize();
+        int fromOffset = (fftSize - synthesisWindowSize) / 2;
+        int toOffset = (longest - synthesisWindowSize) / 2;
+
+        scaleData->synthesisWindow.cutAndAdd
+            (scale->timeDomain.data() + fromOffset,
+             scale->accumulator.data() + toOffset);
+    }
+
+    // Mix this channel and move the accumulator along
+            
+    float *mixptr = cd->mixdown.data();
+    v_zero(mixptr, outhop);
+
+    for (auto &it : cd->scales) {
+        auto &scale = it.second;
+
+        process_t *accptr = scale->accumulator.data();
+        for (int i = 0; i < outhop; ++i) {
+            mixptr[i] += float(accptr[i]);
+        }
+
+        int n = scale->accumulator.size() - outhop;
+        v_move(accptr, accptr + outhop, n);
+        v_zero(accptr + n, outhop);
+
+        if (draining) {
+            if (scale->accumulatorFill > outhop) {
+                auto newFill = scale->accumulatorFill - outhop;
+                m_log.log(2, "draining: reducing accumulatorFill from, to", scale->accumulatorFill, newFill);
+                scale->accumulatorFill = newFill;
+            } else {
+                scale->accumulatorFill = 0;
+            }
+        } else {
+            scale->accumulatorFill = scale->accumulator.size();
+        }
+    }
+}
+
+}
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/R3Stretcher.h
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/finer/R3Stretcher.h
@@ -1,0 +1,510 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_R3_STRETCHERIMPL_H
+#define RUBBERBAND_R3_STRETCHERIMPL_H
+
+#include "BinSegmenter.h"
+#include "Guide.h"
+#include "Peak.h"
+#include "PhaseAdvance.h"
+
+#include "../common/StretchCalculator.h"
+#include "../common/Resampler.h"
+#include "../common/FFT.h"
+#include "../common/FixedVector.h"
+#include "../common/Allocators.h"
+#include "../common/Window.h"
+#include "../common/VectorOpsComplex.h"
+#include "../common/Log.h"
+
+#include "../../rubberband/RubberBandStretcher.h"
+
+#include <map>
+#include <memory>
+#include <atomic>
+
+namespace RubberBand
+{
+
+class R3Stretcher
+{
+public:
+    struct Parameters {
+        double sampleRate;
+        int channels;
+        RubberBandStretcher::Options options;
+        Parameters(double _sampleRate, int _channels,
+                   RubberBandStretcher::Options _options) :
+            sampleRate(_sampleRate), channels(_channels), options(_options) { }
+    };
+    
+    R3Stretcher(Parameters parameters,
+                double initialTimeRatio,
+                double initialPitchScale,
+                Log log);
+    ~R3Stretcher() { }
+
+    void reset();
+    
+    void setTimeRatio(double ratio);
+    void setPitchScale(double scale);
+    void setFormantScale(double scale);
+
+    double getTimeRatio() const;
+    double getPitchScale() const;
+    double getFormantScale() const;
+
+    void setKeyFrameMap(const std::map<size_t, size_t> &);
+
+    void setFormantOption(RubberBandStretcher::Options);
+    void setPitchOption(RubberBandStretcher::Options);
+    
+    void study(const float *const *input, size_t samples, bool final);
+    size_t getSamplesRequired() const;
+    void process(const float *const *input, size_t samples, bool final);
+    int available() const;
+    size_t retrieve(float *const *output, size_t samples) const;
+
+    size_t getPreferredStartPad() const;
+    size_t getStartDelay() const;
+    
+    size_t getChannelCount() const;
+
+    void setExpectedInputDuration(size_t samples);
+    void setMaxProcessSize(size_t samples);
+    size_t getProcessSizeLimit() const;
+    
+    void setDebugLevel(int level) {
+        m_log.setDebugLevel(level);
+        for (auto &sd : m_scaleData) {
+            sd.second->guided.setDebugLevel(level);
+        }
+        m_guide.setDebugLevel(level);
+        m_calculator->setDebugLevel(level);
+    }
+
+protected:
+    struct Limits {
+        int minPreferredOuthop;
+        int maxPreferredOuthop;
+        int minInhop;
+        int maxInhopWithReadahead;
+        int maxInhop;
+        int overallMaxProcessSize;
+        Limits(RubberBandStretcher::Options options, double rate) :
+            // commented values are results when rate = 44100 or 48000
+            minPreferredOuthop(roundUpDiv(rate, 512)), // 128
+            maxPreferredOuthop(roundUpDiv(rate, 128)), // 512
+            minInhop(1),
+            maxInhopWithReadahead(roundUpDiv(rate, 64)), // 1024
+            maxInhop(roundUpDiv(rate, 32)),              // 2048
+            overallMaxProcessSize(524288) {
+            if (options & RubberBandStretcher::OptionWindowShort) {
+                // See note in calculateHop
+                minPreferredOuthop = roundUpDiv(rate, 256); // 256
+                maxPreferredOuthop = (roundUpDiv(rate, 128) * 5) / 4; // 640
+                maxInhopWithReadahead = roundUpDiv(rate, 128); // 512
+                maxInhop = (roundUpDiv(rate, 64) * 3) / 2; // 1536
+            }
+        }
+    };
+    
+    struct ClassificationReadaheadData {
+        FixedVector<process_t> timeDomain;
+        FixedVector<process_t> mag;
+        FixedVector<process_t> phase;
+        ClassificationReadaheadData(int _fftSize) :
+            timeDomain(_fftSize, 0.f),
+            mag(_fftSize/2 + 1, 0.f),
+            phase(_fftSize/2 + 1, 0.f)
+        { }
+
+    private:
+        ClassificationReadaheadData(const ClassificationReadaheadData &) =delete;
+        ClassificationReadaheadData &operator=(const ClassificationReadaheadData &) =delete;
+    };
+    
+    struct ChannelScaleData {
+        int fftSize;
+        int bufSize; // size of every freq-domain array here: fftSize/2 + 1
+        FixedVector<process_t> timeDomain;
+        FixedVector<process_t> real;
+        FixedVector<process_t> imag;
+        FixedVector<process_t> mag;
+        FixedVector<process_t> phase;
+        FixedVector<process_t> advancedPhase;
+        FixedVector<process_t> prevMag;
+        FixedVector<process_t> pendingKick;
+        FixedVector<process_t> accumulator;
+        int accumulatorFill;
+
+        ChannelScaleData(int _fftSize, int _longestFftSize) :
+            fftSize(_fftSize),
+            bufSize(fftSize/2 + 1),
+            timeDomain(fftSize, 0.f),
+            real(bufSize, 0.f),
+            imag(bufSize, 0.f),
+            mag(bufSize, 0.f),
+            phase(bufSize, 0.f),
+            advancedPhase(bufSize, 0.f),
+            prevMag(bufSize, 0.f),
+            pendingKick(bufSize, 0.f),
+            accumulator(_longestFftSize, 0.f),
+            accumulatorFill(0)
+        { }
+
+        void reset() {
+            v_zero(prevMag.data(), prevMag.size());
+            v_zero(pendingKick.data(), pendingKick.size());
+            v_zero(accumulator.data(), accumulator.size());
+            accumulatorFill = 0;
+        }
+
+    private:
+        ChannelScaleData(const ChannelScaleData &) =delete;
+        ChannelScaleData &operator=(const ChannelScaleData &) =delete;
+    };
+
+    struct FormantData {
+        int fftSize;
+        FixedVector<process_t> cepstra;
+        FixedVector<process_t> envelope;
+        FixedVector<process_t> spare;
+
+        FormantData(int _fftSize) :
+            fftSize(_fftSize),
+            cepstra(_fftSize, 0.0),
+            envelope(_fftSize/2 + 1, 0.0),
+            spare(_fftSize/2 + 1, 0.0) { }
+
+        process_t envelopeAt(process_t bin) const {
+            int b0 = int(floor(bin)), b1 = int(ceil(bin));
+            if (b0 < 0 || b0 > fftSize/2) {
+                return 0.0;
+            } else if (b1 == b0 || b1 > fftSize/2) {
+                return envelope.at(b0);
+            } else {
+                process_t diff = bin - process_t(b0);
+                return envelope.at(b0) * (1.0 - diff) + envelope.at(b1) * diff;
+            }
+        }
+    };
+
+    struct ChannelData {
+        std::map<int, std::shared_ptr<ChannelScaleData>> scales;
+        FixedVector<process_t> windowSource;
+        ClassificationReadaheadData readahead;
+        bool haveReadahead;
+        std::unique_ptr<BinClassifier> classifier;
+        FixedVector<BinClassifier::Classification> classification;
+        FixedVector<BinClassifier::Classification> nextClassification;
+        std::unique_ptr<BinSegmenter> segmenter;
+        BinSegmenter::Segmentation segmentation;
+        BinSegmenter::Segmentation prevSegmentation;
+        BinSegmenter::Segmentation nextSegmentation;
+        Guide::Guidance guidance;
+        FixedVector<float> mixdown;
+        FixedVector<float> resampled;
+        std::unique_ptr<RingBuffer<float>> inbuf;
+        std::unique_ptr<RingBuffer<float>> outbuf;
+        std::unique_ptr<FormantData> formant;
+        ChannelData(BinSegmenter::Parameters segmenterParameters,
+                    BinClassifier::Parameters classifierParameters,
+                    int windowSourceSize,
+                    int inRingBufferSize,
+                    int outRingBufferSize,
+                    int hopBufferSize) :
+            scales(),
+            windowSource(windowSourceSize, 0.0),
+            readahead(segmenterParameters.fftSize),
+            haveReadahead(false),
+            classifier(new BinClassifier(classifierParameters)),
+            classification(classifierParameters.binCount,
+                           BinClassifier::Classification::Residual),
+            nextClassification(classifierParameters.binCount,
+                               BinClassifier::Classification::Residual),
+            segmenter(new BinSegmenter(segmenterParameters)),
+            segmentation(), prevSegmentation(), nextSegmentation(),
+            mixdown(inRingBufferSize, 0.f),
+            resampled(hopBufferSize, 0.f),
+            inbuf(new RingBuffer<float>(inRingBufferSize)),
+            outbuf(new RingBuffer<float>(outRingBufferSize)),
+            formant(new FormantData(segmenterParameters.fftSize)) { }
+        void reset() {
+            haveReadahead = false;
+            classifier->reset();
+            segmentation = BinSegmenter::Segmentation();
+            prevSegmentation = BinSegmenter::Segmentation();
+            nextSegmentation = BinSegmenter::Segmentation();
+            for (size_t i = 0; i < nextClassification.size(); ++i) {
+                nextClassification[i] = BinClassifier::Classification::Residual;
+            }
+            inbuf->reset();
+            outbuf->reset();
+            for (auto &s : scales) {
+                s.second->reset();
+            }
+        }
+    };
+
+    struct ChannelAssembly {
+        // Vectors of bare pointers, used to package container data
+        // from different channels into arguments for PhaseAdvance
+        FixedVector<const float *> input;
+        FixedVector<process_t *> mag;
+        FixedVector<process_t *> phase;
+        FixedVector<process_t *> prevMag;
+        FixedVector<Guide::Guidance *> guidance;
+        FixedVector<process_t *> outPhase;
+        FixedVector<float *> mixdown;
+        FixedVector<float *> resampled;
+        ChannelAssembly(int channels) :
+            input(channels, nullptr),
+            mag(channels, nullptr), phase(channels, nullptr),
+            prevMag(channels, nullptr), guidance(channels, nullptr),
+            outPhase(channels, nullptr), mixdown(channels, nullptr),
+            resampled(channels, nullptr) { }
+    };
+
+    struct ScaleData {
+        int fftSize;
+        bool singleWindowMode;
+        FFT fft;
+        Window<process_t> analysisWindow;
+        Window<process_t> synthesisWindow;
+        process_t windowScaleFactor;
+        GuidedPhaseAdvance guided;
+
+        ScaleData(GuidedPhaseAdvance::Parameters guidedParameters,
+                  Log log) :
+            fftSize(guidedParameters.fftSize),
+            singleWindowMode(guidedParameters.singleWindowMode),
+            fft(fftSize),
+            analysisWindow(analysisWindowShape(),
+                           analysisWindowLength()),
+            synthesisWindow(synthesisWindowShape(),
+                            synthesisWindowLength()),
+            windowScaleFactor(0.0),
+            guided(guidedParameters, log)
+        {
+            int asz = analysisWindow.getSize(), ssz = synthesisWindow.getSize();
+            int off = (asz - ssz) / 2;
+            for (int i = 0; i < ssz; ++i) {
+                windowScaleFactor += analysisWindow.getValue(i + off) *
+                    synthesisWindow.getValue(i);
+            }
+        }
+
+        WindowType analysisWindowShape();
+        int analysisWindowLength();
+        WindowType synthesisWindowShape();
+        int synthesisWindowLength();
+    };
+    
+    Log m_log;
+    Parameters m_parameters;
+    const Limits m_limits;
+
+    std::atomic<double> m_timeRatio;
+    std::atomic<double> m_pitchScale;
+    std::atomic<double> m_formantScale;
+    
+    std::vector<std::shared_ptr<ChannelData>> m_channelData;
+    std::map<int, std::shared_ptr<ScaleData>> m_scaleData;
+    Guide m_guide;
+    Guide::Configuration m_guideConfiguration;
+    ChannelAssembly m_channelAssembly;
+    std::unique_ptr<StretchCalculator> m_calculator;
+    std::unique_ptr<Resampler> m_resampler;
+    bool m_useReadahead;
+    std::atomic<int> m_inhop;
+    int m_prevInhop;
+    int m_prevOuthop;
+    uint32_t m_unityCount;
+    int m_startSkip;
+
+    size_t m_studyInputDuration;
+    size_t m_suppliedInputDuration;
+    size_t m_totalTargetDuration;
+    size_t m_consumedInputDuration;
+    size_t m_lastKeyFrameSurpassed;
+    size_t m_totalOutputDuration;
+    std::map<size_t, size_t> m_keyFrameMap;
+    
+    enum class ProcessMode {
+        JustCreated,
+        Studying,
+        Processing,
+        Finished
+    };
+    ProcessMode m_mode;
+
+    void initialise();
+    void prepareInput(const float *const *input, int ix, int n);
+    void consume(bool final);
+    void createResampler();
+    void ensureInbuf(int, bool warn = true);
+    void ensureOutbuf(int, bool warn = true);
+    void calculateHop();
+    void updateRatioFromMap();
+    void analyseChannel(int channel, int inhop, int prevInhop, int prevOuthop);
+    void analyseFormant(int channel);
+    void adjustFormant(int channel);
+    void adjustPreKick(int channel);
+    void synthesiseChannel(int channel, int outhop, bool draining);
+
+    struct ToPolarSpec {
+        int magFromBin;
+        int magBinCount;
+        int polarFromBin;
+        int polarBinCount;
+    };
+
+    Parameters validateSampleRate(const Parameters &params) {
+        Parameters validated { params };
+        double minRate = 8000.0, maxRate = 192000.0;
+        if (params.sampleRate < minRate) {
+            m_log.log(0, "R3Stretcher: WARNING: Unsupported sample rate", params.sampleRate);
+            m_log.log(0, "R3Stretcher: Minimum rate is", minRate);
+            validated.sampleRate = minRate;
+        } else if (params.sampleRate > maxRate) {
+            m_log.log(0, "R3Stretcher: WARNING: Unsupported sample rate", params.sampleRate);
+            m_log.log(0, "R3Stretcher: Maximum rate is", maxRate);
+            validated.sampleRate = maxRate;
+        }
+        return validated;
+    }
+    
+    void convertToPolar(process_t *mag, process_t *phase,
+                        const process_t *real, const process_t *imag,
+                        const ToPolarSpec &s) const {
+        v_cartesian_to_polar(mag + s.polarFromBin,
+                             phase + s.polarFromBin,
+                             real + s.polarFromBin,
+                             imag + s.polarFromBin,
+                             s.polarBinCount);
+        if (s.magFromBin < s.polarFromBin) {
+            v_cartesian_to_magnitudes(mag + s.magFromBin,
+                                      real + s.magFromBin,
+                                      imag + s.magFromBin,
+                                      s.polarFromBin - s.magFromBin);
+        }
+        if (s.magFromBin + s.magBinCount > s.polarFromBin + s.polarBinCount) {
+            v_cartesian_to_magnitudes(mag + s.polarFromBin + s.polarBinCount,
+                                      real + s.polarFromBin + s.polarBinCount,
+                                      imag + s.polarFromBin + s.polarBinCount,
+                                      s.magFromBin + s.magBinCount -
+                                      s.polarFromBin - s.polarBinCount);
+        }
+    }
+    
+    double getEffectiveRatio() const {
+        return m_timeRatio * m_pitchScale;
+    }
+
+    bool isRealTime() const {
+        return m_parameters.options &
+            RubberBandStretcher::OptionProcessRealTime;
+    }
+
+    void areWeResampling(bool *before, bool *after) const {
+
+        if (before) *before = false;
+        if (after) *after = false;
+
+        // Some of the logic about when/whether to resample may have
+        // already been decided, because we might not have a
+        // resampler. This call is for the processing path, we don't
+        // make big decisions here and can't be saying we should
+        // resample if there is no resampler
+        if (!m_resampler) return;
+
+        // In offline mode we always ignore the OptionPitch setting
+        // and resample afterwards, like OptionPitchHighConsistency
+        // (except that we don't resample for ratio of 1.0). This is
+        // because (a) the initial algorithm was developed and tested
+        // that way, (b) R2 works that way and nobody has ever
+        // complained, and (c) otherwise for the command-line tool
+        // (which is probably the most common way to use RB offline)
+        // we would have to choose between defaulting to lower-quality
+        // OptionPitchHighSpeed or offering yet another setting, both
+        // of which are undesirable.
+        
+        if (!isRealTime()) {
+            if (m_pitchScale != 1.0) {
+                // Offline, any pitch scale
+                if (after) *after = true;
+            }
+        } else if (m_parameters.options &
+                   RubberBandStretcher::OptionPitchHighConsistency) {
+            // RT, any pitch scale, HC
+            if (after) *after = true;
+            
+        } else if (m_pitchScale != 1.0) {
+
+            bool hq = (m_parameters.options &
+                       RubberBandStretcher::OptionPitchHighQuality);
+            // We already handled OptionPitchHighConsistency, so if
+            // !hq then we must be HighSpeed
+            if (m_pitchScale > 1.0) {
+                if (hq) {
+                    if (after) *after = true;
+                } else {
+                    if (before) *before = true;
+                }
+            } else if (m_pitchScale < 1.0) {
+                if (hq) {
+                    if (before) *before = true;
+                } else {
+                    if (after) *after = true;
+                }
+            }
+        }
+    }        
+
+    bool useMidSide() const {
+        return m_parameters.channels == 2 &&
+            (m_parameters.options &
+             RubberBandStretcher::OptionChannelsTogether);
+    }
+    
+    bool isSingleWindowed() const {
+        return m_parameters.options &
+            RubberBandStretcher::OptionWindowShort;
+    }
+
+    int getWindowSourceSize() const {
+        int sz = m_guideConfiguration.classificationFftSize +
+            m_limits.maxInhopWithReadahead;
+        if (m_guideConfiguration.longestFftSize > sz) {
+            return m_guideConfiguration.longestFftSize;
+        } else {
+            return sz;
+        }
+    }
+};
+
+}
+
+#endif

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/jni/RubberBandStretcherJNI.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/jni/RubberBandStretcherJNI.cpp
@@ -1,0 +1,650 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "rubberband/RubberBandStretcher.h"
+#include "rubberband/RubberBandLiveShifter.h"
+
+#include "common/Allocators.h"
+
+#include <jni.h>
+
+using namespace RubberBand;
+
+extern "C" {
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    dispose
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_dispose
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    reset
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_reset
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setTimeRatio
+ * Signature: (D)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setTimeRatio
+  (JNIEnv *, jobject, jdouble);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setPitchScale
+ * Signature: (D)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setPitchScale
+  (JNIEnv *, jobject, jdouble);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    getChannelCount
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_getChannelCount
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    getTimeRatio
+ * Signature: ()D
+ */
+JNIEXPORT jdouble JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_getTimeRatio
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    getPitchScale
+ * Signature: ()D
+ */
+JNIEXPORT jdouble JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_getPitchScale
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    getPreferredStartPad
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_getPreferredStartPad
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    getStartDelay
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_getStartDelay
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    getLatency
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_getLatency
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setTransientsOption
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setTransientsOption
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setDetectorOption
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setDetectorOption
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setPhaseOption
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setPhaseOption
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setFormantOption
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setFormantOption
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setPitchOption
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setPitchOption
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setExpectedInputDuration
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setExpectedInputDuration
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setMaxProcessSize
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setMaxProcessSize
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    getProcessSizeLimit
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_getProcessSizeLimit
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    getSamplesRequired
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_getSamplesRequired
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    setKeyFrameMap
+ * Signature: ([J[J)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_setKeyFrameMap
+  (JNIEnv *, jobject, jlongArray, jlongArray);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    study
+ * Signature: ([[FZ)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_study
+  (JNIEnv *, jobject, jobjectArray, jint, jint, jboolean);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    process
+ * Signature: ([[FZ)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_process
+  (JNIEnv *, jobject, jobjectArray, jint, jint, jboolean);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    available
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_available
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    retrieve
+ * Signature: (I)[[F
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_retrieve
+  (JNIEnv *, jobject, jobjectArray, jint, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandStretcher
+ * Method:    initialise
+ * Signature: (IIIDD)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandStretcher_initialise
+  (JNIEnv *, jobject, jint, jint, jint, jdouble, jdouble);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    dispose
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_dispose
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    reset
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_reset
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    setPitchScale
+ * Signature: (D)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_setPitchScale
+  (JNIEnv *, jobject, jdouble);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    getChannelCount
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_getChannelCount
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    getPitchScale
+ * Signature: ()D
+ */
+JNIEXPORT jdouble JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_getPitchScale
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    getStartDelay
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_getStartDelay
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    setFormantOption
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_setFormantOption
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    getBlockSize
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_getBlockSize
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    shift
+ * Signature: ([[FI[[FI)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_shift
+(JNIEnv *, jobject, jobjectArray, jint, jobjectArray, jint);
+
+/*
+ * Class:     com_breakfastquay_rubberband_RubberBandLiveShifter
+ * Method:    initialise
+ * Signature: (III)V
+ */
+JNIEXPORT void JNICALL Java_com_breakfastquay_rubberband_RubberBandLiveShifter_initialise
+  (JNIEnv *, jobject, jint, jint, jint);
+
+}
+
+RubberBandStretcher *
+getStretcher(JNIEnv *env, jobject obj)
+{
+    jclass c = env->GetObjectClass(obj);
+    jfieldID fid = env->GetFieldID(c, "handle", "J");
+    jlong handle = env->GetLongField(obj, fid);
+    return (RubberBandStretcher *)handle;
+}
+
+void
+setStretcher(JNIEnv *env, jobject obj, RubberBandStretcher *stretcher)
+{
+    jclass c = env->GetObjectClass(obj);
+    jfieldID fid = env->GetFieldID(c, "handle", "J");
+    jlong handle = (jlong)stretcher;
+    env->SetLongField(obj, fid, handle);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_initialise(JNIEnv *env, jobject obj, jint sampleRate, jint channels, jint options, jdouble initialTimeRatio, jdouble initialPitchScale)
+{
+    setStretcher(env, obj, new RubberBandStretcher
+                 (sampleRate, channels, options, initialTimeRatio, initialPitchScale));
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_dispose(JNIEnv *env, jobject obj)
+{
+    delete getStretcher(env, obj);
+    setStretcher(env, obj, 0);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_reset(JNIEnv *env, jobject obj)
+{
+    getStretcher(env, obj)->reset();
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setTimeRatio(JNIEnv *env, jobject obj, jdouble ratio)
+{
+    getStretcher(env, obj)->setTimeRatio(ratio);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setPitchScale(JNIEnv *env, jobject obj, jdouble scale)
+{
+    getStretcher(env, obj)->setPitchScale(scale);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_getChannelCount(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->getChannelCount();
+}
+
+JNIEXPORT jdouble JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_getTimeRatio(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->getTimeRatio();
+}
+
+JNIEXPORT jdouble JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_getPitchScale(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->getPitchScale();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_getPreferredStartPad(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->getPreferredStartPad();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_getStartDelay(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->getStartDelay();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_getLatency(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->getLatency();
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setTransientsOption(JNIEnv *env, jobject obj, jint options)
+{
+    getStretcher(env, obj)->setTransientsOption(options);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setDetectorOption(JNIEnv *env, jobject obj, jint options)
+{
+    getStretcher(env, obj)->setDetectorOption(options);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setPhaseOption(JNIEnv *env, jobject obj, jint options)
+{
+    getStretcher(env, obj)->setPhaseOption(options);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setFormantOption(JNIEnv *env, jobject obj, jint options)
+{
+    getStretcher(env, obj)->setFormantOption(options);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setPitchOption(JNIEnv *env, jobject obj, jint options)
+{
+    getStretcher(env, obj)->setPitchOption(options);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setExpectedInputDuration(JNIEnv *env, jobject obj, jlong duration)
+{
+    getStretcher(env, obj)->setExpectedInputDuration(duration);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setMaxProcessSize(JNIEnv *env, jobject obj, jint size)
+{
+    getStretcher(env, obj)->setMaxProcessSize(size);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_getProcessSizeLimit(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->getProcessSizeLimit();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_getSamplesRequired(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->getSamplesRequired();
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_setKeyFrameMap(JNIEnv *env, jobject obj, jlongArray from, jlongArray to)
+{
+    std::map<size_t, size_t> m;
+    int flen = env->GetArrayLength(from);
+    int tlen = env->GetArrayLength(to);
+    jlong *farr = env->GetLongArrayElements(from, 0);
+    jlong *tarr = env->GetLongArrayElements(to, 0);
+    for (int i = 0; i < flen && i < tlen; ++i) {
+        m[farr[i]] = tarr[i];
+    }
+    env->ReleaseLongArrayElements(from, farr, 0);
+    env->ReleaseLongArrayElements(to, tarr, 0);
+    getStretcher(env, obj)->setKeyFrameMap(m);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_study(JNIEnv *env, jobject obj, jobjectArray input, jint offset, jint n, jboolean final)
+{
+    int channels = env->GetArrayLength(input);
+    float **arr = allocate<float *>(channels);
+    float **inbuf = allocate<float *>(channels);
+    for (int c = 0; c < channels; ++c) {
+        jfloatArray cdata = (jfloatArray)env->GetObjectArrayElement(input, c);
+        arr[c] = env->GetFloatArrayElements(cdata, 0);
+        inbuf[c] = arr[c] + offset;
+    }
+
+    getStretcher(env, obj)->study(inbuf, n, final);
+
+    for (int c = 0; c < channels; ++c) {
+        jfloatArray cdata = (jfloatArray)env->GetObjectArrayElement(input, c);
+        env->ReleaseFloatArrayElements(cdata, arr[c], 0);
+    }
+
+    deallocate(inbuf);
+    deallocate(arr);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_process(JNIEnv *env, jobject obj, jobjectArray input, jint offset, jint n, jboolean final)
+{
+    int channels = env->GetArrayLength(input);
+    float **arr = allocate<float *>(channels);
+    float **inbuf = allocate<float *>(channels);
+    for (int c = 0; c < channels; ++c) {
+        jfloatArray cdata = (jfloatArray)env->GetObjectArrayElement(input, c);
+        arr[c] = env->GetFloatArrayElements(cdata, 0);
+        inbuf[c] = arr[c] + offset;
+    }
+
+    getStretcher(env, obj)->process(inbuf, n, final);
+
+    for (int c = 0; c < channels; ++c) {
+        jfloatArray cdata = (jfloatArray)env->GetObjectArrayElement(input, c);
+        env->ReleaseFloatArrayElements(cdata, arr[c], 0);
+    }
+
+    deallocate(inbuf);
+    deallocate(arr);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_available(JNIEnv *env, jobject obj)
+{
+    return getStretcher(env, obj)->available();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandStretcher_retrieve(JNIEnv *env, jobject obj, jobjectArray output, jint offset, jint n)
+{
+    RubberBandStretcher *stretcher = getStretcher(env, obj);
+    size_t channels = stretcher->getChannelCount();
+    
+    float **outbuf = allocate_channels<float>(channels, n);
+    size_t retrieved = stretcher->retrieve(outbuf, n);
+
+    for (size_t c = 0; c < channels; ++c) {
+        jfloatArray cdata = (jfloatArray)env->GetObjectArrayElement(output, c);
+        env->SetFloatArrayRegion(cdata, offset, retrieved, outbuf[c]);
+    }
+    
+    deallocate_channels(outbuf, channels);
+    return retrieved;
+}
+
+RubberBandLiveShifter *
+getLiveShifter(JNIEnv *env, jobject obj)
+{
+    jclass c = env->GetObjectClass(obj);
+    jfieldID fid = env->GetFieldID(c, "handle", "J");
+    jlong handle = env->GetLongField(obj, fid);
+    return (RubberBandLiveShifter *)handle;
+}
+
+void
+setLiveShifter(JNIEnv *env, jobject obj, RubberBandLiveShifter *stretcher)
+{
+    jclass c = env->GetObjectClass(obj);
+    jfieldID fid = env->GetFieldID(c, "handle", "J");
+    jlong handle = (jlong)stretcher;
+    env->SetLongField(obj, fid, handle);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_initialise(JNIEnv *env, jobject obj, jint sampleRate, jint channels, jint options)
+{
+    setLiveShifter(env, obj, new RubberBandLiveShifter
+                   (sampleRate, channels, options));
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_dispose(JNIEnv *env, jobject obj)
+{
+    delete getLiveShifter(env, obj);
+    setLiveShifter(env, obj, 0);
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_reset(JNIEnv *env, jobject obj)
+{
+    getLiveShifter(env, obj)->reset();
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_setPitchScale(JNIEnv *env, jobject obj, jdouble scale)
+{
+    getLiveShifter(env, obj)->setPitchScale(scale);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_getChannelCount(JNIEnv *env, jobject obj)
+{
+    return getLiveShifter(env, obj)->getChannelCount();
+}
+
+JNIEXPORT jdouble JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_getPitchScale(JNIEnv *env, jobject obj)
+{
+    return getLiveShifter(env, obj)->getPitchScale();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_getStartDelay(JNIEnv *env, jobject obj)
+{
+    return getLiveShifter(env, obj)->getStartDelay();
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_setFormantOption(JNIEnv *env, jobject obj, jint options)
+{
+    getLiveShifter(env, obj)->setFormantOption(options);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_getBlockSize(JNIEnv *env, jobject obj)
+{
+    return getLiveShifter(env, obj)->getBlockSize();
+}
+
+JNIEXPORT void JNICALL
+Java_com_breakfastquay_rubberband_RubberBandLiveShifter_shift(JNIEnv *env, jobject obj, jobjectArray input, jint inOffset, jobjectArray output, jint outOffset)
+{
+    int channels = env->GetArrayLength(input);
+    float **inarr = allocate<float *>(channels);
+    float **inbuf = allocate<float *>(channels);
+    float **outarr = allocate<float *>(channels);
+    float **outbuf = allocate<float *>(channels);
+
+    for (int c = 0; c < channels; ++c) {
+        jfloatArray cdata = (jfloatArray)env->GetObjectArrayElement(input, c);
+        inarr[c] = env->GetFloatArrayElements(cdata, 0);
+        inbuf[c] = inarr[c] + inOffset;
+        cdata = (jfloatArray)env->GetObjectArrayElement(output, c);
+        outarr[c] = env->GetFloatArrayElements(cdata, 0);
+        outbuf[c] = outarr[c] + outOffset;
+    }
+
+    getLiveShifter(env, obj)->shift(inbuf, outbuf);
+
+    for (int c = 0; c < channels; ++c) {
+        jfloatArray cdata = (jfloatArray)env->GetObjectArrayElement(input, c);
+        env->ReleaseFloatArrayElements(cdata, inarr[c], 0);
+        cdata = (jfloatArray)env->GetObjectArrayElement(output, c);
+        env->ReleaseFloatArrayElements(cdata, outarr[c], 0);
+    }
+
+    deallocate(inbuf);
+    deallocate(inarr);
+    deallocate(outbuf);
+    deallocate(outarr);
+}
+
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/rubberband-c.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/rubberband-c.cpp
@@ -1,0 +1,280 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "../rubberband/rubberband-c.h"
+#include "../rubberband/RubberBandStretcher.h"
+#include "../rubberband/RubberBandLiveShifter.h"
+
+struct RubberBandState_
+{
+    RubberBand::RubberBandStretcher *m_s;
+};
+
+RubberBandState rubberband_new(unsigned int sampleRate,
+                               unsigned int channels,
+                               RubberBandOptions options,
+                               double initialTimeRatio,
+                               double initialPitchScale)
+{
+    RubberBandState_ *state = new RubberBandState_();
+    state->m_s = new RubberBand::RubberBandStretcher
+        (sampleRate, channels, options,
+         initialTimeRatio, initialPitchScale);
+    return state;
+}
+
+void rubberband_delete(RubberBandState state)
+{
+    delete state->m_s;
+    delete state;
+}
+
+void rubberband_reset(RubberBandState state)
+{
+    state->m_s->reset();
+}
+
+int rubberband_get_engine_version(RubberBandState state)
+{
+    return state->m_s->getEngineVersion(); 
+}
+
+void rubberband_set_time_ratio(RubberBandState state, double ratio)
+{
+    state->m_s->setTimeRatio(ratio);
+}
+
+void rubberband_set_pitch_scale(RubberBandState state, double scale)
+{
+    state->m_s->setPitchScale(scale);
+}
+
+double rubberband_get_time_ratio(const RubberBandState state) 
+{
+    return state->m_s->getTimeRatio();
+}
+
+double rubberband_get_pitch_scale(const RubberBandState state)
+{
+    return state->m_s->getPitchScale();
+}
+
+void rubberband_set_formant_scale(RubberBandState state, double scale)
+{
+    state->m_s->setFormantScale(scale);
+}
+
+double rubberband_get_formant_scale(const RubberBandState state)
+{
+    return state->m_s->getFormantScale();
+}
+
+unsigned int rubberband_get_preferred_start_pad(const RubberBandState state) 
+{
+    return (unsigned int)state->m_s->getPreferredStartPad();
+}
+
+unsigned int rubberband_get_start_delay(const RubberBandState state) 
+{
+    return (unsigned int)state->m_s->getStartDelay();
+}
+
+unsigned int rubberband_get_latency(const RubberBandState state) 
+{
+    return (unsigned int)state->m_s->getLatency();
+}
+
+void rubberband_set_transients_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setTransientsOption(options);
+}
+
+void rubberband_set_detector_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setDetectorOption(options);
+}
+
+void rubberband_set_phase_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setPhaseOption(options);
+}
+
+void rubberband_set_formant_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setFormantOption(options);
+}
+
+void rubberband_set_pitch_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setPitchOption(options);
+}
+
+void rubberband_set_expected_input_duration(RubberBandState state, unsigned int samples)
+{
+    state->m_s->setExpectedInputDuration(samples);
+}
+
+unsigned int rubberband_get_samples_required(const RubberBandState state)
+{
+    return (unsigned int)state->m_s->getSamplesRequired();
+}
+
+void rubberband_set_max_process_size(RubberBandState state, unsigned int samples)
+{
+    state->m_s->setMaxProcessSize(samples);
+}
+
+unsigned int rubberband_get_process_size_limit(RubberBandState state)
+{
+    return (unsigned int)state->m_s->getProcessSizeLimit();
+}
+
+void rubberband_set_key_frame_map(RubberBandState state, unsigned int keyframecount, unsigned int *from, unsigned int *to)
+{
+    std::map<size_t, size_t> kfm;
+    for (unsigned int i = 0; i < keyframecount; ++i) {
+        kfm[from[i]] = to[i];
+    }
+    state->m_s->setKeyFrameMap(kfm);
+}
+
+void rubberband_study(RubberBandState state, const float *const *input, unsigned int samples, int final)
+{
+    state->m_s->study(input, samples, final != 0);
+}
+
+void rubberband_process(RubberBandState state, const float *const *input, unsigned int samples, int final)
+{
+    state->m_s->process(input, samples, final != 0);
+}
+
+int rubberband_available(const RubberBandState state)
+{
+    return state->m_s->available();
+}
+
+unsigned int rubberband_retrieve(const RubberBandState state, float *const *output, unsigned int samples)
+{
+    return (unsigned int)state->m_s->retrieve(output, samples);
+}
+
+unsigned int rubberband_get_channel_count(const RubberBandState state)
+{
+    return (unsigned int)state->m_s->getChannelCount();
+}
+
+void rubberband_calculate_stretch(RubberBandState state)
+{
+    state->m_s->calculateStretch();
+}
+
+void rubberband_set_debug_level(RubberBandState state, int level)
+{
+    state->m_s->setDebugLevel(level);
+}
+
+void rubberband_set_default_debug_level(int level)
+{
+    RubberBand::RubberBandStretcher::setDefaultDebugLevel(level);
+}
+
+struct RubberBandLiveState_
+{
+    RubberBand::RubberBandLiveShifter *m_s;
+};
+
+RubberBandLiveState rubberband_live_new(unsigned int sampleRate,
+                                        unsigned int channels,
+                                        RubberBandOptions options)
+{
+    RubberBandLiveState_ *state = new RubberBandLiveState_();
+    state->m_s = new RubberBand::RubberBandLiveShifter
+        (sampleRate, channels, options);
+    return state;
+}
+
+void rubberband_live_delete(RubberBandLiveState state)
+{
+    delete state->m_s;
+    delete state;
+}
+
+void rubberband_live_reset(RubberBandLiveState state)
+{
+    state->m_s->reset();
+}
+
+void rubberband_live_set_pitch_scale(RubberBandLiveState state, double scale)
+{
+    state->m_s->setPitchScale(scale);
+}
+
+double rubberband_live_get_pitch_scale(const RubberBandLiveState state)
+{
+    return state->m_s->getPitchScale();
+}
+
+void rubberband_live_set_formant_scale(RubberBandLiveState state, double scale)
+{
+    state->m_s->setFormantScale(scale);
+}
+
+double rubberband_live_get_formant_scale(const RubberBandLiveState state)
+{
+    return state->m_s->getFormantScale();
+}
+
+unsigned int rubberband_live_get_start_delay(const RubberBandLiveState state) 
+{
+    return (unsigned int)state->m_s->getStartDelay();
+}
+
+void rubberband_live_set_formant_option(RubberBandLiveState state, RubberBandOptions options)
+{
+    state->m_s->setFormantOption(options);
+}
+
+unsigned int rubberband_live_get_block_size(RubberBandLiveState state)
+{
+    return (unsigned int)state->m_s->getBlockSize();
+}
+
+void rubberband_live_shift(RubberBandLiveState state, const float *const *input, float *const *output)
+{
+    state->m_s->shift(input, output);
+}
+
+unsigned int rubberband_live_get_channel_count(const RubberBandLiveState state)
+{
+    return (unsigned int)state->m_s->getChannelCount();
+}
+
+void rubberband_live_set_debug_level(RubberBandLiveState state, int level)
+{
+    state->m_s->setDebugLevel(level);
+}
+
+void rubberband_live_set_default_debug_level(int level)
+{
+    RubberBand::RubberBandStretcher::setDefaultDebugLevel(level);
+}

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestAllocators.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestAllocators.cpp
@@ -1,0 +1,106 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../common/VectorOps.h"
+#include "../common/Allocators.h"
+
+#include <stdexcept>
+#include <vector>
+
+using namespace RubberBand;
+
+BOOST_AUTO_TEST_SUITE(TestAllocators)
+
+#define COMPARE_ARRAY(a, b)						\
+    for (int cmp_i = 0; cmp_i < (int)(sizeof(a)/sizeof(a[0])); ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i] - b[cmp_i], 1e-14);			\
+    }
+
+#define COMPARE_N(a, b, n)						\
+    for (int cmp_i = 0; cmp_i < n; ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i] - b[cmp_i], 1e-14);			\
+    }
+
+BOOST_AUTO_TEST_CASE(alloc_dealloc)
+{
+    double *v = allocate<double>(4);
+    v[0] = 0.1;
+    v[1] = 2.0;
+    v[2] = -0.3;
+    v[3] = 4.0;
+    double *e = allocate<double>(4);
+    e[0] = -0.3;
+    e[1] = 4.0;
+    e[2] = 0.1;
+    e[3] = 2.0;
+    v_fftshift(v, 4);
+    COMPARE_N(v, e, 4);
+    deallocate(v);
+    deallocate(e);
+}
+
+BOOST_AUTO_TEST_CASE(alloc_zero)
+{
+    double *v = allocate_and_zero<double>(4);
+    BOOST_CHECK_EQUAL(v[0], 0.f);
+    BOOST_CHECK_EQUAL(v[1], 0.f);
+    BOOST_CHECK_EQUAL(v[2], 0.f);
+    BOOST_CHECK_EQUAL(v[3], 0.f);
+    deallocate(v);
+}
+
+BOOST_AUTO_TEST_CASE(alloc_dealloc_channels)
+{
+    double **v = allocate_channels<double>(2, 4);
+    v[0][0] = 0.1;
+    v[0][1] = 2.0;
+    v[0][2] = -0.3;
+    v[0][3] = 4.0;
+    v[1][0] = -0.3;
+    v[1][1] = 4.0;
+    v[1][2] = 0.1;
+    v[1][3] = 2.0;
+    v_fftshift(v[0], 4);
+    COMPARE_N(v[0], v[1], 4);
+    deallocate_channels(v, 2);
+}
+
+BOOST_AUTO_TEST_CASE(stl)
+{
+    std::vector<double, StlAllocator<double> > v;
+    v.push_back(0.1);
+    v.push_back(2.0);
+    v.push_back(-0.3);
+    v.push_back(4.0);
+    double e[] = { -0.3, 4.0, 0.1, 2.0 };
+    v_fftshift(v.data(), 4);
+    COMPARE_N(v.data(), e, 4);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestBinClassifier.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestBinClassifier.cpp
@@ -1,0 +1,193 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+// This test suite (shallowly) tests both BinClassifier and BinSegmenter
+#include "../finer/BinClassifier.h"
+#include "../finer/BinSegmenter.h"
+
+#include "../common/sysutils.h"
+
+using namespace RubberBand;
+
+using std::vector;
+using std::string;
+
+namespace tt = boost::test_tools;
+
+// We use the symbols H, X, and _ for harmonic, percussive, and
+// residual respectively, because they are easier to distinguish than
+// H, P, R
+
+static constexpr auto H = BinClassifier::Classification::Harmonic;
+static constexpr auto X = BinClassifier::Classification::Percussive;
+static constexpr auto _ = BinClassifier::Classification::Residual;
+
+vector<string> classes_to_strings(const vector<BinClassifier::Classification> &v)
+{
+    vector<std::string> sv(v.size(), "*");
+    for (auto i = 0; i < int(v.size()); ++i) {
+        switch (v[i]) {
+        case H: sv[i] = "H"; break;
+        case X: sv[i] = "X"; break;
+        case _: sv[i] = "_"; break;
+        }
+    }
+    return sv;
+}
+
+BOOST_AUTO_TEST_SUITE(TestBinClassifier)
+
+BOOST_AUTO_TEST_CASE(classify_bins)
+{
+    vector<vector<process_t>> magColumns {
+        { 0, 8, 1, 1, 0, 1 },
+        { 0, 8, 0, 0, 0, 0 },
+        { 8, 8, 8, 8, 8, 0 },
+        { 0, 7, 0, 1, 0, 0 },
+        { 0, 6, 0, 0, 0, 0 },
+        { 0, 8, 0, 9, 9, 9 },
+        { 0, 7, 0, 0, 1, 0 }
+    };
+
+    vector<vector<BinClassifier::Classification>> classifications(7, { 6, _ });
+
+    BinClassifier::Parameters params(6, 3, /* lag */ 1, 3, 2.0, 2.0);
+    BinClassifier classifier(params);
+
+    for (int i = 0; i < 7; ++i) {
+        classifier.classify(magColumns[i].data(), classifications[i].data());
+    }
+
+    /*
+       The lag of 1 specified for the horizontal filter means that the
+       results are delayed by a column (here row) but the vertical
+       filter outputs are aligned with the middle of the 3-bin
+       horizontal filters rather than the end.
+    
+       So the horizontal filter outputs (filtering vertically as
+       presented here) are
+           0 8 1 1 0 1 <- This is the "lag" column that is not meaningful
+           0 8 0 0 0 0 <- This is the actual median for the first col (row)
+           0 8 1 1 0 0 
+           0 8 0 1 0 0 
+           0 7 0 1 0 0 
+           0 7 0 1 0 0 
+           0 7 0 0 1 0 
+
+       And the vertical ones (lagged by one column to match the
+       horizontal filter outputs) are
+           0 0 0 0 0 0 <- The "lag" column (here row)
+           0 1 1 1 1 0 <- The effective first column (row)
+           0 0 0 0 0 0 
+           8 8 8 8 8 0 
+           0 0 1 0 0 0 
+           0 0 0 0 0 0 
+           0 0 8 9 9 9
+
+       We have harmonic, percussive, and residual bins. (Initially we
+       detected silent bins too, but of course if done naively that
+       doesn't align with the lagged filter output, and silent bins
+       didn't appear relevant enough to take extra trouble over.) In
+       our case, wherever both horizontal and vertical filter outputs
+       are the same-ish (0, 1, or one of 7/8/9) we expect to see a
+       residual classification. Otherwise we expect harmonic if the
+       horizontal output is greater, percussive otherwise.
+    */
+    
+    vector<vector<BinClassifier::Classification>> expected {
+        // These results are lagged by one relative to the input
+        { _, H, H, H, _, H },
+        { _, H, X, X, X, _ },
+        { _, H, H, H, _, _ },
+        { X, _, X, X, X, _ },
+        { _, H, X, H, _, _ },
+        { _, H, _, H, _, _ },
+        { _, H, X, X, X, X }
+    };
+
+    for (int i = 0; i < 7; ++i) {
+        BOOST_TEST(classes_to_strings(classifications[i]) ==
+                   classes_to_strings(expected[i]),
+                   tt::per_element());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(segment_classification)
+{
+    vector<vector<BinClassifier::Classification>> classification {
+        { _, H, X, X, X, _ },
+        { _, H, H, H, _, _ },
+        { X, _, X, X, X, _ },
+        { _, H, X, H, _, _ },
+        { X, X, _, H, _, _ },
+        { _, H, X, X, X, X },
+        { _, H, _, _, _, _ }
+    };
+
+    BinSegmenter::Parameters params(16, 6, 48000, 3);
+    BinSegmenter segmenter(params);
+
+    vector<BinSegmenter::Segmentation> segmented;
+    for (int i = 0; i < 7; ++i) {
+        segmented.push_back(segmenter.segment(classification[i].data()));
+    }
+
+    /* 
+       Modal filter length 3 was specified, with the ordering for
+       resolving equal counts as H, X, _. So the filtered
+       classifications will be:
+
+           H H X X X X
+           H H H H _ _
+           X X X X X X
+           H H H H _ _
+           X X H _ _ _
+           H H X X X X
+           H _ _ _ _ _
+    */
+       
+    vector<BinSegmenter::Segmentation> expected {
+        {    0.0,  3000.0, 15000.0 },
+        {    0.0,  9000.0,  9000.0 }, // Though any equal values would do!
+        {    0.0,     0.0, 15000.0 },
+        {    0.0,  9000.0,  9000.0 },
+        { 6000.0,  6000.0,  6000.0 }, // Similarly
+        {    0.0,  3000.0, 15000.0 },
+        {    0.0, 24000.0, 24000.0 }
+    };
+
+    for (int i = 0; i < 7; ++i) {
+        BOOST_TEST(segmented[i].percussiveBelow == expected[i].percussiveBelow);
+        BOOST_TEST(segmented[i].percussiveAbove == expected[i].percussiveAbove);
+        BOOST_TEST(segmented[i].residualAbove == expected[i].residualAbove);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestFFT.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestFFT.cpp
@@ -1,0 +1,725 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../common/FFT.h"
+
+#include <iostream>
+
+#include <cstdio>
+#include <cmath>
+
+using namespace RubberBand;
+
+BOOST_AUTO_TEST_SUITE(TestFFT)
+
+#define DEFINE_EPS(fft) \
+    float epsf = 1e-6f; \
+    double eps; \
+    if (fft.getSupportedPrecisions() & FFT::DoublePrecision) { \
+        eps = 1e-14; \
+    } else { \
+        eps = epsf; \
+    } \
+    (void)epsf; (void)eps;
+
+#define USING_FFT(n) \
+    FFT fft(n); \
+    DEFINE_EPS(fft);
+
+#define COMPARE(a, b) BOOST_CHECK_SMALL(a-b, eps) 
+#define COMPARE_F(a, b) BOOST_CHECK_SMALL(a-b, epsf) 
+
+#define COMPARE_ZERO(a) BOOST_CHECK_SMALL(a, eps)
+#define COMPARE_ZERO_F(a) BOOST_CHECK_SMALL(a, epsf)
+
+#define COMPARE_ALL(a, x) \
+    for (int cmp_i = 0; cmp_i < (int)(sizeof(a)/sizeof(a[0])); ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i] - x, eps); \
+    }
+#define COMPARE_ALL_F(a, x) \
+    for (int cmp_i = 0; cmp_i < (int)(sizeof(a)/sizeof(a[0])); ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i] - x, epsf); \
+    }
+#define COMPARE_ARR(a, b, n) \
+    for (int cmp_i = 0; cmp_i < n; ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i] - b[cmp_i], eps); \
+    }
+#define COMPARE_SCALED(a, b, s)						\
+    for (int cmp_i = 0; cmp_i < (int)(sizeof(a)/sizeof(a[0])); ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i]/s - b[cmp_i], eps); \
+    }
+#define COMPARE_SCALED_N(a, b, n, s) \
+    for (int cmp_i = 0; cmp_i < n; ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i]/s - b[cmp_i], eps); \
+    }
+#define COMPARE_SCALED_F(a, b, s)						\
+    for (int cmp_i = 0; cmp_i < (int)(sizeof(a)/sizeof(a[0])); ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i]/s - b[cmp_i], epsf); \
+    }
+
+#define ONE_IMPL_AUTO_TEST_CASE(name, impl) \
+    BOOST_AUTO_TEST_CASE(name##_##impl) \
+    { \
+        std::set<std::string> impls = FFT::getImplementations(); \
+        if (impls.find(#impl) == impls.end()) return; \
+        FFT::setDefaultImplementation(#impl); \
+        performTest_##name(); \
+        FFT::setDefaultImplementation(""); \
+    }
+
+// If you add an implementation in FFT.cpp, add it also to
+// ALL_IMPL_AUTO_TEST_CASE and all_implementations[] below
+
+#define ALL_IMPL_AUTO_TEST_CASE(name) \
+    void performTest_##name (); \
+    ONE_IMPL_AUTO_TEST_CASE(name, ipp); \
+    ONE_IMPL_AUTO_TEST_CASE(name, vdsp); \
+    ONE_IMPL_AUTO_TEST_CASE(name, fftw); \
+    ONE_IMPL_AUTO_TEST_CASE(name, kissfft); \
+    ONE_IMPL_AUTO_TEST_CASE(name, builtin); \
+    ONE_IMPL_AUTO_TEST_CASE(name, dft); \
+    void performTest_##name ()
+
+std::string all_implementations[] = {
+    "ipp", "vdsp", "fftw", "kissfft", "builtin", "dft"
+};
+
+BOOST_AUTO_TEST_CASE(showImplementations)
+{
+    std::set<std::string> impls = FFT::getImplementations();
+    BOOST_TEST_MESSAGE("The following implementations are compiled in and will be tested:");
+    for (int i = 0; i < int(sizeof(all_implementations)/sizeof(all_implementations[0])); ++i) {
+        if (impls.find(all_implementations[i]) != impls.end()) {
+            BOOST_TEST_MESSAGE(" +" << all_implementations[i]);
+        }
+    }
+    BOOST_TEST_MESSAGE("The following implementations are NOT compiled in and will not be tested:");
+    for (int i = 0; i < int(sizeof(all_implementations)/sizeof(all_implementations[0])); ++i) {
+        if (impls.find(all_implementations[i]) == impls.end()) {
+            BOOST_TEST_MESSAGE(" -" << all_implementations[i]);
+        }
+    }
+}
+
+
+/*
+ * 1a. Simple synthetic signals, transforms to separate real/imag arrays,
+ *     double-precision
+ */
+
+ALL_IMPL_AUTO_TEST_CASE(dc)
+{
+    // DC-only signal. The DC bin is purely real
+    double in[] = { 1, 1, 1, 1 };
+    double re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE(re[0], 4.0);
+    COMPARE_ZERO(re[1]);
+    COMPARE_ZERO(re[2]);
+    COMPARE_ALL(im, 0.0);
+    double back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(sine)
+{
+    // Sine. Output is purely imaginary
+    double in[] = { 0, 1, 0, -1 };
+    double re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_ALL(re, 0.0);
+    COMPARE_ZERO(im[0]);
+    COMPARE(im[1], -2.0);
+    COMPARE_ZERO(im[2]);
+    double back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(sine_8)
+{
+    // Longer sine. With only 4 elements, the real transform only
+    // needs to get the DC and Nyquist bins right for its two complex
+    // sub-transforms. We need a longer test to check the real
+    // transform is working properly.
+    double cospi4 = 0.5 * sqrt(2.0);
+    double in[] = { 0, cospi4, 1.0, cospi4, 0.0, -cospi4, -1.0, -cospi4 };
+    double re[5], im[5];
+    USING_FFT(8);
+    fft.forward(in, re, im);
+    COMPARE_ALL(re, 0.0);
+    COMPARE_ZERO(im[0]);
+    COMPARE(im[1], -4.0);
+    COMPARE_ZERO(im[2]);
+    COMPARE_ZERO(im[3]);
+    COMPARE_ZERO(im[4]);
+    double back[8];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 8);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(cosine)
+{
+    // Cosine. Output is purely real
+    double in[] = { 1, 0, -1, 0 };
+    double re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_ZERO(re[0]);
+    COMPARE(re[1], 2.0);
+    COMPARE_ZERO(re[2]);
+    COMPARE_ALL(im, 0.0);
+    double back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(cosine_8)
+{
+    // Longer cosine.
+    double cospi4 = 0.5 * sqrt(2.0);
+    double in[] = { 1.0, cospi4, 0.0, -cospi4, -1.0, -cospi4, 0.0, cospi4 };
+    double re[5], im[5];
+    USING_FFT(8);
+    fft.forward(in, re, im);
+    COMPARE_ALL(im, 0.0);
+    COMPARE_ZERO(re[0]);
+    COMPARE(re[1], 4.0);
+    COMPARE_ZERO(re[2]);
+    COMPARE_ZERO(re[3]);
+    COMPARE_ZERO(re[4]);
+    double back[8];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 8);
+}
+	
+ALL_IMPL_AUTO_TEST_CASE(sineCosine)
+{
+    // Sine and cosine mixed
+    double in[] = { 0.5, 1, -0.5, -1 };
+    double re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_ZERO(re[0]);
+    COMPARE(re[1], 1.0);
+    COMPARE_ZERO(re[2]);
+    COMPARE_ZERO(im[0]);
+    COMPARE(im[1], -2.0);
+    COMPARE_ZERO(im[2]);
+    double back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(nyquist)
+{
+    double in[] = { 1, -1, 1, -1 };
+    double re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_ZERO(re[0]);
+    COMPARE_ZERO(re[1]);
+    COMPARE(re[2], 4.0);
+    COMPARE_ALL(im, 0.0);
+    double back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(dirac)
+{
+    double in[] = { 1, 0, 0, 0 };
+    double re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE(re[0], 1.0);
+    COMPARE(re[1], 1.0);
+    COMPARE(re[2], 1.0);
+    COMPARE_ALL(im, 0.0);
+    double back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+
+/*
+ * 1b. Simple synthetic signals, transforms to separate real/imag arrays,
+ *     single-precision (i.e. single-precision version of 1a)
+ */
+
+ALL_IMPL_AUTO_TEST_CASE(dcF)
+{
+    // DC-only signal. The DC bin is purely real
+    float in[] = { 1, 1, 1, 1 };
+    float re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_F(re[0], 4.0f);
+    COMPARE_ZERO_F(re[1]);
+    COMPARE_ZERO_F(re[2]);
+    COMPARE_ALL_F(im, 0.0f);
+    float back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(sineF)
+{
+    // Sine. Output is purely imaginary
+    float in[] = { 0, 1, 0, -1 };
+    float re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_ALL_F(re, 0.0f);
+    COMPARE_ZERO_F(im[0]);
+    COMPARE_F(im[1], -2.0f);
+    COMPARE_ZERO_F(im[2]);
+    float back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(cosineF)
+{
+    // Cosine. Output is purely real
+    float in[] = { 1, 0, -1, 0 };
+    float re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_ZERO_F(re[0]);
+    COMPARE_F(re[1], 2.0f);
+    COMPARE_ZERO_F(re[2]);
+    COMPARE_ALL_F(im, 0.0f);
+    float back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+	
+ALL_IMPL_AUTO_TEST_CASE(sineCosineF)
+{
+    // Sine and cosine mixed
+    float in[] = { 0.5, 1, -0.5, -1 };
+    float re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_ZERO_F(re[0]);
+    COMPARE_F(re[1], 1.0f);
+    COMPARE_ZERO_F(re[2]);
+    COMPARE_ZERO_F(im[0]);
+    COMPARE_F(im[1], -2.0f);
+    COMPARE_ZERO_F(im[2]);
+    float back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(nyquistF)
+{
+    float in[] = { 1, -1, 1, -1 };
+    float re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_ZERO_F(re[0]);
+    COMPARE_ZERO_F(re[1]);
+    COMPARE_F(re[2], 4.0f);
+    COMPARE_ALL_F(im, 0.0f);
+    float back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(diracF)
+{
+    float in[] = { 1, 0, 0, 0 };
+    float re[3], im[3];
+    USING_FFT(4);
+    fft.forward(in, re, im);
+    COMPARE_F(re[0], 1.0f);
+    COMPARE_F(re[1], 1.0f);
+    COMPARE_F(re[2], 1.0f);
+    COMPARE_ALL_F(im, 0.0f);
+    float back[4];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+
+
+/*
+ * 2a. Subset of synthetic signals, testing different output formats
+ *     (interleaved complex, polar, magnitude-only, and our weird
+ *     cepstral thing), double-precision
+ */ 
+
+ALL_IMPL_AUTO_TEST_CASE(interleaved)
+{
+    // Sine and cosine mixed, test output format
+    double in[] = { 0.5, 1, -0.5, -1 };
+    double out[6];
+    USING_FFT(4);
+    fft.forwardInterleaved(in, out);
+    COMPARE_ZERO(out[0]);
+    COMPARE_ZERO(out[1]);
+    COMPARE(out[2], 1.0);
+    COMPARE(out[3], -2.0);
+    COMPARE_ZERO(out[4]);
+    COMPARE_ZERO(out[5]);
+    double back[4];
+    fft.inverseInterleaved(out, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(sinePolar)
+{
+    double in[] = { 0, 1, 0, -1 };
+    double mag[3], phase[3];
+    USING_FFT(4);
+    fft.forwardPolar(in, mag, phase);
+    COMPARE_ZERO(mag[0]);
+    COMPARE(mag[1], 2.0);
+    COMPARE_ZERO(mag[2]);
+    // No meaningful tests for phase[i] where mag[i]==0 (phase
+    // could legitimately be anything)
+    COMPARE(phase[1], -M_PI/2.0);
+    double back[4];
+    fft.inversePolar(mag, phase, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(cosinePolar)
+{
+    double in[] = { 1, 0, -1, 0 };
+    double mag[3], phase[3];
+    USING_FFT(4);
+    fft.forwardPolar(in, mag, phase);
+    COMPARE_ZERO(mag[0]);
+    COMPARE(mag[1], 2.0);
+    COMPARE_ZERO(mag[2]);
+    // No meaningful tests for phase[i] where mag[i]==0 (phase
+    // could legitimately be anything)
+    COMPARE_ZERO(phase[1]);
+    double back[4];
+    fft.inversePolar(mag, phase, back);
+    COMPARE_SCALED(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(magnitude)
+{
+    // Sine and cosine mixed
+    double in[] = { 0.5, 1, -0.5, -1 };
+    double out[3];
+    USING_FFT(4);
+    fft.forwardMagnitude(in, out);
+    COMPARE_ZERO(out[0]);
+    COMPARE_F(float(out[1]), sqrtf(5.0));
+    COMPARE_ZERO(out[2]);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(cepstrum)
+{
+    double in[] = { 1, 0, 0, 0, 1, 0, 0, 0 };
+    double mag[5];
+    USING_FFT(8);
+    fft.forwardMagnitude(in, mag);
+    double cep[8];
+    fft.inverseCepstral(mag, cep);
+    BOOST_CHECK_SMALL(cep[1], 1e-9);
+    BOOST_CHECK_SMALL(cep[2], 1e-9);
+    BOOST_CHECK_SMALL(cep[3], 1e-9);
+    BOOST_CHECK_SMALL(cep[5], 1e-9);
+    BOOST_CHECK_SMALL(cep[6], 1e-9);
+    BOOST_CHECK_SMALL(cep[7], 1e-9);
+    BOOST_CHECK_SMALL(-6.561181 - cep[0]/8, 0.000001);
+    BOOST_CHECK_SMALL( 7.254329 - cep[4]/8, 0.000001);
+}
+
+
+/*
+ * 2b. Subset of synthetic signals, testing different output formats
+ *     (interleaved complex, polar, magnitude-only, and our weird
+ *     cepstral thing), single-precision (i.e. single-precision
+ *     version of 2a)
+ */ 
+	
+ALL_IMPL_AUTO_TEST_CASE(interleavedF)
+{
+    // Sine and cosine mixed, test output format
+    float in[] = { 0.5, 1, -0.5, -1 };
+    float out[6];
+    USING_FFT(4);
+    fft.forwardInterleaved(in, out);
+    COMPARE_ZERO_F(out[0]);
+    COMPARE_ZERO_F(out[1]);
+    COMPARE_F(out[2], 1.0f);
+    COMPARE_F(out[3], -2.0f);
+    COMPARE_ZERO_F(out[4]);
+    COMPARE_ZERO_F(out[5]);
+    float back[4];
+    fft.inverseInterleaved(out, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(cosinePolarF)
+{
+    float in[] = { 1, 0, -1, 0 };
+    float mag[3], phase[3];
+    USING_FFT(4);
+    fft.forwardPolar(in, mag, phase);
+    COMPARE_ZERO_F(mag[0]);
+    COMPARE_F(mag[1], 2.0f);
+    COMPARE_ZERO_F(mag[2]);
+    // No meaningful tests for phase[i] where mag[i]==0 (phase
+    // could legitimately be anything)
+    COMPARE_ZERO_F(phase[1]);
+    float back[4];
+    fft.inversePolar(mag, phase, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(sinePolarF)
+{
+    float in[] = { 0, 1, 0, -1 };
+    float mag[3], phase[3];
+    USING_FFT(4);
+    fft.forwardPolar(in, mag, phase);
+    COMPARE_ZERO_F(mag[0]);
+    COMPARE_F(mag[1], 2.0f);
+    COMPARE_ZERO_F(mag[2]);
+    // No meaningful tests for phase[i] where mag[i]==0 (phase
+    // could legitimately be anything)
+    COMPARE_F(phase[1], -float(M_PI)/2.0f);
+    float back[4];
+    fft.inversePolar(mag, phase, back);
+    COMPARE_SCALED_F(back, in, 4);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(magnitudeF)
+{
+    // Sine and cosine mixed
+    float in[] = { 0.5, 1, -0.5, -1 };
+    float out[3];
+    USING_FFT(4);
+    fft.forwardMagnitude(in, out);
+    COMPARE_ZERO_F(out[0]);
+    COMPARE_F(float(out[1]), sqrtf(5.0f));
+    COMPARE_ZERO_F(out[2]);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(cepstrumF)
+{
+    float in[] = { 1, 0, 0, 0, 1, 0, 0, 0 };
+    float mag[5];
+    USING_FFT(8);
+    fft.forwardMagnitude(in, mag);
+    float cep[8];
+    fft.inverseCepstral(mag, cep);
+    COMPARE_ZERO_F(cep[1]);
+    COMPARE_ZERO_F(cep[2]);
+    COMPARE_ZERO_F(cep[3]);
+    COMPARE_ZERO_F(cep[5]);
+    COMPARE_ZERO_F(cep[6]);
+    COMPARE_ZERO_F(cep[7]);
+    BOOST_CHECK_SMALL(-6.561181 - cep[0]/8, 0.000001);
+    BOOST_CHECK_SMALL( 7.254329 - cep[4]/8, 0.000001);
+}
+
+
+/*
+ * 4. Bounds checking, double-precision and single-precision
+ */
+
+ALL_IMPL_AUTO_TEST_CASE(forwardArrayBounds)
+{
+    double in[] = { 1, 1, -1, -1 };
+
+    // Initialise output bins to something recognisable, so we can
+    // tell if they haven't been written
+    double re[] = { 999, 999, 999, 999, 999 };
+    double im[] = { 999, 999, 999, 999, 999 };
+    
+    USING_FFT(4);
+    fft.forward(in, re+1, im+1);
+    
+    // Check we haven't overrun the output arrays
+    COMPARE(re[0], 999.0);
+    COMPARE(im[0], 999.0);
+    COMPARE(re[4], 999.0);
+    COMPARE(im[4], 999.0);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(inverseArrayBounds)
+{
+    // The inverse transform is only supposed to refer to the first
+    // N/2+1 bins and synthesise the rest rather than read them - so
+    // initialise the next one to some value that would mess up the
+    // results if it were used
+    double re[] = { 0, 1, 0, 456 };
+    double im[] = { 0, -2, 0, 456 };
+
+    // Initialise output bins to something recognisable, so we can
+    // tell if they haven't been written
+    double out[] = { 999, 999, 999, 999, 999, 999 };
+    
+    USING_FFT(4);
+    fft.inverse(re, im, out+1);
+
+    // Check we haven't overrun the output arrays
+    COMPARE(out[0], 999.0);
+    COMPARE(out[5], 999.0);
+
+    // And check the results are as we expect, i.e. that we haven't
+    // used the bogus final bin
+    COMPARE(out[1] / 4, 0.5);
+    COMPARE(out[2] / 4, 1.0);
+    COMPARE(out[3] / 4, -0.5);
+    COMPARE(out[4] / 4, -1.0);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(forwardArrayBoundsF)
+{
+    float in[] = { 1, 1, -1, -1 };
+    
+    // Initialise output bins to something recognisable, so we can
+    // tell if they haven't been written
+    float re[] = { 999, 999, 999, 999, 999 };
+    float im[] = { 999, 999, 999, 999, 999 };
+    
+    USING_FFT(4);
+    fft.forward(in, re+1, im+1);
+    
+    // Check we haven't overrun the output arrays
+    COMPARE_F(re[0], 999.0f);
+    COMPARE_F(im[0], 999.0f);
+    COMPARE_F(re[4], 999.0f);
+    COMPARE_F(im[4], 999.0f);
+}
+
+ALL_IMPL_AUTO_TEST_CASE(inverseArrayBoundsF)
+{
+    // The inverse transform is only supposed to refer to the first
+    // N/2+1 bins and synthesise the rest rather than read them - so
+    // initialise the next one to some value that would mess up the
+    // results if it were used
+    float re[] = { 0, 1, 0, 456 };
+    float im[] = { 0, -2, 0, 456 };
+
+    // Initialise output bins to something recognisable, so we can
+    // tell if they haven't been written
+    float out[] = { 999, 999, 999, 999, 999, 999 };
+    
+    USING_FFT(4);
+    fft.inverse(re, im, out+1);
+    
+    // Check we haven't overrun the output arrays
+    COMPARE_F(out[0], 999.0f);
+    COMPARE_F(out[5], 999.0f);
+
+    // And check the results are as we expect, i.e. that we haven't
+    // used the bogus final bin
+    COMPARE_F(out[1] / 4.0f, 0.5f);
+    COMPARE_F(out[2] / 4.0f, 1.0f);
+    COMPARE_F(out[3] / 4.0f, -0.5f);
+    COMPARE_F(out[4] / 4.0f, -1.0f);
+}
+
+
+/*
+ * 6. Slightly longer transforms of pseudorandom data.
+ */
+
+ALL_IMPL_AUTO_TEST_CASE(random_precalc_16)
+{
+    double in[] = {
+        -0.24392125308057722, 0.03443898163344272, 0.3448145656738877,
+        -0.9625837464603908, 3.366568317669671, 0.9947191221586653,
+        -1.5038984435999945, 1.3859898682581235, -1.1230576306688778,
+        -1.6757487116512024, -1.5874436867863229, -2.0794018781307155,
+        -0.5450152775818973, 0.7530907176983748, 1.0743170685904255,
+        3.1787609811018775
+    };
+    double expected_re[] = {
+        1.41162899482, 7.63975551593, -1.20622641052, -1.77829578443,
+        3.12678465246, -2.84220463109, -7.17083743716, 0.497290409945,
+        -1.84690167439,
+    };
+    double expected_im[] = {
+        0.0, -4.67826048083, 8.58829211964, 4.96449646815,
+        1.41626511493, -3.77219223978, 6.96219662744, 2.23138519225,
+        0.0,
+    };
+    double re[9], im[9];
+    USING_FFT(16);
+    if (eps < 1e-11) {
+        eps = 1e-11;
+    }
+    fft.forward(in, re, im);
+    COMPARE_ARR(re, expected_re, 9);
+    COMPARE_ARR(im, expected_im, 9);
+    double back[16];
+    fft.inverse(re, im, back);
+    COMPARE_SCALED(back, in, 16);
+}
+
+/* This one has data from a PRNG, with a fixed seed. Must pass two
+ * tests: (i) same as DFT; (ii) inverse produces original input (after
+ * scaling) */
+ALL_IMPL_AUTO_TEST_CASE(random)
+{
+    const int n = 64;
+    double *in = new double[n];
+    double *re = new double[n/2 + 1];
+    double *im = new double[n/2 + 1];
+    double *re_compare = new double[n/2 + 1];
+    double *im_compare = new double[n/2 + 1];
+    double *back = new double[n];
+    srand(0);
+    for (int i = 0; i < n; ++i) {
+        in[i] = (double(rand()) / double(RAND_MAX)) * 4.0 - 2.0;
+    }
+    USING_FFT(n);
+    if (eps < 1e-11) {
+        eps = 1e-11;
+    }
+    fft.forward(in, re, im);
+    fft.inverse(re, im, back);
+    FFT::setDefaultImplementation("dft");
+    fft.forward(in, re_compare, im_compare);
+    COMPARE_ARR(re, re_compare, n/2 + 1);
+    COMPARE_ARR(im, im_compare, n/2 + 1);
+    COMPARE_SCALED_N(back, in, n, n);
+    delete[] back;
+    delete[] im_compare;
+    delete[] re_compare;
+    delete[] im;
+    delete[] re;
+    delete[] in;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestLiveShifter.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestLiveShifter.cpp
@@ -1,0 +1,298 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../../rubberband/RubberBandLiveShifter.h"
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+#include <cmath>
+
+using namespace RubberBand;
+
+using std::vector;
+using std::cerr;
+using std::endl;
+using std::string;
+using std::ofstream;
+
+namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_SUITE(TestLiveShifter)
+
+static void dumpTo(string basename,
+                   const vector<float> &data)
+{
+    string dir = "/tmp";
+    string filename = dir + "/" + basename + ".csv";
+    ofstream file(filename, std::ios::out | std::ios::binary);
+    if (!file) {
+        cerr << "dumpTo: failed to open file \"" << filename << "\" for writing" << endl;
+        return;
+    }
+    file << "sample,V" << endl;
+    for (int i = 0; i < int(data.size()); ++i) {
+        file << i << "," << data[i] << endl;
+    }
+}
+
+static void dump(string prefix,
+                 const vector<float> &in,
+                 const vector<float> &out,
+                 const vector<float> &expected,
+                 int delay)
+{
+    cerr << "dump: delay reported as " << delay << endl;
+
+    if (prefix != "") {
+        prefix += "-";
+    }
+    
+    dumpTo(prefix + "in", in);
+    dumpTo(prefix + "out", out);
+    dumpTo(prefix + "expected", expected);
+
+    vector<float> shifted;
+    vector<float> diff;
+    for (int i = 0; i + delay < int(out.size()); ++i) {
+        shifted.push_back(out[i + delay]);
+        diff.push_back(out[i + delay] - expected[i]);
+    }
+    dumpTo(prefix + "shifted", shifted);
+    dumpTo(prefix + "diff", diff);
+}
+
+static void check_sinusoid_unchanged(int n, int rate, float freq,
+                                     RubberBandLiveShifter::Options options,
+                                     string debugPrefix = {})
+{
+    bool printDebug = (debugPrefix != "");
+    
+    if (printDebug) {
+        RubberBandLiveShifter::setDefaultDebugLevel(2);
+    }
+    
+    RubberBandLiveShifter shifter(rate, 1, options);
+    
+    int blocksize = shifter.getBlockSize();
+    BOOST_TEST(blocksize == 512);
+
+    n = (n / blocksize + 1) * blocksize;
+    
+    vector<float> in(n), out(n);
+    for (int i = 0; i < n; ++i) {
+        in[i] = 0.5f * sinf(float(i) * freq * M_PI * 2.f / float(rate));
+    }
+
+    for (int i = 0; i < n; i += blocksize) {
+        float *inp = in.data() + i;
+        float *outp = out.data() + i;
+        shifter.shift(&inp, &outp);
+    }
+
+    int delay = shifter.getStartDelay();
+    
+    // We now have n samples of a simple sinusoid with stretch factor
+    // 1.0; obviously we expect the output to be essentially the same
+    // thing. It will have lower precision for a while at the start,
+    // so we check that with a threshold of 0.1; after that we expect
+    // better precision.
+
+    int slackpart = 2048;
+    float slackeps = 1.0e-1f;
+    float eps = 1.0e-3f;
+
+#ifdef USE_BQRESAMPLER
+    eps = 1.0e-2f;
+#endif
+    
+    for (int i = 0; i < slackpart; ++i) {
+        float fin = in[i];
+        float fout = out[delay + i];
+        float err = fabsf(fin - fout);
+        if (err > slackeps) {
+            cerr << "Error at index " << i << " exceeds slack eps "
+                 << slackeps << ": output " << fout << " - input "
+                 << fin << " = " << fout - fin << endl;
+            BOOST_TEST(err < eps);
+            break;
+        }
+    }
+    
+    for (int i = slackpart; i < n - delay; ++i) {
+        float fin = in[i];
+        float fout = out[delay + i];
+        float err = fabsf(fin - fout);
+        if (err > eps) {
+            cerr << "Error at index " << i << " exceeds tight eps "
+                 << eps << ": output " << fout << " - input "
+                 << fin << " = " << fout - fin << endl;
+            BOOST_TEST(err < eps);
+            break;
+        }
+    }
+
+    if (printDebug) {
+        RubberBandLiveShifter::setDefaultDebugLevel(0);
+        dump(debugPrefix, in, out, in, delay);
+    }
+}
+
+static void check_sinusoid_shifted(int n, int rate, float freq, float shift,
+                                   RubberBandLiveShifter::Options options,
+                                   string debugPrefix = {})
+{
+    bool printDebug = (debugPrefix != "");
+    
+    if (printDebug) {
+        RubberBandLiveShifter::setDefaultDebugLevel(2);
+    }
+    
+    RubberBandLiveShifter shifter(rate, 1, options);
+
+    shifter.setPitchScale(shift);
+    
+    int blocksize = shifter.getBlockSize();
+    BOOST_TEST(blocksize == 512);
+
+    n = (n / blocksize + 1) * blocksize;
+    
+    vector<float> in(n), out(n), expected(n);
+    int endpoint = n;
+    if (endpoint > 20000) endpoint -= 10000;
+    for (int i = 0; i < n; ++i) {
+        float value = 0.5f * sinf(float(i) * freq * M_PI * 2.f / float(rate));
+        if (i > endpoint && value > 0.f && in[i-1] <= 0.f) break;
+        in[i] = value;
+        expected[i] = 0.5f * sinf(float(i) * freq * shift * M_PI * 2.f / float(rate));
+    }
+
+    for (int i = 0; i < n; i += blocksize) {
+        float *inp = in.data() + i;
+        float *outp = out.data() + i;
+        shifter.shift(&inp, &outp);
+    }
+
+    int reportedDelay = shifter.getStartDelay();
+    int slackpart = 2048;
+
+    double lastCrossing = -1;
+
+    double eps = 2.0;
+
+    int i0 = reportedDelay + slackpart;
+    int i1 = endpoint;
+
+    for (int i = i0; i < i1; ++i) {
+        if (out[i-1] < 0.f && out[i] >= 0.f) {
+            double crossing = (i-1) + (out[i-1] / (out[i-1] - out[i]));
+            if (lastCrossing >= 0) {
+                double f = rate / (crossing - lastCrossing);
+                double diff = freq * shift - f;
+                double ratio = f / (freq * shift);
+                double cents = 1200.0 * (log(ratio)/log(2.0));
+                if (fabs(cents) >= eps) {
+                    cerr << "i = " << i << " (from " << i0 << " to " << i1 << ", out[i-1] = " << out[i-1] << ", out[i] = " << out[i] << "), f = " << f << ", in freq = " << freq << ", out freq = " << freq * shift << ", ratio = " << ratio << ", cents = " << cents << ", diff = " << diff << ", eps = " << eps << ", shift = " << shift << ", factor = " << fabs(cents)/eps << endl;
+                    BOOST_TEST(fabs(cents) < eps);
+                }
+            }
+            lastCrossing = crossing;
+        }
+    }
+
+    if (printDebug) {
+        RubberBandLiveShifter::setDefaultDebugLevel(0);
+        dump(debugPrefix, in, out, expected, reportedDelay);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_unchanged)
+{
+    int n = 20000;
+
+    // delay = 2112, correct
+    
+    check_sinusoid_unchanged(n, 44100, 440.f, 0);
+    check_sinusoid_unchanged(n, 48000, 260.f, 0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_down_octave_440)
+{
+    // Checked: delay = 3648, seems ok
+    
+    int n = 30000;
+    check_sinusoid_shifted(n, 44100, 440.f, 0.5f, 0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_down_octave_260)
+{
+    // Checked: delay = 3648, correct
+
+    int n = 30000;
+    check_sinusoid_shifted(n, 48000, 260.f, 0.5f, 0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_down_2octave)
+{
+    // Checked: delay = 6784, sound
+    
+    int n = 30000;
+    check_sinusoid_shifted(n, 44100, 440.f, 0.25f, 0);
+    check_sinusoid_shifted(n, 48000, 260.f, 0.25f, 0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_up_octave_440)
+{
+    // Checked: delay = 2879, correct
+    
+    int n = 30000;
+    check_sinusoid_shifted(n, 44100, 440.f, 2.0f, 0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_up_octave_260)
+{
+    // Checked: delay = 2879, seems ok
+
+    int n = 30000;
+    check_sinusoid_shifted(n, 44100, 260.f, 2.0f, 0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_down_0_99)
+{
+    int n = 30000;
+    check_sinusoid_shifted(n, 44100, 440.f, 0.99f, 0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_up_1_01)
+{
+    int n = 30000;
+    check_sinusoid_shifted(n, 44100, 440.f, 1.01f, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestResampler.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestResampler.cpp
@@ -1,0 +1,224 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../common/Resampler.h"
+
+#include <stdexcept>
+#include <vector>
+#include <cmath>
+#include <iostream>
+
+using namespace RubberBand;
+
+using std::cerr;
+using std::endl;
+
+using std::vector;
+
+BOOST_AUTO_TEST_SUITE(TestResampler)
+
+#define LEN(a) (int(sizeof(a)/sizeof(a[0])))
+
+static vector<float>
+sine(double samplerate, double frequency, int nsamples)
+{
+    vector<float> v(nsamples, 0.f);
+    for (int i = 0; i < nsamples; ++i) {
+        v[i] = sin ((i * 2.0 * M_PI * frequency) / samplerate);
+    }
+    return v;
+}
+
+#define COMPARE_N(a, b, n)                    \
+    for (int cmp_i = 0; cmp_i < n; ++cmp_i) { \
+        BOOST_CHECK_SMALL((a)[cmp_i] - (b)[cmp_i], 1e-4f);      \
+    }
+
+static const float guard_value = -999.f;
+
+BOOST_AUTO_TEST_CASE(interpolated_sine_1ch_interleaved)
+{
+    // Interpolating a sinusoid should give us a sinusoid, once we've
+    // dropped the first few samples
+    vector<float> in = sine(8, 2, 1000); // 2Hz wave at 8Hz: [ 0, 1, 0, -1 ] etc
+    vector<float> expected = sine(16, 2, 2000);
+    vector<float> out(in.size() * 2 + 1, guard_value);
+    Resampler r(Resampler::Parameters(), 1);
+    int returned = r.resampleInterleaved
+        (out.data(), out.size(), in.data(), in.size(), 2, true);
+
+    // because final was true, we expect to have exactly the right
+    // number of samples back
+    BOOST_CHECK_EQUAL(returned, int(in.size() * 2));
+    BOOST_CHECK_NE(out[returned-1], guard_value);
+    BOOST_CHECK_EQUAL(out[returned], guard_value);
+
+    // and they should match the expected data, at least in the middle
+    const float *outf = out.data() + 200, *expectedf = expected.data() + 200;
+    COMPARE_N(outf, expectedf, 600);
+}
+
+BOOST_AUTO_TEST_CASE(interpolated_sine_1ch_noninterleaved)
+{
+    // Interpolating a sinusoid should give us a sinusoid, once we've
+    // dropped the first few samples
+    vector<float> in = sine(8, 2, 1000); // 2Hz wave at 8Hz: [ 0, 1, 0, -1 ] etc
+    vector<float> expected = sine(16, 2, 2000);
+    vector<float> out(in.size() * 2 + 1, guard_value);
+    const float *in_data = in.data();
+    float *out_data = out.data();
+    Resampler r(Resampler::Parameters(), 1);
+    int returned = r.resample
+        (&out_data, out.size(), &in_data, in.size(), 2, true);
+
+    // because final was true, we expect to have exactly the right
+    // number of samples back
+    BOOST_CHECK_EQUAL(returned, int(in.size() * 2));
+    BOOST_CHECK_NE(out[returned-1], guard_value);
+    BOOST_CHECK_EQUAL(out[returned], guard_value);
+
+    // and they should match the expected data, at least in the middle
+    const float *outf = out.data() + 200, *expectedf = expected.data() + 200;
+    COMPARE_N(outf, expectedf, 600);
+}
+
+BOOST_AUTO_TEST_CASE(overrun_interleaved)
+{
+    // Check that the outcount argument is correctly used: any samples
+    // already in the out buffer beyond outcount*channels must be left
+    // untouched. We test this with short buffers (likely to be
+    // shorter than the resampler filter length) and longer ones, with
+    // resampler ratios that reduce, leave unchanged, and raise the
+    // sample rate, and with all quality settings.
+
+    // Options are ordered from most normal/likely to least.
+    
+    int channels = 2;
+
+    int lengths[] = { 6000, 6 };
+    int constructionBufferSizes[] = { 0, 1000 };
+    double ratios[] = { 1.0, 10.0, 0.1 };
+    Resampler::Quality qualities[] = {
+        Resampler::FastestTolerable, Resampler::Best, Resampler::Fastest
+    };
+
+    bool failed = false;
+    
+    for (int li = 0; li < LEN(lengths); ++li) {
+        for (int cbi = 0; cbi < LEN(constructionBufferSizes); ++cbi) {
+            for (int ri = 0; ri < LEN(ratios); ++ri) {
+                for (int qi = 0; qi < LEN(qualities); ++qi) {
+                    
+                    int length = lengths[li];
+                    double ratio = ratios[ri];
+                    Resampler::Parameters parameters;
+                    parameters.quality = qualities[qi];
+                    parameters.maxBufferSize = constructionBufferSizes[cbi];
+                    Resampler r(parameters, channels);
+
+                    float *inbuf = new float[length * channels];
+                    for (int i = 0; i < length; ++i) {
+                        for (int c = 0; c < channels; ++c) {
+                            inbuf[i*channels+c] =
+                                sinf((i * 2.0 * M_PI * 440.0) / 44100.0);
+                        }
+                    }
+
+                    int outcount = int(round(length * ratio));
+                    outcount -= 10;
+                    if (outcount < 1) outcount = 1;
+                    int outbuflen = outcount + 10;
+                    float *outbuf = new float[outbuflen * channels];
+                    for (int i = 0; i < outbuflen; ++i) {
+                        for (int c = 0; c < channels; ++c) {
+                            outbuf[i*channels+c] = guard_value;
+                        }
+                    }
+/*
+                    cerr << "\nTesting with length = " << length << ", ratio = "
+                         << ratio << ", outcount = " << outcount << ", final = false"
+                         << endl;
+*/                    
+                    int returned = r.resampleInterleaved
+                        (outbuf, outcount, inbuf, length, ratio, false);
+
+                    BOOST_CHECK_LE(returned, outcount);
+                    
+                    for (int i = returned; i < outbuflen; ++i) {
+                        for (int c = 0; c < channels; ++c) {
+                            BOOST_CHECK_EQUAL(outbuf[i*channels+c], guard_value);
+                            if (outbuf[i*channels+c] != guard_value) {
+                                failed = true;
+                            }
+                        }
+                    }
+
+                    if (failed) {
+                        cerr << "Test failed, abandoning remaining loop cycles"
+                             << endl;
+                        break;
+                    }
+/*
+                    cerr << "\nContinuing with length = " << length << ", ratio = "
+                         << ratio << ", outcount = " << outcount << ", final = true"
+                         << endl;
+*/
+                    returned = r.resampleInterleaved
+                        (outbuf, outcount, inbuf, length, ratio, true);
+
+                    BOOST_CHECK_LE(returned, outcount);
+
+                    for (int i = returned; i < outbuflen; ++i) {
+                        for (int c = 0; c < channels; ++c) {
+                            BOOST_CHECK_EQUAL(outbuf[i*channels+c], guard_value);
+                            if (outbuf[i*channels+c] != guard_value) {
+                                failed = true;
+                            }
+                        }
+                    }
+
+                    delete[] outbuf;
+                    delete[] inbuf;
+
+                    if (failed) {
+                        cerr << "Test failed, abandoning remaining loop cycles"
+                             << endl;
+                        break;
+                    }
+                }
+
+                if (failed) break;
+            }
+            if (failed) break;
+        }
+        if (failed) break;
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestSignalBits.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestSignalBits.cpp
@@ -1,0 +1,350 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../common/MovingMedian.h"
+#include "../common/HistogramFilter.h"
+#include "../finer/Peak.h"
+
+using namespace RubberBand;
+
+using std::vector;
+
+namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_SUITE(TestSignalBits)
+
+BOOST_AUTO_TEST_CASE(moving_median_simple_3)
+{
+    MovingMedian<double> mm(3);
+    vector<double> arr { 1.0, 2.0, 3.0 };
+    vector<double> expected { 1.0, 2.0, 2.0 };
+    MovingMedian<double>::filter(mm, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(moving_median_simple_4)
+{
+    MovingMedian<double> mm(4);
+    vector<double> arr { 1.0, 2.0, 3.0, 4.0 };
+    vector<double> expected { 2.0, 2.0, 3.0, 3.0 };
+    MovingMedian<double>::filter(mm, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(moving_median_simple_3_4)
+{
+    MovingMedian<double> mm(3);
+    vector<double> arr { 1.2, 0.6, 1.0e-6, 1.0 };
+    vector<double> expected { 0.6, 0.6, 0.6, 1.0e-6 };
+    MovingMedian<double>::filter(mm, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(moving_median_simple_5_4)
+{
+    MovingMedian<double> mm(5);
+    vector<double> arr { 1.2, 0.6, 1.0e-6, 1.0 };
+    vector<double> expected { 0.6, 0.6, 0.6, 0.6 };
+    MovingMedian<double>::filter(mm, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+  
+BOOST_AUTO_TEST_CASE(moving_median_order_1)
+{
+    MovingMedian<double> mm(1);
+    vector<double> arr { 1.2, 0.6, 1.0e-6, 1.0e-6 };
+    vector<double> expected = arr;
+    MovingMedian<double>::filter(mm, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+  
+BOOST_AUTO_TEST_CASE(moving_median_n_1)
+{
+    MovingMedian<double> mm(6);
+    vector<double> arr { 1.0 };
+    vector<double> expected { 1.0 };
+    MovingMedian<double>::filter(mm, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(histogram_median_simple_3)
+{
+    HistogramFilter hf(5, 3); // nValues, filterLength
+    vector<int> arr { 1, 2, 3 };
+    vector<int> expected { 1, 2, 2 };
+    HistogramFilter::medianFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(histogram_median_simple_4)
+{
+    HistogramFilter hf(5, 4); // nValues, filterLength
+    vector<int> arr { 1, 2, 3, 4 };
+    vector<int> expected { 2, 2, 3, 3 };
+    HistogramFilter::medianFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(histogram_median_simple_3_4)
+{
+    HistogramFilter hf(5, 3); // nValues, filterLength
+    vector<int> arr { 3, 1, 0, 2 };
+    vector<int> expected { 1, 1, 1, 0 };
+    HistogramFilter::medianFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(histogram_median_simple_5_4)
+{
+    HistogramFilter hf(5, 5);
+    vector<int> arr { 3, 1, 0, 2 };
+    vector<int> expected { 1, 1, 1, 1 };
+    HistogramFilter::medianFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+  
+BOOST_AUTO_TEST_CASE(histogram_median_order_1)
+{
+    HistogramFilter hf(4, 1);
+    vector<int> arr { 3, 1, 0, 0 };
+    vector<int> expected = arr;
+    HistogramFilter::medianFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+  
+BOOST_AUTO_TEST_CASE(histogram_median_n_1)
+{
+    HistogramFilter hf(3, 6);
+    vector<int> arr { 1 };
+    vector<int> expected { 1 };
+    HistogramFilter::medianFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(histogram_mode_simple_3)
+{
+    HistogramFilter hf(5, 3); // nValues, filterLength
+    vector<int> arr { 1, 2, 2 };
+    vector<int> expected { 1, 2, 2 };
+    HistogramFilter::modalFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(histogram_mode_simple_4)
+{
+    HistogramFilter hf(5, 4); // nValues, filterLength
+    vector<int> arr { 1, 2, 2, 4 };
+    vector<int> expected { 2, 2, 2, 2 };
+    HistogramFilter::modalFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(histogram_mode_simple_3_4)
+{
+    HistogramFilter hf(5, 3); // nValues, filterLength
+    vector<int> arr { 3, 1, 0, 0 };
+    vector<int> expected { 1, 0, 0, 0 };
+    HistogramFilter::modalFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(histogram_mode_simple_5_4)
+{
+    HistogramFilter hf(5, 5);
+    vector<int> arr { 3, 1, 0, 0 };
+    vector<int> expected { 0, 0, 0, 0 };
+    HistogramFilter::modalFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+  
+BOOST_AUTO_TEST_CASE(histogram_mode_order_1)
+{
+    HistogramFilter hf(4, 1);
+    vector<int> arr { 3, 1, 0, 0 };
+    vector<int> expected = arr;
+    HistogramFilter::modalFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+  
+BOOST_AUTO_TEST_CASE(histogram_mode_n_1)
+{
+    HistogramFilter hf(3, 6);
+    vector<int> arr { 1 };
+    vector<int> expected { 1 };
+    HistogramFilter::modalFilter(hf, arr);
+    BOOST_TEST(arr == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(peakpick_nearest_2_1)
+{
+    Peak<double> pp(1);
+    vector<double> in { -0.1 };
+    vector<int> out(1);
+    vector<int> expected { 0 };
+    pp.findNearestAndNextPeaks(in.data(), 2, out.data(), nullptr);
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(peakpick_nearest_2_5)
+{
+    Peak<double> pp(5);
+    vector<double> in { -0.3, -0.1, -0.2, 1.0, -0.3 };
+    vector<int> out(5);
+    vector<int> expected { 3, 3, 3, 3, 3 };
+    pp.findNearestAndNextPeaks(in.data(), 2, out.data(), nullptr);
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(peakpick_nearest_2_12)
+{
+    Peak<double> pp(12);
+    vector<double> in { -0.3, -0.1, -0.2, 1.0, -0.3, -0.5,
+                        -0.5, -0.4, -0.1, -0.1, -0.2, -0.3 };
+    vector<int> out(12);
+    vector<int> expected { 3, 3, 3, 3, 3, 3, 8, 8, 8, 8, 8, 8 };
+    pp.findNearestAndNextPeaks(in.data(), 2, out.data(), nullptr);
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(peakpick_nearest_1_12)
+{
+    Peak<double> pp(12);
+    vector<double> in { -0.3, -0.1, -0.2, 1.0, -0.3, -0.5,
+                        -0.5, -0.4, -0.1, -0.1, -0.2, -0.3 };
+    vector<int> out(12);
+    vector<int> expected { 1, 1, 3, 3, 3, 3, 8, 8, 8, 8, 8, 8 };
+    pp.findNearestAndNextPeaks(in.data(), 1, out.data(), nullptr);
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(peakpick_nearest_0_12)
+{
+    Peak<double> pp(12);
+    vector<double> in { -0.3, -0.1, -0.2, 1.0, -0.3, -0.5,
+                        -0.5, -0.4, -0.1, -0.1, -0.2, -0.3 };
+    vector<int> out(12);
+    vector<int> expected { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+    pp.findNearestAndNextPeaks(in.data(), 0, out.data(), nullptr);
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(peakpick_next_2_1)
+{
+    Peak<double> pp(1);
+    vector<double> in { -0.1 };
+    vector<int> out(1);
+    vector<int> expected { 0 };
+    pp.findNearestAndNextPeaks(in.data(), 2, nullptr, out.data());
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(peakpick_next_2_5)
+{
+    Peak<double> pp(5);
+    vector<double> in { -0.3, -0.1, -0.2, 1.0, -0.3 };
+    vector<int> out(5);
+    vector<int> expected { 3, 3, 3, 3, 4 };
+    pp.findNearestAndNextPeaks(in.data(), 2, nullptr, out.data());
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(peakpick_next_2_12)
+{
+    Peak<double> pp(12);
+    vector<double> in { -0.3, -0.1, 0.2, -1.0, -0.3, -0.5,
+                        -0.5, -0.4, -0.1, -0.1, -0.2, -0.3 };
+    vector<int> out(12);
+    vector<int> expected { 2, 2, 2, 8, 8, 8, 8, 8, 8, 9, 10, 11 };
+    pp.findNearestAndNextPeaks(in.data(), 2, nullptr, out.data());
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(troughpick_nearest_2_1)
+{
+    Peak<double, std::less<double>> pp(1);
+    vector<double> in { -0.1 };
+    vector<int> out(1);
+    vector<int> expected { 0 };
+    pp.findNearestAndNextPeaks(in.data(), 2, out.data(), nullptr);
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(troughpick_nearest_2_5)
+{
+    Peak<double, std::less<double>> pp(5);
+    vector<double> in { -0.3, -0.1, -0.4, 0.1, -0.3 };
+    vector<int> out(5);
+    vector<int> expected { 2, 2, 2, 2, 2 };
+    pp.findNearestAndNextPeaks(in.data(), 2, out.data(), nullptr);
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(troughpick_nearest_2_12)
+{
+    Peak<double, std::less<double>> pp(12);
+    vector<double> in { -0.3, -0.1, -0.2, 1.0, -0.3, -0.5,
+                        -0.5, -0.4, -0.1, -0.1, -0.2, -0.3 };
+    vector<int> out(12);
+    vector<int> expected { 0, 0, 0, 5, 5, 5, 5, 5, 11, 11, 11, 11 };
+    pp.findNearestAndNextPeaks(in.data(), 2, out.data(), nullptr);
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(troughpick_next_2_1)
+{
+    Peak<double, std::less<double>> pp(1);
+    vector<double> in { -0.1 };
+    vector<int> out(1);
+    vector<int> expected { 0 };
+    pp.findNearestAndNextPeaks(in.data(), 2, nullptr, out.data());
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(troughpick_next_2_5)
+{
+    Peak<double, std::less<double>> pp(5);
+    vector<double> in { -0.3, -0.1, -0.4, 0.1, -0.3 };
+    vector<int> out(5);
+    vector<int> expected { 2, 2, 2, 3, 4 };
+    pp.findNearestAndNextPeaks(in.data(), 2, nullptr, out.data());
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(troughpick_next_2_12)
+{
+    Peak<double, std::less<double>> pp(12);
+    vector<double> in { -0.3, -0.1, 0.2, 1.0, -0.3, -0.5,
+                        -0.5, -0.4, -0.1, -0.1, -0.2, -0.3 };
+    vector<int> out(12);
+    vector<int> expected { 0, 5, 5, 5, 5, 5, 11, 11, 11, 11, 11, 11 };
+    pp.findNearestAndNextPeaks(in.data(), 2, nullptr, out.data());
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestStretchCalculator.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestStretchCalculator.cpp
@@ -1,0 +1,133 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../common/StretchCalculator.h"
+
+#include <iostream>
+
+using namespace RubberBand;
+
+using std::cerr;
+using std::endl;
+
+using std::vector;
+
+namespace tt = boost::test_tools;
+
+static Log cerrLog(
+    [](const char *message) {
+        cerr << message << "\n";
+    },
+    [](const char *message, double arg) {
+        cerr << message << ": " << arg << "\n";
+    },
+    [](const char *message, double arg0, double arg1) {
+        cerr << message << ": (" << arg0 << ", " << arg1 << ")\n";
+    }
+    );
+
+BOOST_AUTO_TEST_SUITE(TestStretchCalculator)
+
+BOOST_AUTO_TEST_CASE(offline_linear_hp)
+{
+    StretchCalculator sc(44100, 512, true, cerrLog);
+
+    vector<int> out, expected;
+
+    out = sc.calculate(1.0, 5120, { 1.0, 1.0, 1.0, 1.0, 1.0,
+                                    1.0, 1.0, 1.0, 1.0, 1.0 }); 
+    expected = { 512, 512, 512, 512, 512,
+                 512, 512, 512, 512, 512 };
+    BOOST_TEST(out == expected, tt::per_element());
+
+    out = sc.calculate(0.5, 5120, { 1.0, 1.0, 1.0, 1.0, 1.0,
+                                    1.0, 1.0, 1.0, 1.0, 1.0 }); 
+    expected = { 256, 256, 256, 256, 256,
+                 256, 256, 256, 256, 256 };
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(offline_linear_nohp)
+{
+    StretchCalculator sc(44100, 512, false, cerrLog);
+
+    vector<int> out, expected;
+
+    out = sc.calculate(1.0, 5120, { 1.0, 1.0, 1.0, 1.0, 1.0,
+                                    1.0, 1.0, 1.0, 1.0, 1.0 }); 
+    expected = { 512, 512, 512, 512, 512,
+                 512, 512, 512, 512, 512 };
+    BOOST_TEST(out == expected, tt::per_element());
+
+    out = sc.calculate(0.5, 5120, { 1.0, 1.0, 1.0, 1.0, 1.0,
+                                    1.0, 1.0, 1.0, 1.0, 1.0 }); 
+    expected = { 256, 256, 256, 256, 256,
+                 256, 256, 256, 256, 256 };
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(offline_onep_hp)
+{
+    StretchCalculator sc(44100, 512, true, cerrLog);
+    
+    vector<int> out, expected;
+
+    out = sc.calculate(1.0, 5120, { 1.0, 1.0, 1.0, 1.0, 2.0,
+                                    1.0, 1.0, 1.0, 1.0, 1.0 }); 
+    expected = { 512, 512, 512, 512, -512,
+                 512, 512, 512, 512, 512 };
+    BOOST_TEST(out == expected, tt::per_element());
+
+    out = sc.calculate(0.5, 5120, { 1.0, 1.0, 1.0, 1.0, 2.0,
+                                    1.0, 1.0, 1.0, 1.0, 1.0 }); 
+    expected = { 256, 256, 256, 256, -512,
+                 205, 205, 204, 205, 205 };
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(offline_onep_nohp)
+{
+    StretchCalculator sc(44100, 512, false, cerrLog);
+    
+    vector<int> out, expected;
+
+    out = sc.calculate(1.0, 5120, { 1.0, 1.0, 1.0, 1.0, 2.0,
+                                    1.0, 1.0, 1.0, 1.0, 1.0 }); 
+    expected = { 512, 512, 512, 512, 512,
+                 512, 512, 512, 512, 512 };
+    BOOST_TEST(out == expected, tt::per_element());
+
+    out = sc.calculate(0.5, 5120, { 1.0, 1.0, 1.0, 1.0, 2.0,
+                                    1.0, 1.0, 1.0, 1.0, 1.0 }); 
+    expected = { 256, 256, 256, 256, 256,
+                 256, 256, 256, 256, 256 };
+    BOOST_TEST(out == expected, tt::per_element());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestStretcher.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestStretcher.cpp
@@ -1,0 +1,1547 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../../rubberband/RubberBandStretcher.h"
+
+#include <iostream>
+
+#include <cmath>
+
+using namespace RubberBand;
+
+using std::vector;
+using std::cerr;
+using std::endl;
+
+namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_SUITE(TestStretcher)
+
+BOOST_AUTO_TEST_CASE(engine_version)
+{
+    RubberBandStretcher s2(44100, 1, RubberBandStretcher::OptionEngineFaster);
+    BOOST_TEST(s2.getEngineVersion() == 2);
+    BOOST_TEST(s2.getProcessSizeLimit() == 524288u);
+    RubberBandStretcher s3(44100, 1, RubberBandStretcher::OptionEngineFiner);
+    BOOST_TEST(s3.getEngineVersion() == 3);
+    BOOST_TEST(s3.getProcessSizeLimit() == 524288u);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_unchanged_offline_faster)
+{
+    int n = 10000;
+    float freq = 440.f;
+    int rate = 44100;
+    RubberBandStretcher stretcher
+        (rate, 1, RubberBandStretcher::OptionEngineFaster);
+
+    vector<float> in(n), out(n);
+    for (int i = 0; i < n; ++i) {
+        in[i] = sinf(float(i) * freq * M_PI * 2.f / float(rate));
+    }
+    float *inp = in.data(), *outp = out.data();
+
+    stretcher.setMaxProcessSize(n);
+    stretcher.setExpectedInputDuration(n);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.study(&inp, n, true);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.process(&inp, n, true);
+    BOOST_TEST(stretcher.available() == n);
+
+    BOOST_TEST(stretcher.getStartDelay() == 0u); // offline mode
+    
+    size_t got = stretcher.retrieve(&outp, n);
+    BOOST_TEST(got == size_t(n));
+    BOOST_TEST(stretcher.available() == -1);
+
+    // We now have n samples of a simple sinusoid with stretch factor
+    // 1.0; obviously we expect the output to be essentially the same
+    // thing. It will have lower precision for a while at the start
+    // and end because of windowing factors, so we check those with a
+    // threshold of 0.1; in the middle we expect better
+    // precision. Note that these are relative tolerances, not
+    // absolute, i.e. 0.001 means 0.001x the smaller value - so they
+    // are tighter than they appear.
+
+    // This syntax for comparing containers with a certain tolerance
+    // using BOOST_TEST is just bonkers. I can't find the << syntax to
+    // combine manipulators documented anywhere other than in a
+    // release note, but it does work. Well, sort of - it works this
+    // way around but not as per_element << tolerance. And
+    // tolerance(0.1) doesn't do what you'd expect if the things
+    // you're comparing are floats (it sets the tolerance for doubles,
+    // leaving float comparison unchanged). Clever... too clever.
+    
+    BOOST_TEST(out == in,
+               tt::tolerance(0.1f) << tt::per_element());
+    
+    BOOST_TEST(vector<float>(out.begin() + 1024, out.begin() + n - 1024) ==
+               vector<float>(in.begin() + 1024, in.begin() + n - 1024),
+               tt::tolerance(0.001f) << tt::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_unchanged_offline_finer)
+{
+    int n = 10000;
+    float freq = 440.f;
+    int rate = 44100;
+
+    RubberBandStretcher stretcher
+        (rate, 1, RubberBandStretcher::OptionEngineFiner);
+    
+    vector<float> in(n), out(n);
+    for (int i = 0; i < n; ++i) {
+        in[i] = sinf(float(i) * freq * M_PI * 2.f / float(rate));
+    }
+    float *inp = in.data(), *outp = out.data();
+
+    stretcher.setMaxProcessSize(n);
+    stretcher.setExpectedInputDuration(n);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.study(&inp, n, true);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.process(&inp, n, true);
+    BOOST_TEST(stretcher.available() == n);
+
+    BOOST_TEST(stretcher.getStartDelay() == 0u); // offline mode
+    
+    size_t got = stretcher.retrieve(&outp, n);
+    BOOST_TEST(got == size_t(n));
+    BOOST_TEST(stretcher.available() == -1);
+
+    // The R3 engine is actually less precise than R2 here because of
+    // its different windowing design, though see the note above about
+    // what these tolerances mean
+    
+    BOOST_TEST(out == in,
+               tt::tolerance(0.35f) << tt::per_element());
+    
+    BOOST_TEST(vector<float>(out.begin() + 1024, out.begin() + n - 1024) ==
+               vector<float>(in.begin() + 1024, in.begin() + n - 1024),
+               tt::tolerance(0.01f) << tt::per_element());
+
+//    std::cout << "ms\tV" << std::endl;
+//    for (int i = 0; i < n; ++i) {
+//        std::cout << i << "\t" << out[i] - in[i] << std::endl;
+//    }
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_2x_offline_finer)
+{
+    int n = 10000;
+    float freq = 441.f; // so a cycle is an exact number of samples
+    int rate = 44100;
+
+    RubberBandStretcher stretcher
+        (rate, 1, RubberBandStretcher::OptionEngineFiner);
+
+    stretcher.setTimeRatio(2.0);
+    
+    vector<float> in(n), out(n*2);
+    for (int i = 0; i < n*2; ++i) {
+        out[i] = sinf(float(i) * freq * M_PI * 2.f / float(rate));
+        if (i < n) {
+            in[i] = out[i];
+        }
+    }
+    float *inp = in.data(), *outp = out.data();
+
+    stretcher.setMaxProcessSize(n);
+    stretcher.setExpectedInputDuration(n);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.study(&inp, n, true);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.process(&inp, n, true);
+    BOOST_TEST(stretcher.available() == n*2);
+
+    BOOST_TEST(stretcher.getStartDelay() == 0u); // offline mode
+    
+    size_t got = stretcher.retrieve(&outp, n*2);
+    BOOST_TEST(got == size_t(n)*2);
+    BOOST_TEST(stretcher.available() == -1);
+
+    int period = -1;
+    for (int i = 1000; i < 2000; ++i) {
+        if (period >= 0) ++period;
+        if (out[i] <= 0.f && out[i+1] > 0.f) {
+            if (period == -1) period = 0;
+            else break;
+        }
+    }
+    BOOST_TEST(period == 100);
+    
+    int offset = 0;
+    for (int i = 0; i < 200; ++i) {
+        if (out[i] <= 0.f && out[i+1] > -0.01f) {
+            offset = i + 1;
+            break;
+        }
+    }
+
+    // overall
+    
+    double rms = 0.0;
+    for (int i = 0; i < n - offset; ++i) {
+        double diff = out[i + offset] - in[i];
+        rms += diff * diff;
+    }
+    rms = sqrt(rms / double(n - offset));
+    BOOST_TEST(rms < 0.2);
+
+    // steady state
+    
+    rms = 0.0;
+    for (int i = 1500; i < n - offset - 3000; ++i) {
+        double diff = out[i + offset + 1500] - in[i + 1500];
+        rms += diff * diff;
+    }
+    rms = sqrt(rms / double(n - offset - 3000));
+    BOOST_TEST(rms < 0.1);
+}
+
+static vector<float> process_realtime(RubberBandStretcher &stretcher,
+                                      const vector<float> &in,
+                                      int nOut,
+                                      int bs,
+                                      bool roundUpProcessSize,
+                                      bool printDebug)
+{
+    int n = in.size();
+    vector<float> out(nOut, 0.f);
+
+    // Prime the start
+    {
+        float *source = out.data(); // just reuse out because it's silent
+        stretcher.process(&source, stretcher.getPreferredStartPad(), false);
+    }
+
+    int toSkip = stretcher.getStartDelay();
+    
+    int inOffset = 0, outOffset = 0;
+
+    while (outOffset < nOut) {
+
+        // Obtain a single block of size bs, simulating realtime
+        // playback. The following might be the content of a
+        // sound-producing callback function
+
+        int needed = std::min(bs, nOut - outOffset);
+        int obtained = 0;
+
+        while (obtained < needed) {
+
+            int available = stretcher.available();
+
+            if (available < 0) { // finished
+                for (int i = obtained; i < needed; ++i) {
+                    out[outOffset++] = 0.f;
+                }
+                break;
+
+            } else if (available == 0) { // need to provide more input
+                int required = stretcher.getSamplesRequired();
+                BOOST_TEST(required > 0); // because available == 0
+                int toProcess = required;
+                if (roundUpProcessSize) {
+                    // We sometimes want to explicitly test passing
+                    // large blocks to process, longer than
+                    // getSamplesRequired indicates
+                    toProcess = std::max(required, bs);
+                }
+                bool final = false;
+                if (toProcess >= n - inOffset) {
+                    toProcess = n - inOffset;
+                    final = true;
+                }
+                const float *const source = in.data() + inOffset;
+//                cerr << "toProcess = " << toProcess << ", inOffset = " << inOffset << ", n = " << n << ", required = " << required << ", outOffset = " << outOffset << ", obtained = " << obtained << ", bs = " << bs << ", final = " << final << endl;
+                stretcher.process(&source, toProcess, final);
+                inOffset += toProcess;
+                BOOST_TEST(stretcher.available() > 0);
+                continue;
+
+            } else if (toSkip > 0) { // available > 0 && toSkip > 0
+                float *target = out.data() + outOffset;
+                int toRetrieve = std::min(toSkip, available);
+                int retrieved = stretcher.retrieve(&target, toRetrieve);
+                BOOST_TEST(retrieved == toRetrieve);
+                toSkip -= retrieved;
+                
+            } else { // available > 0
+                float *target = out.data() + outOffset;
+                int toRetrieve = std::min(needed - obtained, available);
+                int retrieved = stretcher.retrieve(&target, toRetrieve);
+                BOOST_TEST(retrieved == toRetrieve);
+                obtained += retrieved;
+                outOffset += retrieved;
+            }
+        }
+    }
+
+    if (printDebug) {
+        // The initial # is to allow grep on the test output
+        std::cout << "#sample\tV" << std::endl;
+        for (int i = 0; i < nOut; ++i) {
+            std::cout << "#" << i << "\t" << out[i] << std::endl;
+        }
+    }
+
+    return out;
+}
+
+static void sinusoid_realtime(RubberBandStretcher::Options options,
+                              double timeRatio,
+                              double pitchScale,
+                              int bs = 512,
+                              bool roundUpProcessSize = false,
+                              bool printDebug = false)
+{
+    int n = (timeRatio < 1.0 ? 80000 : 40000);
+    if (n < bs * 2) n = bs * 2;
+    int nOut = int(ceil(n * timeRatio));
+    float freq = 441.f;
+    int rate = 44100;
+
+    // This test simulates block-by-block realtime processing with
+    // latency compensation, and checks that the output is all in the
+    // expected place
+
+    RubberBandStretcher stretcher(rate, 1, options, timeRatio, pitchScale);
+
+    if (printDebug) {
+        stretcher.setDebugLevel(2);
+    }
+
+    stretcher.setMaxProcessSize(bs);
+    
+    // The input signal is a fixed frequency sinusoid that steps up in
+    // amplitude every 1/10 of the total duration - from 0.1 at the
+    // start, via increments of 0.1, to 1.0 at the end
+    
+    vector<float> in(n);
+    for (int i = 0; i < n; ++i) {
+        float amplitude = float((i / (n/10)) + 1) / 10.f;
+        float sample = amplitude *
+            sinf(float(i) * freq * M_PI * 2.f / float(rate));
+        in[i] = sample;
+    }
+
+    vector<float> out = process_realtime(stretcher, in, nOut, bs,
+                                         roundUpProcessSize, printDebug);
+        
+    // Step through the output signal in chunk of 1/20 of its duration
+    // (i.e. a rather arbitrary two per expected 0.1 increment in
+    // amplitude) and for each chunk, verify that the frequency is
+    // right and the amplitude is what we expect at that point
+
+    for (int chunk = 0; chunk < 20; ++chunk) {
+
+//        cerr << "chunk " << chunk << " of 20" << endl;
+        
+        int i0 = (nOut * chunk) / 20;
+        int i1 = (nOut * (chunk + 1)) / 20;
+
+        // frequency
+
+        int positiveCrossings = 0;
+        for (int i = i0; i + 1 < i1; ++i) {
+            if (out[i] <= 0.f && out[i+1] > 0.f) {
+                ++positiveCrossings;
+            }
+        }
+
+        int expectedCrossings = int(round((freq * pitchScale *
+                                           double(i1 - i0)) / rate));
+
+        bool highSpeedPitch =
+            ! ((options & RubberBandStretcher::OptionPitchHighQuality) ||
+               (options & RubberBandStretcher::OptionPitchHighConsistency));
+
+        // The check here has to depend on whether we are in Finer or
+        // Faster mode. In Finer mode, we expect to be generally exact
+        // but in the first and last chunks we can be out by one
+        // crossing if slowing, more if speeding up. In Faster mode we
+        // need to cut more slack
+
+        int slack = 0;
+
+        if (options & RubberBandStretcher::OptionEngineFiner) {
+            if (chunk == 19) {
+                slack = 5;
+            } else if (options & RubberBandStretcher::OptionWindowShort) {
+                slack = 2;
+            } else if (chunk == 0 || highSpeedPitch) {
+                slack = 1;
+            }
+        } else {
+            slack = 1;
+            if (chunk == 0) {
+                slack = (timeRatio < 1.0 ? 3 : 2);
+            } else if (chunk == 19) {
+                // all bets are off, practically
+                slack = expectedCrossings / 2;
+            } else {
+                slack = 1;
+            }
+        }
+
+        BOOST_TEST(positiveCrossings <= expectedCrossings + slack);
+        BOOST_TEST(positiveCrossings >= expectedCrossings - slack);
+        
+        // amplitude
+        
+        double rms = 0.0;
+        for (int i = i0; i < i1; ++i) {
+            rms += out[i] * out[i];
+        }
+        rms = sqrt(rms / double(i1 - i0));
+
+        double expected = (chunk/2 + 1) * 0.05 * sqrt(2.0);
+
+        double maxOver = 0.01;
+        double maxUnder = 0.1;
+
+        if (!(options & RubberBandStretcher::OptionEngineFiner) ||
+            (options & RubberBandStretcher::OptionWindowShort)) {
+            maxUnder = 0.2;
+        } else if (chunk == 19) {
+            maxUnder = 0.15;
+        }
+        
+        BOOST_TEST(rms - expected < maxOver);
+        BOOST_TEST(expected - rms < maxUnder);
+    }        
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_samepitch_realtime_finer)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      8.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_samepitch_realtime_finer)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      0.5, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_higher_realtime_finer)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      4.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_higher_realtime_finer_hqpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighQuality,
+                      4.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_higher_realtime_finer_hcpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      4.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_higher_realtime_finer)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      0.5, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_higher_realtime_finer_hqpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighQuality,
+                      0.5, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_higher_realtime_finer_hcpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      0.5, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_lower_realtime_finer)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      8.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_lower_realtime_finer_hqpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighQuality,
+                      8.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_lower_realtime_finer_hcpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      8.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_samepitch_realtime_finer_short)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionWindowShort,
+                      8.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_samepitch_realtime_finer_short)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionWindowShort,
+                      0.5, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_higher_realtime_finer_short)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionWindowShort,
+                      4.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_higher_realtime_finer_short_hcpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionWindowShort |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      4.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_higher_realtime_finer_short)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionWindowShort,
+                      0.5, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_higher_realtime_finer_hcpitch_short)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionWindowShort |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      0.5, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_lower_realtime_finer_short)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionWindowShort,
+                      8.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_lower_realtime_finer_short_hcpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionWindowShort |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      8.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_samepitch_realtime_faster)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      8.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_samepitch_realtime_faster)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      0.5, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_higher_realtime_faster)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      4.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_higher_realtime_faster_hqpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighQuality,
+                      4.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_higher_realtime_faster_hcpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      4.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_higher_realtime_faster)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      0.5, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_higher_realtime_faster_hqpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighQuality,
+                      0.5, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_fast_higher_realtime_faster_hcpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      0.5, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_lower_realtime_faster)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      8.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_lower_realtime_faster_hqpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighQuality,
+                      8.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_slow_lower_realtime_faster_hcpitch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      8.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_realtime_long_blocksize_faster)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      4.0, 0.5,
+                      80000, true);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_realtime_long_blocksize_faster_stretch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      2.0, 1.0,
+                      80000, true);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_realtime_long_blocksize_faster_shrink)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      0.8, 1.0,
+                      80000, true);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_realtime_long_blocksize_faster_higher)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      1.0, 2.0,
+                      80000, true);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_realtime_long_blocksize_faster_lower)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFaster |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      1.0, 0.5,
+                      80000, true);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_realtime_long_blocksize_finer)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      4.0, 0.5,
+                      80000, true);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_realtime_long_blocksize_finer_stretch)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      2.0, 1.0,
+                      80000, true);
+}
+
+BOOST_AUTO_TEST_CASE(sinusoid_realtime_long_blocksize_finer_shift)
+{
+    sinusoid_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      1.0, 0.5,
+                      80000, true);
+}
+
+BOOST_AUTO_TEST_CASE(impulses_2x_offline_faster)
+{
+    int n = 10000;
+    int rate = 44100;
+    RubberBandStretcher stretcher
+        (rate, 1, RubberBandStretcher::OptionEngineFaster);
+
+    stretcher.setTimeRatio(2.0);
+
+    vector<float> in(n, 0.f), out(n * 2, 0.f);
+
+    in[100] = 1.f;
+    in[101] = -1.f;
+
+    in[5000] = 1.f;
+    in[5001] = -1.f;
+
+    in[9900] = 1.f;
+    in[9901] = -1.f;
+    
+    float *inp = in.data(), *outp = out.data();
+
+    stretcher.setMaxProcessSize(n);
+    stretcher.setExpectedInputDuration(n);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.study(&inp, n, true);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.process(&inp, n, true);
+    BOOST_TEST(stretcher.available() == n * 2);
+
+    BOOST_TEST(stretcher.getStartDelay() == 0u); // offline mode
+    
+    size_t got = stretcher.retrieve(&outp, n * 2);
+    BOOST_TEST(got == size_t(n) * 2);
+    BOOST_TEST(stretcher.available() == -1);
+
+    int peak0 = -1, peak1 = -1, peak2 = -1;
+    float max;
+    
+    max = -2.f;
+    for (int i = 0; i < n/2; ++i) {
+        if (out[i] > max) { max = out[i]; peak0 = i; }
+    }
+
+    max = -2.f;
+    for (int i = n/2; i < (n*3)/2; ++i) {
+        if (out[i] > max) { max = out[i]; peak1 = i; }
+    }
+
+    max = -2.f;
+    for (int i = (n*3)/2; i < n*2; ++i) {
+        if (out[i] > max) { max = out[i]; peak2 = i; }
+    }
+
+    BOOST_TEST(peak0 == 100);
+    BOOST_TEST(peak1 > n - 600);
+    BOOST_TEST(peak1 < n + 500);
+    BOOST_TEST(peak2 > n*2 - 600);
+    BOOST_TEST(peak2 < n*2);
+/*
+    std::cout << "ms\tV" << std::endl;
+    for (int i = 0; i < n*2; ++i) {
+        std::cout << i << "\t" << out[i] << std::endl;
+    }
+*/
+}
+
+BOOST_AUTO_TEST_CASE(impulses_2x_offline_finer)
+{
+    int n = 10000;
+    int rate = 44100;
+    RubberBandStretcher stretcher
+        (rate, 1, RubberBandStretcher::OptionEngineFiner);
+
+    stretcher.setTimeRatio(2.0);
+
+    vector<float> in(n, 0.f), out(n * 2, 0.f);
+
+    in[100] = 1.f;
+    in[101] = -1.f;
+
+    in[5000] = 1.f;
+    in[5001] = -1.f;
+
+    in[9900] = 1.f;
+    in[9901] = -1.f;
+    
+    float *inp = in.data(), *outp = out.data();
+
+    stretcher.setMaxProcessSize(n);
+    stretcher.setExpectedInputDuration(n);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.study(&inp, n, true);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.process(&inp, n, true);
+    BOOST_TEST(stretcher.available() == n * 2);
+
+    BOOST_TEST(stretcher.getStartDelay() == 0u); // offline mode
+    
+    size_t got = stretcher.retrieve(&outp, n * 2);
+    BOOST_TEST(got == size_t(n) * 2);
+    BOOST_TEST(stretcher.available() == -1);
+
+    int peak0 = -1, peak1 = -1, peak2 = -1;
+    float max;
+
+    max = -2.f;
+    for (int i = 0; i < n/2; ++i) {
+        if (out[i] > max) { max = out[i]; peak0 = i; }
+    }
+
+    max = -2.f;
+    for (int i = n/2; i < (n*3)/2; ++i) {
+        if (out[i] > max) { max = out[i]; peak1 = i; }
+    }
+
+    max = -2.f;
+    for (int i = (n*3)/2; i < n*2; ++i) {
+        if (out[i] > max) { max = out[i]; peak2 = i; }
+    }
+
+    BOOST_TEST(peak0 == 100);
+    BOOST_TEST(peak1 > n - 400);
+    BOOST_TEST(peak1 < n + 50);
+    BOOST_TEST(peak2 > n*2 - 600);
+    BOOST_TEST(peak2 < n*2);
+/*
+    std::cout << "ms\tV" << std::endl;
+    for (int i = 0; i < n*2; ++i) {
+        std::cout << i << "\t" << out[i] << std::endl;
+    }
+*/
+}
+
+BOOST_AUTO_TEST_CASE(impulses_2x_5up_offline_finer)
+{
+    int n = 10000;
+    int rate = 44100;
+    RubberBandStretcher stretcher
+        (rate, 1, RubberBandStretcher::OptionEngineFiner);
+
+    stretcher.setTimeRatio(2.0);
+    stretcher.setPitchScale(1.5);
+
+    vector<float> in(n, 0.f), out(n * 2, 0.f);
+
+    in[100] = 1.f;
+    in[101] = -1.f;
+
+    in[5000] = 1.f;
+    in[5001] = -1.f;
+
+    in[9900] = 1.f;
+    in[9901] = -1.f;
+    
+    float *inp = in.data(), *outp = out.data();
+
+    stretcher.setMaxProcessSize(n);
+    stretcher.setExpectedInputDuration(n);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.study(&inp, n, true);
+    BOOST_TEST(stretcher.available() == 0);
+
+    stretcher.process(&inp, n, true);
+    BOOST_TEST(stretcher.available() == n * 2);
+
+    BOOST_TEST(stretcher.getStartDelay() == 0u); // offline mode
+    
+    size_t got = stretcher.retrieve(&outp, n * 2);
+    BOOST_TEST(got == size_t(n) * 2);
+    BOOST_TEST(stretcher.available() == -1);
+
+    int peak0 = -1, peak1 = -1, peak2 = -1;
+    float max;
+
+    max = -2.f;
+    for (int i = 0; i < n/2; ++i) {
+        if (out[i] > max) { max = out[i]; peak0 = i; }
+    }
+
+    max = -2.f;
+    for (int i = n/2; i < (n*3)/2; ++i) {
+        if (out[i] > max) { max = out[i]; peak1 = i; }
+    }
+
+    max = -2.f;
+    for (int i = (n*3)/2; i < n*2; ++i) {
+        if (out[i] > max) { max = out[i]; peak2 = i; }
+    }
+
+    BOOST_TEST(peak0 < 250);
+    BOOST_TEST(peak1 > n - 400);
+    BOOST_TEST(peak1 < n + 50);
+    BOOST_TEST(peak2 > n*2 - 600);
+    BOOST_TEST(peak2 < n*2);
+/*
+    std::cout << "ms\tV" << std::endl;
+    for (int i = 0; i < n*2; ++i) {
+        std::cout << i << "\t" << out[i] << std::endl;
+    }
+*/
+}
+
+static void impulses_realtime(RubberBandStretcher::Options options,
+                              double timeRatio,
+                              double pitchScale,
+                              bool printDebug)
+{
+    int n = 10000;
+    int nOut = int(ceil(n * timeRatio));
+    int rate = 48000;
+    int bs = 1024;
+
+    RubberBandStretcher stretcher(rate, 1, options, timeRatio, pitchScale);
+
+    if (printDebug) {
+        stretcher.setDebugLevel(2);
+    }
+    
+    vector<float> in(n, 0.f);
+
+    in[100] = 1.f;
+    in[101] = -1.f;
+
+    in[5000] = 1.f;
+    in[5001] = -1.f;
+
+    in[9900] = 1.f;
+    in[9901] = -1.f;
+
+    vector<float> out = process_realtime(stretcher, in, nOut, bs,
+                                         false, printDebug);
+
+    int peak0 = -1, peak1 = -1, peak2 = -1;
+    float max;
+
+    max = -2.f;
+    for (int i = 0; i < nOut/4; ++i) {
+        if (out[i] > max) { max = out[i]; peak0 = i; }
+    }
+
+    max = -2.f;
+    for (int i = nOut/4; i < (nOut*3)/4; ++i) {
+        if (out[i] > max) { max = out[i]; peak1 = i; }
+    }
+
+    max = -2.f;
+    for (int i = (nOut*3)/4; i < nOut; ++i) {
+        if (out[i] > max) { max = out[i]; peak2 = i; }
+    }
+
+    // These limits aren't alarming, but it may be worth tightening
+    // them and and taking a look at the waveforms
+    
+    BOOST_TEST(peak0 < int(ceil(210 * timeRatio)));
+    BOOST_TEST(peak0 > int(ceil(50 * timeRatio)));
+
+    BOOST_TEST(peak1 < int(ceil(5070 * timeRatio)));
+    BOOST_TEST(peak1 > int(ceil(4640 * timeRatio)));
+
+    BOOST_TEST(peak2 < int(ceil(9970 * timeRatio)));
+    BOOST_TEST(peak2 > int(ceil(9670 * timeRatio)));
+
+    if (printDebug) {
+        std::cout << "#sample\tV" << std::endl;
+        for (int i = 0; i < n*2; ++i) {
+            std::cout << "#" << i << "\t" << out[i] << std::endl;
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(impulses_slow_samepitch_realtime_finer)
+{
+    impulses_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      8.0, 1.0,
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(impulses_fast_samepitch_realtime_finer)
+{
+    impulses_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      0.5, 1.0,
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(impulses_slow_higher_realtime_finer)
+{
+    impulses_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      4.0, 1.5,
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(impulses_slow_higher_realtime_finer_hqpitch)
+{
+    impulses_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighQuality,
+                      4.0, 1.5,
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(impulses_slow_higher_realtime_finer_hcpitch)
+{
+    impulses_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      4.0, 1.5,
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(impulses_slow_lower_realtime_finer)
+{
+    impulses_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime,
+                      8.0, 0.5,
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(impulses_slow_lower_realtime_finer_hqpitch)
+{
+    impulses_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighQuality,
+                      8.0, 0.5,
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(impulses_slow_lower_realtime_finer_hcpitch)
+{
+    impulses_realtime(RubberBandStretcher::OptionEngineFiner |
+                      RubberBandStretcher::OptionProcessRealTime |
+                      RubberBandStretcher::OptionPitchHighConsistency,
+                      8.0, 0.5,
+                      false);
+}
+
+static void final_realtime(RubberBandStretcher::Options options,
+                           double timeRatio,
+                           double pitchScale,
+                           bool finalAfterFinishing,
+                           bool printDebug)
+{
+    int n = 10000;
+    float freq = 440.f;
+    int rate = 44100;
+    int blocksize = 700;
+    RubberBandStretcher stretcher(rate, 1, options);
+
+    if (printDebug) {
+        stretcher.setDebugLevel(2);
+    }
+
+    stretcher.setTimeRatio(timeRatio);
+    stretcher.setPitchScale(pitchScale);
+
+    int nOut = int(ceil(n * timeRatio));
+    int excess = std::max(nOut, n);
+    vector<float> in(n, 0.f), out(nOut + excess, 0.f);
+
+    for (int i = 0; i < 100; ++i) {
+        in[n - 101 + i] = sinf(float(i) * freq * M_PI * 2.f / float(rate));
+    }
+    
+    // Prime the start
+    {
+        float *source = out.data(); // just reuse out because it's silent
+        stretcher.process(&source, stretcher.getPreferredStartPad(), false);
+    }
+
+    float *inp = in.data(), *outp = out.data();
+
+    stretcher.setMaxProcessSize(blocksize);
+    BOOST_TEST(stretcher.available() == 0);
+
+    int toSkip = stretcher.getStartDelay();
+    
+    int incount = 0, outcount = 0;
+    while (true) {
+
+        int inbs = std::min(blocksize, n - incount);
+
+        bool final;
+        if (finalAfterFinishing) {
+            BOOST_TEST(inbs >= 0);
+            final = (inbs == 0);
+        } else {
+            BOOST_TEST(inbs > 0);
+            final = (incount + inbs >= n);
+        }
+        
+        float *in = inp + incount;
+        stretcher.process(&in, inbs, final);
+        incount += inbs;
+
+        int avail = stretcher.available();
+        BOOST_TEST(avail >= 0);
+        BOOST_TEST(outcount + avail < nOut + excess);
+
+//        cerr << "in = " << inbs << ", incount now = " << incount << ", avail = " << avail << endl;
+
+        float *out = outp + outcount;
+
+        if (toSkip > 0) {
+            int skipHere = std::min(toSkip, avail);
+            size_t got = stretcher.retrieve(&out, skipHere);
+            BOOST_TEST(got == size_t(skipHere));
+            toSkip -= got;
+//            cerr << "got = " << got << ", toSkip now = " << toSkip << ", n = " << n << endl;
+        }
+
+        avail = stretcher.available();
+        if (toSkip == 0 && avail > 0) {
+            size_t got = stretcher.retrieve(&out, avail);
+            BOOST_TEST(got == size_t(avail));
+            outcount += got;
+//            cerr << "got = " << got << ", outcount = " << outcount << ", n = " << n << endl;
+            if (final) {
+                BOOST_TEST(stretcher.available() == -1);
+            } else {
+                BOOST_TEST(stretcher.available() == 0);
+            }
+        }
+
+        if (final) break;
+    }
+
+    BOOST_TEST(outcount >= nOut);
+    
+    if (printDebug) {
+        // The initial # is to allow grep on the test output
+        std::cout << "#sample\tV" << std::endl;
+        for (int i = 0; i < outcount; ++i) {
+            std::cout << "#" << i << "\t" << out[i] << std::endl;
+        }
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(final_slow_samepitch_realtime_finer)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   8.0, 1.0,
+                   false,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_slow_samepitch_realtime_finer_after)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   8.0, 1.0,
+                   true,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_fast_samepitch_realtime_finer)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   0.2, 1.0,
+                   false,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_fast_samepitch_realtime_finer_after)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   0.2, 1.0,
+                   true,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_slow_higher_realtime_finer)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   8.0, 1.5,
+                   false,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_slow_higher_realtime_finer_after)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   8.0, 1.5,
+                   true,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_fast_higher_realtime_finer)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   0.2, 1.5,
+                   false,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_fast_higher_realtime_finer_after)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   0.2, 1.5,
+                   true,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_slow_lower_realtime_finer)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   8.0, 0.5,
+                   false,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_slow_lower_realtime_finer_after)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   8.0, 0.5,
+                   true,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_fast_lower_realtime_finer)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   0.2, 0.5,
+                   false,
+                   false);
+}
+
+BOOST_AUTO_TEST_CASE(final_fast_lower_realtime_finer_after)
+{
+    final_realtime(RubberBandStretcher::OptionEngineFiner |
+                   RubberBandStretcher::OptionProcessRealTime |
+                   RubberBandStretcher::OptionPitchHighConsistency,
+                   0.2, 0.5,
+                   true,
+                   false);
+}
+
+static void with_resets(RubberBandStretcher::Options options,
+                        double timeRatio,
+                        double pitchScale)
+{
+    const int n = 10000;
+    const int nOut = int(round(n * timeRatio));
+    const int rate = 44100;
+    const bool realtime =
+        (options & RubberBandStretcher::OptionProcessRealTime);
+
+    vector<float> in(n, 0.f), outRef(nOut, 0.f), out(nOut, 0.f);
+
+    in[100] = 1.f;
+    in[101] = -1.f;
+
+    in[5000] = 1.f;
+    in[5001] = -1.f;
+
+    in[9900] = 1.f;
+    in[9901] = -1.f;
+    
+    int nExpected = 0;
+    
+    RubberBandStretcher *stretcher = nullptr;
+
+    // Combinations we need to ensure produce identical outputs:
+    // 1. With timeRatio and pitchScale passed to constructor
+    // 2. Then reset called and run again
+    // 3. New instance, no ratios passed to ctor, timeRatio and
+    //    pitchScale set after construction
+    // 4. Then reset called and run again
+    // 5. Reset called again, timeRatio and pitchScale set again (to
+    //    the same things, just in case the act of setting them
+    //    changes anything) and run again
+    // 6. More input supplied and left in stretcher (output not
+    //    retrieved) - then reset called and run again
+
+    for (int run = 1; run <= 6; ++run) { // run being index into list above
+
+        float *inp = in.data(), *outp = out.data();
+
+        if (run == 1 || run == 3) {
+            delete stretcher;
+            if (run == 1) {
+                stretcher = new RubberBandStretcher(rate, 1, options,
+                                                    timeRatio, pitchScale);
+            } else {
+                stretcher = new RubberBandStretcher(rate, 1, options);
+                stretcher->setTimeRatio(timeRatio);
+                stretcher->setPitchScale(pitchScale);
+            }
+        }
+
+        if (run == 2 || run > 3) {
+            stretcher->reset();
+            if (run == 5) {
+                stretcher->setTimeRatio(timeRatio);
+                stretcher->setPitchScale(pitchScale);
+            }
+        }
+
+        if (run == 6) {
+            if (realtime) {
+                stretcher->process(&inp, n / 2, false);
+            } else {
+                stretcher->study(&inp, n / 2, true);
+                stretcher->process(&inp, n / 2, false);
+            }
+            stretcher->reset();
+        }
+        
+        // In every case we request nOut samples into out, and nActual
+        // records how many we actually get
+        int nActual = 0;
+        
+        if (realtime) {
+
+            int blocksize = 1024;
+            int nIn = 0;
+
+            while (nActual < nOut) {
+                int bsHere = blocksize;
+                bool final = false;
+                if (nIn + blocksize > n) {
+                    bsHere = n - nIn;
+                    final = true;
+                }
+                stretcher->process(&inp, bsHere, final);
+                nIn += bsHere;
+                inp += bsHere;
+                int avail = stretcher->available();
+                if (avail < 0) break;
+                int toGet = avail;
+                if (nActual + toGet > nOut) {
+                    toGet = nOut - nActual;
+                }
+                int got = (int)stretcher->retrieve(&outp, toGet);
+                nActual += got;
+                outp += got;
+                if (final) break;
+            }
+                
+            BOOST_TEST(nActual <= nOut);
+            
+        } else {
+            
+            stretcher->setMaxProcessSize(n);
+            stretcher->setExpectedInputDuration(n);
+            BOOST_TEST(stretcher->available() == 0);
+
+            stretcher->study(&inp, n, true);
+            BOOST_TEST(stretcher->available() == 0);
+
+            stretcher->process(&inp, n, true);
+            BOOST_TEST(stretcher->available() == nOut);
+
+            BOOST_TEST(stretcher->getStartDelay() == 0u); // offline mode
+    
+            nActual = (int)stretcher->retrieve(&outp, nOut);
+            BOOST_TEST(nActual == nOut);
+            BOOST_TEST(stretcher->available() == -1);
+        }
+
+        if (run == 1) { // set up expectations for subsequent runs
+
+            for (int i = 0; i < nActual; ++i) {
+                outRef[i] = out[i];
+            }
+            nExpected = nActual;
+
+        } else { // check expectations
+            
+            BOOST_TEST(nActual == nExpected);
+            
+            for (int i = 0; i < nActual; ++i) {
+                BOOST_TEST(out[i] == outRef[i]);
+                if (out[i] != outRef[i]) {
+                    std::cerr << "Failure at index " << i << " of "
+                              << nActual << " in run " << run << std::endl;
+                    break;
+                }
+            }
+        }
+    }
+
+    delete stretcher;
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_1x_0up_offline_finer)
+{
+    with_resets(RubberBandStretcher::OptionEngineFiner, 1.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_2x_0up_offline_finer)
+{
+    with_resets(RubberBandStretcher::OptionEngineFiner, 2.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_2x_5up_offline_finer)
+{
+    with_resets(RubberBandStretcher::OptionEngineFiner, 2.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_1x_0up_offline_faster)
+{
+    with_resets(RubberBandStretcher::OptionEngineFaster, 1.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_2x_0up_offline_faster)
+{
+    with_resets(RubberBandStretcher::OptionEngineFaster, 2.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_2x_5up_offline_faster)
+{
+    with_resets(RubberBandStretcher::OptionEngineFaster, 2.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_1x_0up_realtime_finer)
+{
+    with_resets(RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFiner, 1.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_2x_0up_realtime_finer)
+{
+    with_resets(RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFiner, 2.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_2x_5up_realtime_finer)
+{
+    with_resets(RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFiner, 2.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_1x_0up_realtime_faster)
+{
+    with_resets(RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFaster, 1.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_2x_0up_realtime_faster)
+{
+    with_resets(RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFaster, 2.0, 1.0);
+}
+
+BOOST_AUTO_TEST_CASE(with_resets_2x_5up_realtime_faster)
+{
+    with_resets(RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFaster, 2.0, 1.5);
+}
+
+BOOST_AUTO_TEST_CASE(long_blocksize_with_smoothing)
+{
+    // Test added because the smoothing option was calling alloca in a
+    // loop, which could run us out of stack. This test is best used
+    // with a small stack artificially enforced via e.g. ulimit -s 32
+    
+    int n = 10000;
+    float freq = 440.f;
+    int rate = 44100;
+    RubberBandStretcher stretcher
+        (rate, 1,
+         RubberBandStretcher::OptionEngineFaster |
+         RubberBandStretcher::OptionProcessOffline |
+         RubberBandStretcher::OptionSmoothingOn);
+    
+    vector<float> in(n);
+    for (int i = 0; i < n; ++i) {
+        in[i] = sinf(float(i) * freq * M_PI * 2.f / float(rate));
+    }
+    float *inp = in.data();
+
+    stretcher.setMaxProcessSize(n);
+    stretcher.setExpectedInputDuration(n);
+
+    stretcher.study(&inp, n, true);
+    stretcher.process(&inp, n, true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestVectorOps.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestVectorOps.cpp
@@ -1,0 +1,251 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../common/VectorOps.h"
+
+#include <stdexcept>
+#include <vector>
+
+using namespace RubberBand;
+
+BOOST_AUTO_TEST_SUITE(TestVectorOps)
+
+#define COMPARE_ARRAY(a, b)						\
+    for (int cmp_i = 0; cmp_i < (int)(sizeof(a)/sizeof(a[0])); ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i] - b[cmp_i], 1e-14);			\
+    }
+
+#define COMPARE_N(a, b, n)						\
+    for (int cmp_i = 0; cmp_i < n; ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i] - b[cmp_i], 1e-14);			\
+    }
+
+BOOST_AUTO_TEST_CASE(add)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double b[] = { -1.0, 3.0, -4.5 };
+    double expected[] = { 0.0, 5.0, -1.5 };
+    v_add(a, b, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(add_with_gain)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double b[] = { -1.0, 3.0, -4.5 };
+    double expected[] = { -0.5, 6.5, -3.75 };
+    v_add_with_gain(a, b, 1.5, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(subtract)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double b[] = { -1.0, 3.0, -4.5 };
+    double expected[] = { 2.0, -1.0, 7.5 };
+    v_subtract(a, b, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(scale)
+{
+    double a[] = { -1.0, 3.0, -4.5 };
+    double scale = -0.5;
+    double expected[] = { 0.5, -1.5, 2.25 };
+    v_scale(a, scale, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(multiply)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double b[] = { -1.0, 3.0, -4.5 };
+    double expected[] = { -1.0, 6.0, -13.5 };
+    v_multiply(a, b, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(multiply_and_add)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double b[] = { -1.0, 3.0, -4.5 };
+    double c[] = { 3.0, -1.0, 4.0 };
+    double expected[] = { 2.0, 5.0, -9.5 };
+    v_multiply_and_add(c, a, b, 3);
+    COMPARE_N(c, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(divide)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double b[] = { -1.0, 3.0, -4.5 };
+    double expected[] = { -1.0, 2.0/3.0, 3.0/-4.5 };
+    v_divide(a, b, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(sum)
+{
+    double a[] = { 1.0, 2.0, -3.5 };
+    double s = v_sum(a, 3);
+    BOOST_CHECK_EQUAL(s, -0.5);
+}
+
+BOOST_AUTO_TEST_CASE(multiply_and_sum)
+{
+    double a[] = { 2.0, 0.0, -1.5 };
+    double b[] = { 3.0, 4.0, 5.0 };
+    double s = v_multiply_and_sum(a, b, 3);
+    BOOST_CHECK_EQUAL(s, -1.5);
+}
+
+BOOST_AUTO_TEST_CASE(log)
+{
+    double a[] = { 1.0, 1.0 / M_E, M_E };
+    double expected[] = { 0.0, -1.0, 1.0 };
+    v_log(a, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(exp)
+{
+    double a[] = { 0.0, -1.0, 2.0 };
+    double expected[] = { 1.0, 1.0 / M_E, M_E * M_E };
+    v_exp(a, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(sqrt)
+{
+    double a[] = { 0.0, 1.0, 4.0 };
+    double expected[] = { 0.0, 1.0, 2.0 };
+    v_sqrt(a, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(square)
+{
+    double a[] = { 0.0, 1.5, -2.0 };
+    double expected[] = { 0.0, 2.25, 4.0 };
+    v_square(a, 3);
+    COMPARE_N(a, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(abs)
+{
+    double a[] = { -1.9, 0.0, 0.01, -0.0 };
+    double expected[] = { 1.9, 0.0, 0.01, 0.0 };
+    v_abs(a, 4);
+    COMPARE_N(a, expected, 4);
+}
+
+BOOST_AUTO_TEST_CASE(mean)
+{
+    double a[] = { -1.0, 1.6, 3.0 };
+    double s = v_mean(a, 3);
+    BOOST_CHECK_EQUAL(s, 1.2);
+}
+
+BOOST_AUTO_TEST_CASE(interleave_1)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double *ch[] = { a };
+    double o[3];
+    double expected[] = { 1.0, 2.0, 3.0 };
+    v_interleave(o, ch, 1, 3);
+    COMPARE_N(o, expected, 3);
+}
+
+BOOST_AUTO_TEST_CASE(interleave_2)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double b[] = { 4.0, 5.0, 6.0 };
+    double *ch[] = { a, b };
+    double o[6];
+    double expected[] = { 1.0, 4.0, 2.0, 5.0, 3.0, 6.0 };
+    v_interleave(o, ch, 2, 3);
+    COMPARE_N(o, expected, 6);
+}
+
+BOOST_AUTO_TEST_CASE(interleave_3)
+{
+    double a[] = { 1.0, 2.0 };
+    double b[] = { 3.0, 4.0 };
+    double c[] = { 5.0, 6.0 };
+    double *ch[] = { a, b, c };
+    double o[6];
+    double expected[] = { 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 };
+    v_interleave(o, ch, 3, 2);
+    COMPARE_N(o, expected, 6);
+}
+
+BOOST_AUTO_TEST_CASE(deinterleave_1)
+{
+    double a[] = { 1.0, 2.0, 3.0 };
+    double o[3];
+    double *oo[] = { o };
+    double *expected[] = { a };
+    v_deinterleave(oo, a, 1, 3);
+    COMPARE_N(oo[0], expected[0], 3);
+}
+
+BOOST_AUTO_TEST_CASE(deinterleave_2)
+{
+    double a[] = { 1.0, 4.0, 2.0, 5.0, 3.0, 6.0 };
+    double o1[3], o2[3];
+    double *oo[] = { o1, o2 };
+    double e1[] = { 1.0, 2.0, 3.0 }, e2[] = { 4.0, 5.0, 6.0 };
+    double *expected[] = { e1, e2 };
+    v_deinterleave(oo, a, 2, 3);
+    COMPARE_N(oo[0], expected[0], 3);
+    COMPARE_N(oo[1], expected[1], 3);
+}
+
+BOOST_AUTO_TEST_CASE(deinterleave_3)
+{
+    double a[] = { 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 };
+    double o1[2], o2[2], o3[2];
+    double *oo[] = { o1, o2, o3 };
+    double e1[] = { 1.0, 2.0 }, e2[] = { 3.0, 4.0 }, e3[] = { 5.0, 6.0 };
+    double *expected[] = { e1, e2, e3 };
+    v_deinterleave(oo, a, 3, 2);
+    COMPARE_N(oo[0], expected[0], 2);
+    COMPARE_N(oo[1], expected[1], 2);
+    COMPARE_N(oo[2], expected[2], 2);
+}
+
+BOOST_AUTO_TEST_CASE(fftshift)
+{
+    double a[] = { 0.1, 2.0, -0.3, 4.0 };
+    double e[] = { -0.3, 4.0, 0.1, 2.0 };
+    v_fftshift(a, 4);
+    COMPARE_N(a, e, 4);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestVectorOpsComplex.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/TestVectorOpsComplex.cpp
@@ -1,0 +1,134 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "../common/VectorOpsComplex.h"
+#include "../common/VectorOps.h"
+
+#include <stdexcept>
+#include <vector>
+#include <iostream>
+
+using namespace RubberBand;
+
+BOOST_AUTO_TEST_SUITE(TestVectorOpsComplex)
+
+#ifdef USE_APPROXIMATE_ATAN2
+static const double eps = 5.0e-3;
+static const double eps_approx = eps;
+#else
+static const double eps = 1.0e-14;
+static const double eps_approx = 1.0e-8;
+#endif
+    
+#define COMPARE_N(a, b, n) \
+    for (int cmp_i = 0; cmp_i < n; ++cmp_i) { \
+        BOOST_CHECK_SMALL(a[cmp_i] - b[cmp_i], eps); \
+    }
+
+BOOST_AUTO_TEST_CASE(cartesian_to_magnitudes)
+{
+    double re[] = { 1.0, 3.0 };
+    double im[] = { 2.0, -4.0 };
+    double o[2];
+    double expected[] = { sqrt(5.0), 5.0 };
+    v_cartesian_to_magnitudes(o, re, im, 2);
+    COMPARE_N(o, expected, 2);
+}
+
+BOOST_AUTO_TEST_CASE(cartesian_interleaved_to_magnitudes)
+{
+    double a[] = { 1.0, 2.0, 3.0, -4.0 };
+    double o[2];
+    double expected[] = { sqrt(5.0), 5.0 };
+    v_cartesian_interleaved_to_magnitudes(o, a, 2);
+    COMPARE_N(o, expected, 2);
+}
+
+BOOST_AUTO_TEST_CASE(cartesian_to_polar)
+{
+    double re[] = { 0.0, 1.0, 0.0 };
+    double im[] = { 0.0, 1.0, -1.0 };
+    double mo[3], po[3];
+    double me[] = { 0.0, sqrt(2.0), 1.0 };
+    double pe[] = { 0.0, M_PI / 4.0, -M_PI * 0.5 };
+    v_cartesian_to_polar(mo, po, re, im, 3);
+    COMPARE_N(mo, me, 3);
+    COMPARE_N(po, pe, 3);
+}
+
+BOOST_AUTO_TEST_CASE(cartesian_to_polar_interleaved_inplace)
+{
+    double a[] = { 0.0, 0.0, 1.0, 1.0, 0.0, -1.0 };
+    double e[] = { 0.0, 0.0, sqrt(2.0), M_PI / 4.0, 1.0, -M_PI * 0.5 };
+    v_cartesian_to_polar_interleaved_inplace(a, 3);
+    COMPARE_N(a, e, 6);
+}
+
+BOOST_AUTO_TEST_CASE(cartesian_interleaved_to_polar)
+{
+    double a[] = { 0.0, 0.0, 1.0, 1.0, 0.0, -1.0 };
+    double mo[3], po[3];
+    double me[] = { 0.0, sqrt(2.0), 1.0 };
+    double pe[] = { 0.0, M_PI / 4.0, -M_PI * 0.5 };
+    v_cartesian_interleaved_to_polar(mo, po, a, 3);
+    COMPARE_N(mo, me, 3);
+    COMPARE_N(po, pe, 3);
+}
+
+BOOST_AUTO_TEST_CASE(polar_to_cartesian)
+{
+    double m[] = { 0.0, sqrt(2.0), 1.0 };
+    double p[] = { 0.0, M_PI / 4.0, -M_PI * 0.5 };
+    double ro[3], io[3];
+    double re[] = { 0.0, 1.0, 0.0 };
+    double ie[] = { 0.0, 1.0, -1.0 };
+    v_polar_to_cartesian(ro, io, m, p, 3);
+    COMPARE_N(ro, re, 3);
+    COMPARE_N(io, ie, 3);
+}
+
+BOOST_AUTO_TEST_CASE(polar_to_cartesian_interleaved_inplace)
+{
+    double a[] = { 0.0, 0.0, sqrt(2.0), M_PI / 4.0, 1.0, -M_PI * 0.5 };
+    double e[] = { 0.0, 0.0, 1.0, 1.0, 0.0, -1.0 };
+    v_polar_interleaved_to_cartesian_inplace(a, 3);
+    COMPARE_N(a, e, 6);
+}
+
+BOOST_AUTO_TEST_CASE(polar_to_cartesian_interleaved)
+{
+    double m[] = { 0.0, sqrt(2.0), 1.0 };
+    double p[] = { 0.0, M_PI / 4.0, -M_PI * 0.5 };
+    double o[6];
+    double e[] = { 0.0, 0.0, 1.0, 1.0, 0.0, -1.0 };
+    v_polar_to_cartesian_interleaved(o, m, p, 3);
+    COMPARE_N(o, e, 6);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/test.cpp
+++ b/Packages/PlaybackDSP/Sources/CPlaybackDSP/vendor/src/test/test.cpp
@@ -1,0 +1,28 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2024 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#define BOOST_TEST_MODULE RubberBand
+#ifndef BOOST_TEST_DYN_LINK
+#define BOOST_TEST_DYN_LINK
+#endif
+#include <boost/test/unit_test.hpp>

--- a/Packages/PlaybackDSP/Sources/PlaybackDSP/TimeStretchStream.swift
+++ b/Packages/PlaybackDSP/Sources/PlaybackDSP/TimeStretchStream.swift
@@ -1,0 +1,45 @@
+import CPlaybackDSP
+import Foundation
+
+/// Stateful mono Float32 stretching. Keep one instance for a continuous source;
+/// create a new instance after seeking or changing speed. Call only serially.
+public final class TimeStretchStream {
+    public static let engineName = "Rubber Band R3"
+    private let handle: UnsafeMutableRawPointer
+    private var isFinished = false
+
+    public enum Failure: Error {
+        case invalidConfiguration
+        case invalidSamples
+        case processingFailed
+        case alreadyFinished
+    }
+
+    public init(sampleRate: Double, rate: Double) throws {
+        guard let handle = sayit_stretch_create(sampleRate, rate) else {
+            throw Failure.invalidConfiguration
+        }
+        self.handle = handle
+    }
+
+    deinit { sayit_stretch_destroy(handle) }
+
+    /// Finalization drains lookahead and trims padding to round(inputFrames / rate).
+    /// At 1×, samples pass through unchanged.
+    public func process(_ samples: [Float], final: Bool = false) throws -> [Float] {
+        guard !isFinished else { throw Failure.alreadyFinished }
+        guard samples.count <= Int(Int32.max), samples.allSatisfy(\.isFinite) else {
+            throw Failure.invalidSamples
+        }
+        var count: Int32 = 0
+        let result = samples.withUnsafeBufferPointer {
+            sayit_stretch_process(handle, $0.baseAddress, Int32($0.count), final ? 1 : 0, &count)
+        }
+        guard count >= 0 else { throw Failure.processingFailed }
+        isFinished = final
+        guard count > 0, let result else { return [] }
+        let output = Array(UnsafeBufferPointer(start: result, count: Int(count)))
+        guard output.allSatisfy(\.isFinite) else { throw Failure.processingFailed }
+        return output
+    }
+}

--- a/Packages/PlaybackDSP/Sources/PlaybackDSPRender/main.swift
+++ b/Packages/PlaybackDSP/Sources/PlaybackDSPRender/main.swift
@@ -1,0 +1,65 @@
+@preconcurrency import AVFoundation
+import Foundation
+import PlaybackDSP
+
+// Offline listening fixtures use exactly the same streaming wrapper as playback.
+// Usage: swift run -c release --package-path Packages/PlaybackDSP PlaybackDSPRender input.wav output-directory
+@main
+struct RenderComparison {
+    static func main() throws {
+        guard CommandLine.arguments.count == 3 else {
+            print("Usage: PlaybackDSPRender input-audio output-directory")
+            return
+        }
+        let source = URL(fileURLWithPath: CommandLine.arguments[1])
+        let destination = URL(fileURLWithPath: CommandLine.arguments[2], isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        let input = try AVAudioFile(forReading: source, commonFormat: .pcmFormatFloat32, interleaved: false)
+        let sampleRate = input.processingFormat.sampleRate
+        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: input.processingFormat, frameCapacity: 4096),
+              let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1) else {
+            throw TimeStretchStream.Failure.invalidConfiguration
+        }
+        print("engine,rate,input_frames,output_frames,processing_seconds")
+        for rate in [0.5, 0.75, 1.0, 1.25, 1.5, 2.0] {
+            let url = destination.appendingPathComponent("speed-\(rate).wav")
+            guard !FileManager.default.fileExists(atPath: url.path) else {
+                throw CocoaError(.fileWriteFileExists)
+            }
+            let output = try AVAudioFile(forWriting: url, settings: format.settings)
+            let stream = try TimeStretchStream(sampleRate: sampleRate, rate: rate)
+            var outputFrames = 0
+            var processingSeconds = 0.0
+            input.framePosition = 0
+            func write(_ samples: [Float], final: Bool = false) throws {
+                let start = ContinuousClock.now
+                let stretched = try stream.process(samples, final: final)
+                let elapsed = start.duration(to: .now).components
+                processingSeconds += Double(elapsed.seconds) + Double(elapsed.attoseconds) / 1e18
+                guard !stretched.isEmpty else { return }
+                guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(stretched.count)),
+                      let channel = buffer.floatChannelData?[0] else {
+                    throw TimeStretchStream.Failure.processingFailed
+                }
+                buffer.frameLength = AVAudioFrameCount(stretched.count)
+                for index in stretched.indices { channel[index] = stretched[index] }
+                try output.write(from: buffer)
+                outputFrames += stretched.count
+            }
+            while input.framePosition < input.length {
+                try input.read(into: inputBuffer)
+                guard let channels = inputBuffer.floatChannelData, inputBuffer.frameLength > 0 else {
+                    throw TimeStretchStream.Failure.invalidSamples
+                }
+                let channelCount = Int(input.processingFormat.channelCount)
+                var mono = [Float](repeating: 0, count: Int(inputBuffer.frameLength))
+                for channel in 0..<channelCount {
+                    for frame in mono.indices { mono[frame] += channels[channel][frame] / Float(channelCount) }
+                }
+                try write(mono)
+            }
+            try write([], final: true)
+            print("\(TimeStretchStream.engineName),\(rate),\(input.length),\(outputFrames),\(processingSeconds)")
+        }
+    }
+}

--- a/Packages/PlaybackDSP/Tests/PlaybackDSPTests/TimeStretchTests.swift
+++ b/Packages/PlaybackDSP/Tests/PlaybackDSPTests/TimeStretchTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import PlaybackDSP
+
+@Suite("Pitch-preserving playback DSP")
+struct TimeStretchTests {
+    static let rates = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+
+    static func tone(sampleRate: Double, duration: Double = 3) -> [Float] {
+        (0..<Int(sampleRate * duration)).map { frame in
+            let time = Double(frame) / sampleRate
+            let envelope = min(1, time / 0.02, (duration - time) / 0.02)
+            return Float(0.25 * envelope * sin(2 * .pi * 220 * time))
+        }
+    }
+
+    @Test("All speeds preserve pitch, duration and level", arguments: rates, [24_000.0, 44_100.0, 48_000.0])
+    func pitchAndDuration(rate: Double, sampleRate: Double) throws {
+        let input = Self.tone(sampleRate: sampleRate)
+        let stream = try TimeStretchStream(sampleRate: sampleRate, rate: rate)
+        var output: [Float] = []
+        // Irregular chunks exercise cumulative rounding and continuous state.
+        for start in stride(from: 0, to: input.count, by: 997) {
+            output += try stream.process(Array(input[start..<min(start + 997, input.count)]))
+        }
+        output += try stream.process([], final: true)
+        #expect(output.count == Int((Double(input.count) / rate).rounded()))
+        #expect(output.allSatisfy { $0.isFinite })
+        let middle = Array(output[Int(sampleRate / 4)..<(output.count - Int(sampleRate / 4))])
+        let rms = sqrt(middle.reduce(0.0) { $0 + Double($1 * $1) } / Double(middle.count))
+        let crossings = zip(middle, middle.dropFirst()).filter { $0 <= 0 && $1 > 0 }.count
+        let frequency = Double(crossings) * sampleRate / Double(middle.count)
+        #expect(abs(frequency - 220) < 3)
+        #expect(rms > 0.10 && rms < 0.25)
+        #expect((output.map { abs($0) }.max() ?? 0) < 0.5)
+        if rate == 1 { #expect(output == input) }
+    }
+
+    @Test("Short clips drain their tail at every speed", arguments: rates)
+    func shortTail(rate: Double) throws {
+        for count in [1, 37, 240, 2400] {
+            let stream = try TimeStretchStream(sampleRate: 24_000, rate: rate)
+            let output = try stream.process([Float](repeating: 0.1, count: count), final: true)
+            #expect(output.count == Int((Double(count) / rate).rounded()))
+            #expect(output.allSatisfy { $0.isFinite })
+        }
+    }
+
+    @Test("Invalid inputs fail and finalized streams cannot be reused")
+    func invalidInputs() throws {
+        for rate in [0, -1, 3, Double.nan, Double.infinity] {
+            #expect(throws: TimeStretchStream.Failure.self) {
+                try TimeStretchStream(sampleRate: 24_000, rate: rate)
+            }
+        }
+        #expect(throws: TimeStretchStream.Failure.self) {
+            try TimeStretchStream(sampleRate: 0, rate: 1)
+        }
+        let stream = try TimeStretchStream(sampleRate: 24_000, rate: 1.5)
+        #expect(throws: TimeStretchStream.Failure.self) { try stream.process([.nan]) }
+        #expect(try stream.process([], final: true).isEmpty)
+        #expect(throws: TimeStretchStream.Failure.self) { try stream.process([0]) }
+    }
+
+    @Test("New streams after seek or speed change do not carry old audio")
+    func resetIsolation() throws {
+        let first = try TimeStretchStream(sampleRate: 24_000, rate: 2)
+        _ = try first.process(Self.tone(sampleRate: 24_000))
+        let second = try TimeStretchStream(sampleRate: 24_000, rate: 0.5)
+        let silence = try second.process([Float](repeating: 0, count: 24_000), final: true)
+        #expect(silence.allSatisfy { abs($0) < 0.0001 })
+    }
+}

--- a/SayIt.xcodeproj/project.pbxproj
+++ b/SayIt.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		2F13AD95B66B59D9BEFAB69D /* VoiceProfileRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48CC76FCF104B6EA0CCFFC3 /* VoiceProfileRecord.swift */; };
 		2F98443BCC6A9CE666AFF7D2 /* SayItCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E5B162BA286FB4707D990A4 /* SayItCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		30F806119784A3EA06D08732 /* APITokenCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AADDFBAF6765A7A9E46F6F /* APITokenCreation.swift */; };
+		31CB6C9597C1FD2312EB3DE6 /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */; };
 		32FC4CC7ADAA06A627E07AD0 /* HTTPEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEAC3BEEF3A43EBD6DCF107 /* HTTPEventStreamTests.swift */; };
 		35C5858DED5258F9813091A5 /* SynthesisError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF73CF550608FF1F4C96C1B /* SynthesisError.swift */; };
 		360339154AB4814D00BBCB3B /* TokenCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62B45AACA98296E67663E5A /* TokenCreationSheet.swift */; };
@@ -126,7 +127,7 @@
 		3E69D945BB53BFBF82FCAA9D /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68391B4A83D06AD4C1FFAA0 /* OnboardingView.swift */; };
 		3F22D38886E6E44E0156F0F7 /* VoiceDiscoveryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AD71761AE179BEA6A20967 /* VoiceDiscoveryRequest.swift */; };
 		40F3797F2C6B54BD494E8C74 /* APITokenDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8697FFA4EB481A4A7FB1A3A /* APITokenDigestTests.swift */; };
-		419CB00AB6F80C7F4A3F46BC /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */; };
+		419CB00AB6F80C7F4A3F46BC /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 71DDF93755CA3F43B4C3D31B /* MLXAudioCore */; };
 		41DE1A049C2D3BFE630D7177 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 12D3C7903194A06085F4C99C /* Atomics */; };
 		4251B261B2659D5CB44E474C /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C074F8772DC89E43CE2A267 /* DesignTokens.swift */; };
 		435E896B82A959E7FDFB0403 /* SayItApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CEBAFD3BF5D864C5BD06D /* SayItApplication.swift */; };
@@ -176,6 +177,7 @@
 		560101541C1F3A848FE2B02F /* SayItSelectionAgentMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E19E0A44E938CCC17DEF7EE /* SayItSelectionAgentMain.swift */; };
 		560D74E1A13F3E50F535D55F /* MenuFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504A1CDB257EFB01D742FAE6 /* MenuFooterView.swift */; };
 		560E27275E9D1815E261F41E /* TimeInterval+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7392C8CFFBB121658EBD9597 /* TimeInterval+Formatting.swift */; };
+		56D2AEA8E65D228BBC9509CF /* TimeStretchPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */; };
 		56ECCB4BAC727F46AA2408EF /* VoiceCloneRequirements.swift in Sources */ = {isa = PBXBuildFile; fileRef = E052AB297B6730E47BF28A4D /* VoiceCloneRequirements.swift */; };
 		56F431F50DFF88F2785B215B /* SpeechTitleGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF89D0850C4A3A612A71C738 /* SpeechTitleGeneratorTests.swift */; };
 		57F882F8230C74C9C260774F /* UpdateOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DD06F06BB2F0F12013A199 /* UpdateOffer.swift */; };
@@ -208,7 +210,7 @@
 		660B9287719F72B11783D3C1 /* ResumeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = C159E47E305909312F3675A5 /* ResumeCommand.swift */; };
 		662931D02D9303078BB8AE62 /* VoiceTuningSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61809FAC6AB3B4223A714878 /* VoiceTuningSpace.swift */; };
 		673810EDC217C5CD2640A55A /* PlaybackRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6517CAB9846FFD0FD879B897 /* PlaybackRate.swift */; };
-		690DD7FC6DABD5D8A65B7A48 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 71DDF93755CA3F43B4C3D31B /* MLXAudioCore */; };
+		690DD7FC6DABD5D8A65B7A48 /* PlaybackDSP in Frameworks */ = {isa = PBXBuildFile; productRef = 7D5589CFD718091E8391DB68 /* PlaybackDSP */; };
 		69CE3A628AAE1587B7976D71 /* VoiceStudioSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AEFBFB440C0388E52C0DEC /* VoiceStudioSnapshot.swift */; };
 		6B2A2003079910D0A146A378 /* SayItHTTPServer+PlaybackRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC29C1C1131C5748DA67D61 /* SayItHTTPServer+PlaybackRoutes.swift */; };
 		6B8EA518D4DB7702985F43FA /* RegisteredServiceStartup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB5BBA9182ED3B21E5A1465 /* RegisteredServiceStartup.swift */; };
@@ -946,6 +948,7 @@
 		456A6147E5C1F299C5F70B42 /* AccessibilityAncestorSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAncestorSearch.swift; sourceTree = "<group>"; };
 		45838FA1413995858EC9E5C3 /* StatusHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusHeaderView.swift; sourceTree = "<group>"; };
 		45FA49ACF4B53BA6833BADA6 /* SKILL.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SKILL.md; sourceTree = "<group>"; };
+		4616A529E899E2F12ACCA917 /* PlaybackDSP */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PlaybackDSP; path = Packages/PlaybackDSP; sourceTree = SOURCE_ROOT; };
 		46A2C77FAF415C25A265B262 /* HTTPSubmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPSubmission.swift; sourceTree = "<group>"; };
 		46C4FDBB3A3112F47070537F /* APITokenPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenPreset.swift; sourceTree = "<group>"; };
 		4704665E76548BC4B54EAAE2 /* VoiceCloneRequirementsSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCloneRequirementsSnapshot.swift; sourceTree = "<group>"; };
@@ -1132,6 +1135,7 @@
 		B825339FFDAD336D58CA0052 /* SpeechChunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechChunk.swift; sourceTree = "<group>"; };
 		B9BFBF98DB02E32E3E824EF6 /* BackendPrimitiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPrimitiveTests.swift; sourceTree = "<group>"; };
 		BA18E0AFEFF10C13815F3D6D /* APITokenScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITokenScope.swift; sourceTree = "<group>"; };
+		BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeStretchPlaybackTests.swift; sourceTree = "<group>"; };
 		BB95F4768AD968BE1C4CBCD1 /* SayItStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayItStyles.swift; sourceTree = "<group>"; };
 		BD2C197A18B385CC45949276 /* DiagnosticEvent+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiagnosticEvent+Snapshot.swift"; sourceTree = "<group>"; };
 		BE4174D1D4EB7E48D19724DA /* SelectionCaptureFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionCaptureFlow.swift; sourceTree = "<group>"; };
@@ -1280,10 +1284,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				690DD7FC6DABD5D8A65B7A48 /* PlaybackDSP in Frameworks */,
 				0922BE8F5F7353F975466383 /* SayItCore.framework in Frameworks */,
 				89AD3D4D8907B9BD8BC76B7F /* SayItProtocol.framework in Frameworks */,
-				690DD7FC6DABD5D8A65B7A48 /* MLXAudioCore in Frameworks */,
-				419CB00AB6F80C7F4A3F46BC /* MLXAudioTTS in Frameworks */,
+				419CB00AB6F80C7F4A3F46BC /* MLXAudioCore in Frameworks */,
+				31CB6C9597C1FD2312EB3DE6 /* MLXAudioTTS in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1935,6 +1940,7 @@
 			isa = PBXGroup;
 			children = (
 				D5368688F97DCA95208246D6 /* Fixtures */,
+				E6A9ADAA62A15BD6C74D2CEF /* Packages */,
 				04D76396770A2F14616CD133 /* Resources */,
 				4835E83DFC07A19B7BC7DEF9 /* Resources */,
 				180CF2F43C8748887CC1F6A5 /* SayIt */,
@@ -2164,6 +2170,14 @@
 			path = Tests/SayItUpdateTests;
 			sourceTree = "<group>";
 		};
+		E6A9ADAA62A15BD6C74D2CEF /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				4616A529E899E2F12ACCA917 /* PlaybackDSP */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
 		EA01701396BB7A5E45BFB811 /* Diagnostics */ = {
 			isa = PBXGroup;
 			children = (
@@ -2261,6 +2275,7 @@
 				C66497ED594E15E3EF2CF5FD /* SpeechQueuePolicyTests.swift */,
 				DC8FE48DDB4640E0887AC670 /* SynthesisActorTests.swift */,
 				40828984E8B5F3F75C795F92 /* SynthesisOperationLifecycleTests.swift */,
+				BA38A3A6BAAD4592EE617D31 /* TimeStretchPlaybackTests.swift */,
 				9E44B62D54EF87F46363D70C /* VoiceProfileStoreTests.swift */,
 				9842DB392263544D975DAA5F /* VoiceTuningPolicyTests.swift */,
 			);
@@ -2353,6 +2368,7 @@
 			);
 			name = SayItBackend;
 			packageProductDependencies = (
+				7D5589CFD718091E8391DB68 /* PlaybackDSP */,
 				71DDF93755CA3F43B4C3D31B /* MLXAudioCore */,
 				A3CB740DA97596EA73A0ED80 /* MLXAudioTTS */,
 			);
@@ -2731,6 +2747,7 @@
 				C93AA06F3A6E248872ED93BC /* XCRemoteSwiftPackageReference "swift-collections" */,
 				2E71412ABA0D3631AC8F7E2B /* XCRemoteSwiftPackageReference "swift-nio" */,
 				8FA3A87EEEF8E0DC0F7CA93B /* XCRemoteSwiftPackageReference "Yams" */,
+				84D82FD5D4C643C189B34542 /* XCLocalSwiftPackageReference "Packages/PlaybackDSP" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 932443B985F40D816A0FD3B7 /* Products */;
@@ -3317,6 +3334,7 @@
 				F88A3CF15CA4053F7D587898 /* SpeechQueuePolicyTests.swift in Sources */,
 				BD7E756DBD67FF169CDD68C2 /* SynthesisActorTests.swift in Sources */,
 				97FFD241C34F9894CF4E8B9E /* SynthesisOperationLifecycleTests.swift in Sources */,
+				56D2AEA8E65D228BBC9509CF /* TimeStretchPlaybackTests.swift in Sources */,
 				04EDE873EF293B5BAFCD4C49 /* VoiceProfileStoreTests.swift in Sources */,
 				2D698A1F3469FA1866B99A24 /* VoiceTuningPolicyTests.swift in Sources */,
 			);
@@ -4486,6 +4504,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		84D82FD5D4C643C189B34542 /* XCLocalSwiftPackageReference "Packages/PlaybackDSP" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/PlaybackDSP;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		0FB0C4A704F0962960BDE609 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -4588,6 +4613,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = EDE9B52C93821E68A0BAF348 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */;
 			productName = MLXAudioCore;
+		};
+		7D5589CFD718091E8391DB68 /* PlaybackDSP */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PlaybackDSP;
 		};
 		966CEFC1C422D50A7DA22CD1 /* DequeModule */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Sources/SayItBackend/Playback/PlaybackController.swift
+++ b/Sources/SayItBackend/Playback/PlaybackController.swift
@@ -3,6 +3,7 @@
 import Foundation
 @preconcurrency import MediaPlayer
 import Observation
+import PlaybackDSP
 import SayItCore
 import SayItProtocol
 
@@ -10,7 +11,7 @@ import SayItProtocol
 @Observable
 final class PlaybackController: BackendPlaybackControlling {
     static let modelSwitchFadeDuration: Duration = .milliseconds(24)
-    static let highQualityTimePitchOverlap: Float = 32
+    static let timeStretchEngineName = TimeStretchStream.engineName
     static let schedulingHorizon: TimeInterval = 12
     static let schedulingChunkDuration: TimeInterval = 2
     static let fileReadFrameCount = 65_536
@@ -23,7 +24,11 @@ final class PlaybackController: BackendPlaybackControlling {
 
     private let engine = AVAudioEngine()
     private let player = AVAudioPlayerNode()
-    private let timePitch = AVAudioUnitTimePitch()
+    private var timeStretch: TimeStretchStream?
+    private var processingIsComplete = false
+    private var pendingSourceFrames: Int64 = 0
+    private var scheduledOutputFrames: Int64 = 0
+    private var renderRate: Double = 1
     private let timeline = TimelineDriver()
     private var audioConfigurationTask: Task<Void, Never>?
     private var audioConfigurationRecoveryTask: Task<Void, Never>?
@@ -97,7 +102,19 @@ final class PlaybackController: BackendPlaybackControlling {
     }
     var rate: Double = 1 {
         didSet {
-            timePitch.rate = Float(rate)
+            guard rate != oldValue else { return }
+            let wasPlaying = state == .playing
+            let anchor = currentPlaybackTime()
+            do {
+                if hasStoredAudio {
+                    try rescheduleAudio(from: anchor)
+                    elapsed = anchor
+                    lastStablePlaybackTime = anchor
+                    if wasPlaying { try startPlayback() }
+                }
+            } catch {
+                reportFailure(error, shouldResume: wasPlaying)
+            }
             scheduleCompletionWatchdog()
             updateNowPlaying()
         }
@@ -126,10 +143,6 @@ final class PlaybackController: BackendPlaybackControlling {
 
     init() {
         engine.attach(player)
-        engine.attach(timePitch)
-        timePitch.rate = Float(rate)
-        timePitch.pitch = 0
-        timePitch.overlap = Self.highQualityTimePitchOverlap
         configureRemoteCommands()
         monitorAudioConfiguration()
     }
@@ -345,6 +358,12 @@ final class PlaybackController: BackendPlaybackControlling {
     func finishBuffering() {
         synthesisIsComplete = true
         estimatedDuration = generatedDuration
+        do {
+            try scheduleAvailableAudio()
+        } catch {
+            reportFailure(error)
+            return
+        }
         if state == .buffering {
             play()
         } else {
@@ -492,16 +511,7 @@ final class PlaybackController: BackendPlaybackControlling {
         engine.stop()
         player.stop()
         engine.disconnectNodeOutput(player)
-        engine.disconnectNodeOutput(timePitch)
-        engine.connect(player, to: timePitch, format: format)
-        engine.connect(
-            timePitch,
-            to: engine.mainMixerNode,
-            format: format
-        )
-        timePitch.rate = Float(rate)
-        timePitch.pitch = 0
-        timePitch.overlap = Self.highQualityTimePitchOverlap
+        engine.connect(player, to: engine.mainMixerNode, format: format)
         engine.prepare()
         configuredSampleRate = format.sampleRate
         try ensureEngineRunning()
@@ -601,6 +611,7 @@ final class PlaybackController: BackendPlaybackControlling {
     ) {
         let generation = scheduleGeneration
         scheduledBufferCount += 1
+        scheduledOutputFrames += Int64(buffer.frameLength)
         player.scheduleBuffer(
             buffer,
             completionCallbackType: .dataPlayedBack
@@ -636,6 +647,11 @@ final class PlaybackController: BackendPlaybackControlling {
         completionWatchdogTask = nil
         scheduleGeneration &+= 1
         scheduledBufferCount = 0
+        scheduledOutputFrames = 0
+        pendingSourceFrames = 0
+        timeStretch = nil
+        processingIsComplete = false
+        renderRate = rate
         if var frameScheduler {
             frameScheduler.reset(startingAt: frameScheduler.nextFrame)
             self.frameScheduler = frameScheduler
@@ -658,38 +674,54 @@ final class PlaybackController: BackendPlaybackControlling {
     }
 
     private func scheduleAvailableAudio() throws {
-        guard let pcmStore, var frameScheduler else { return }
-        while let range = frameScheduler.nextRange(
-            availableFrameCount: pcmStore.frameCount
-        ) {
-            var samples = try pcmStore.readFrames(
+        guard let pcmStore, var frameScheduler, !processingIsComplete else { return }
+        if timeStretch == nil {
+            renderRate = rate
+            timeStretch = try TimeStretchStream(sampleRate: sampleRate, rate: renderRate)
+        }
+        guard let timeStretch else { return }
+        while let range = frameScheduler.nextRange(availableFrameCount: pcmStore.frameCount) {
+            let samples = try pcmStore.readFrames(
                 startingAt: range.lowerBound,
                 count: Int(range.count)
             )
             guard samples.count == range.count else {
                 throw CocoaError(.fileReadCorruptFile)
             }
-            if shouldFadeInNextScheduledBuffer {
-                samples = PCMTransitionRamp.fadeInHead(
-                    samples,
-                    frameCount: transitionFrameCount
-                )
-                shouldFadeInNextScheduledBuffer = false
-            }
-            let buffer = try makeBuffer(
-                samples: samples,
-                sampleRate: sampleRate
-            )
-            if configuredSampleRate == nil {
-                try prepareAudioGraph(for: buffer.format)
-            } else {
-                try ensureEngineRunning()
-            }
-            try validatePlayerFormat(for: buffer)
-            schedule(buffer, sourceFrameCount: Int64(range.count))
+            let output = try timeStretch.process(samples)
+            pendingSourceFrames += Int64(range.count)
             frameScheduler.didSchedule(range)
+            try scheduleProcessedAudio(output)
+        }
+        if synthesisIsComplete, frameScheduler.nextFrame == pcmStore.frameCount {
+            let tail = try timeStretch.process([], final: true)
+            try scheduleProcessedAudio(tail)
+            // A unity-rate stream has no delayed output to attach this accounting to.
+            if pendingSourceFrames > 0 {
+                frameScheduler.didComplete(frameCount: pendingSourceFrames)
+                pendingSourceFrames = 0
+            }
+            processingIsComplete = true
         }
         self.frameScheduler = frameScheduler
+    }
+
+    private func scheduleProcessedAudio(_ output: [Float]) throws {
+        guard !output.isEmpty else { return }
+        var samples = output
+        if shouldFadeInNextScheduledBuffer {
+            samples = PCMTransitionRamp.fadeInHead(samples, frameCount: transitionFrameCount)
+            shouldFadeInNextScheduledBuffer = false
+        }
+        let buffer = try makeBuffer(samples: samples, sampleRate: sampleRate)
+        if configuredSampleRate == nil {
+            try prepareAudioGraph(for: buffer.format)
+        } else {
+            try ensureEngineRunning()
+        }
+        try validatePlayerFormat(for: buffer)
+        schedule(buffer, sourceFrameCount: pendingSourceFrames)
+        pendingSourceFrames = 0
     }
 
     private func currentPlaybackTime() -> TimeInterval {
@@ -701,7 +733,8 @@ final class PlaybackController: BackendPlaybackControlling {
         }
         return min(
             scheduleOffset
-                + Double(playerTime.sampleTime) / playerTime.sampleRate,
+                + Double(min(playerTime.sampleTime, scheduledOutputFrames))
+                    / playerTime.sampleRate * renderRate,
             generatedDuration
         )
     }
@@ -722,7 +755,7 @@ final class PlaybackController: BackendPlaybackControlling {
               scheduledBufferCount == 0 else {
             return
         }
-        if synthesisIsComplete {
+        if synthesisIsComplete, processingIsComplete {
             completePlayback()
         } else if state == .playing {
             enterBufferingState()
@@ -789,10 +822,14 @@ final class PlaybackController: BackendPlaybackControlling {
     }
 
     private func enterBufferingState() {
-        elapsed = generatedDuration
+        // Restart from the audible source position, including the processor's
+        // held-back lookahead, when progressive synthesis catches up.
+        elapsed = currentPlaybackTime()
         lastStablePlaybackTime = elapsed
         invalidateScheduledAudio()
-        scheduleOffset = elapsed
+        let frame = Int64((elapsed * sampleRate).rounded(.down))
+        frameScheduler?.reset(startingAt: frame)
+        scheduleOffset = Double(frame) / sampleRate
         state = .buffering
         updateNowPlaying()
     }

--- a/Tests/SayItBackendTests/BackendProjectionTests.swift
+++ b/Tests/SayItBackendTests/BackendProjectionTests.swift
@@ -97,6 +97,6 @@ struct BackendProjectionTests {
         #expect(PlaybackController.preferredStartBufferDuration(for: 0.5) == 1.2)
         #expect(PlaybackController.preferredStartBufferDuration(for: 1) == 1.2)
         #expect(PlaybackController.preferredStartBufferDuration(for: 2) == 2.4)
-        #expect(PlaybackController.highQualityTimePitchOverlap == 32)
+        #expect(PlaybackController.timeStretchEngineName == "Rubber Band R3")
     }
 }

--- a/Tests/SayItBackendTests/TimeStretchPlaybackTests.swift
+++ b/Tests/SayItBackendTests/TimeStretchPlaybackTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import SayItCore
+import SayItProtocol
+import Testing
+@testable import SayItBackend
+
+// Uses the real output graph, muted. Opt in on a Mac with an audio output device.
+@Suite("Time-stretched playback integration", .serialized,
+       .enabled(if: ProcessInfo.processInfo.environment["SAYIT_PLAYBACK_INTEGRATION"] == "1"))
+@MainActor
+struct TimeStretchPlaybackTests {
+    private func enqueue(_ playback: PlaybackController, id: UUID, duration: Double, index: Int = 0) throws {
+        let samples = (0..<Int(24_000 * duration)).map {
+            Float(0.1 * sin(2 * .pi * 220 * Double($0) / 24_000))
+        }
+        try playback.enqueue(AudioChunk(requestID: id, index: index, samples: samples,
+                                        sampleRate: 24_000, startsParagraph: false))
+    }
+
+    private func waitUntilFinished(_ playback: PlaybackController, timeout: Double) async throws {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while playback.state != .finished && playback.state != .failed && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(playback.state == .finished)
+        #expect(playback.failureMessage == nil)
+    }
+
+    @Test("Real output graph finishes at the requested speed", arguments: [0.5, 0.75, 1.0, 1.25, 1.5, 2.0])
+    func duration(rate: Double) async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = rate
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP integration fixture", estimatedDuration: 1, modelID: nil)
+        try enqueue(playback, id: id, duration: 1)
+        let start = ContinuousClock.now
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 1 / rate + 2)
+        let wall = start.duration(to: .now)
+        #expect(wall > .seconds(1 / rate - 0.2))
+        #expect(wall < .seconds(1 / rate + 0.75))
+        #expect(abs(playback.elapsed - 1) < 0.001)
+    }
+
+    @Test("Speed changes, paused seeks and replay preserve source position")
+    func controls() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 0.5
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP control fixture", estimatedDuration: 2, modelID: nil)
+        try enqueue(playback, id: id, duration: 2)
+        playback.finishBuffering()
+        try await Task.sleep(for: .milliseconds(300))
+        let before = playback.elapsed
+        playback.rate = 2
+        #expect(playback.state == .playing)
+        #expect(abs(playback.elapsed - before) < 0.15)
+        playback.pause()
+        #expect(playback.state == .paused)
+        playback.rate = 0.75
+        #expect(playback.state == .paused)
+        playback.seek(to: 1.5)
+        #expect(abs(playback.elapsed - 1.5) < 0.001)
+        playback.play()
+        try await waitUntilFinished(playback, timeout: 2)
+        playback.rate = 2
+        playback.play()
+        try await waitUntilFinished(playback, timeout: 3)
+    }
+
+    @Test("Progressive underruns retain the delayed audio and completion tail")
+    func progressive() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 1.5
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP progressive fixture", estimatedDuration: 1, modelID: nil)
+        try enqueue(playback, id: id, duration: 0.5)
+        playback.play()
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(playback.state == .buffering)
+        #expect(playback.elapsed < playback.generatedDuration)
+        try enqueue(playback, id: id, duration: 0.5, index: 1)
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 2)
+        #expect(abs(playback.elapsed - 1) < 0.001)
+    }
+
+    @Test("Long playback replenishes the scheduling horizon")
+    func schedulingHorizon() async throws {
+        let playback = PlaybackController()
+        defer { playback.stop() }
+        playback.volume = 0
+        playback.rate = 2
+        let id = UUID()
+        playback.prepare(requestID: id, title: "DSP horizon fixture", estimatedDuration: 13, modelID: nil)
+        try enqueue(playback, id: id, duration: 13)
+        playback.finishBuffering()
+        try await waitUntilFinished(playback, timeout: 9)
+        #expect(abs(playback.elapsed - 13) < 0.001)
+    }
+}

--- a/Tests/SayItPlaybackTests/AudioArchiveTests.swift
+++ b/Tests/SayItPlaybackTests/AudioArchiveTests.swift
@@ -8,7 +8,7 @@ struct AudioArchiveTests {
     @Test("Playback uses high quality time stretching")
     @MainActor
     func playbackUsesHighQualityTimeStretching() {
-        #expect(PlaybackController.highQualityTimePitchOverlap == 32)
+        #expect(PlaybackController.timeStretchEngineName == "Rubber Band R3")
         #expect(
             PlaybackController.preferredStartBufferDuration(for: 1) == 1.2
         )

--- a/project.yml
+++ b/project.yml
@@ -8,6 +8,8 @@ options:
   groupSortPosition: top
 
 packages:
+  PlaybackDSP:
+    path: Packages/PlaybackDSP
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     exactVersion: 2.9.6
@@ -105,6 +107,8 @@ targets:
     sources:
       - path: Sources/SayItBackend
     dependencies:
+      - package: PlaybackDSP
+        product: PlaybackDSP
       - target: SayItCore
       - target: SayItProtocol
       - package: MLXAudio


### PR DESCRIPTION
Compare pitch-preserving playback using Rubber Band 4.0.0's R3 Finer engine instead of AVAudioUnitTimePitch. This is an independent listening experiment based on main, alternative to #25 and #26; these engine branches should not be merged together.

The existing 0.5–2× controls drive a continuous real-time R3 stream with standard windows and unchanged pitch. Original audio and exports remain unchanged, and 1× bypasses processing exactly. Startup padding and delay follow the engine's reported requirements. Variable output counts are buffered, final output is drained and trimmed to the cumulative target, and live rate changes reschedule from the audible source position. Progressive underruns retain delayed source audio.

The upstream sources are pinned and vendored, using Apple Accelerate and the bundled resampler. No runtime library installation is required. Rubber Band is GPL-2.0-or-later or commercially licensed: this experimental combined build uses the GPLv3 option, documented in `Packages/PlaybackDSP/COMPARISON-LICENSE.md`. The existing Say It source retains its MIT license. This is not an automatic dependency choice for the MIT distribution.

Validation:
- DSP tests passed at six speeds (0.5, 0.75, 1, 1.25, 1.5, 2×) and three sample rates (24, 44.1, 48 kHz), checking duration, pitch, level, finite samples, short tails and reset isolation.
- Muted real-output integration tests passed for every speed, live rate changes, paused seeks, replay, progressive underruns, and playback beyond the scheduling horizon.
- Full existing package suite: 358 tests passed with the app's compiled MLX Metal library.
- Local app build, signing verification, package linkage, updater and catalog checks passed. Existing upstream MLX dependency warnings remain.
- The offline renderer produced six speech WAVs with the expected sample counts. This engine used more processing time than the other two on the fixture, but remained faster than real time. Perceptual quality remains for manual assessment.

Run `swift test --package-path Packages/PlaybackDSP -c release` for DSP tests, or set `SAYIT_PLAYBACK_INTEGRATION=1` when running `TimeStretchPlaybackTests` on a Mac with audio output. The `PlaybackDSPRender` tool renders a saved source file at all comparison speeds; usage is in `Packages/PlaybackDSP/README.md`.

For listening, keep native Speaking Pace at Natural and compare identical text/voice or saved audio. Assess metallic artifacts, consonants and voice warmth, especially at 0.5× and 2×. Run only one local comparison app at a time because variants share the local app identity and settings.
